### PR TITLE
fix: resolve TD-002, TD-013, TD-014 tech debt items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,19 @@ go.work.sum
 *~
 .DS_Store
 
+# AI agent tools (user-local config/cache, not project docs)
+.claude/
+.cursor/
+.cursorignore
+.cursorrules
+.windsurf/
+.aider*
+.continue/
+.copilot-instructions
+
+# Project AI context folder is intentionally tracked — do not ignore ai/
+!ai/
+
 # Build output - acloud binaries
 acloud
 acloud-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Detailed context is split across focused files in the `ai/` folder. Read only the file(s) relevant to your current task:
+
+| Task type | Read |
+|-----------|------|
+| Building, running tests, linting, CI workflows | [`ai/DEVEX.md`](ai/DEVEX.md) |
+| Understanding repo layout, packages, command tree | [`ai/REPO.md`](ai/REPO.md) |
+| Understanding architecture, design patterns, data flow | [`ai/ARCHITECTURE.md`](ai/ARCHITECTURE.md) |
+| Writing new code, naming files, following project conventions | [`ai/CONVENTIONS.md`](ai/CONVENTIONS.md) |
+| Fixing bugs, refactoring, reviewing code quality | [`ai/TECH_DEBT.md`](ai/TECH_DEBT.md) |
+
+For tasks that span multiple concerns (e.g., implementing a new resource), read both `ai/ARCHITECTURE.md` and `ai/CONVENTIONS.md`.
+Before fixing a bug or refactoring existing code, check `ai/TECH_DEBT.md` for known issues and the agreed fix approach.

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -1,0 +1,281 @@
+# ARCHITECTURE.md — Code Architecture & Design Patterns
+
+## Execution Flow
+
+`main.go` → `cmd.Execute()` → root Cobra command → subcommand handler.
+
+Global flags registered on `rootCmd` (available on every command):
+- `--debug, -d` — enables HTTP request/response logging to stderr (microsecond-precision, stderr output)
+- `--project-id` — target project (falls back to active context if omitted)
+
+Commands use `Run` (not `RunE`). Errors are printed with `fmt.Printf` and the handler returns early — no exit codes are used in resource commands.
+
+---
+
+## Client Initialization & Caching
+
+`GetArubaClient()` in `cmd/root.go` returns a cached `aruba.Client`. The cache is package-level state protected by `sync.Mutex`.
+
+**Cache invalidation** — the cached instance is reused only when ALL of the following match the prior call:
+```
+cachedClientID == config.ClientID
+cachedSecret   == config.ClientSecret
+cachedDebug    == debugEnabled
+cachedBaseURL  == baseURL
+cachedTokenIssuer == tokenIssuerURL
+```
+
+**Client construction** (when cache misses):
+```go
+options := aruba.DefaultOptions()
+// WithNativeLogger() added if --debug is set
+aruba.NewClient(options)
+```
+
+**Defaults applied inside `GetArubaClient()`** (not in `LoadConfig`):
+- `BaseURL` → `https://api.arubacloud.com` if empty
+- `TokenIssuerURL` → predefined Aruba identity URL if empty
+
+If `LoadConfig()` fails (missing `~/.acloud.yaml`), the error is wrapped:
+> `"failed to load configuration: %w. Please run 'acloud config set' to configure credentials"`
+
+---
+
+## SDK Call Pattern
+
+All resource operations follow the builder pattern through the client:
+
+```go
+client.FromStorage().Volumes().Create(ctx, projectID, request, nil)
+client.FromCompute().CloudServers().Get(ctx, projectID, id, nil)
+client.FromNetwork().VPCs().List(ctx, projectID, nil)
+```
+
+- The 4th argument (`options`) is always `nil` in current commands.
+- `ctx` is always `context.Background()`, declared inline in the handler.
+- The response carries `.IsError()`, `.StatusCode`, `.Error.Title`, `.Error.Detail`, and `.Data`.
+
+**Response error check pattern:**
+```go
+if response != nil && response.IsError() && response.Error != nil {
+    fmt.Printf("Failed - Status: %d\n", response.StatusCode)
+    if response.Error.Title != nil {
+        fmt.Printf("Error: %s\n", *response.Error.Title)
+    }
+    if response.Error.Detail != nil {
+        fmt.Printf("Detail: %s\n", *response.Error.Detail)
+    }
+    return
+}
+```
+
+---
+
+## Project ID Resolution
+
+`GetProjectID(cmd)` in `cmd/root.go` resolves in order:
+1. `--project-id` flag value (if non-empty)
+2. `GetCurrentProjectID()` → reads `CurrentContext` from `~/.acloud-context.yaml`, returns its `ProjectID`
+3. Returns error: `"project ID not specified. Use --project-id flag or set a context with 'acloud context use <name>'"`
+
+---
+
+## Config Subsystem
+
+**File:** `~/.acloud.yaml` (permissions `0600` on write)
+
+**Struct:**
+```go
+type Config struct {
+    ClientID       string `yaml:"clientId"`
+    ClientSecret   string `yaml:"clientSecret"`
+    BaseURL        string `yaml:"baseUrl,omitempty"`
+    TokenIssuerURL string `yaml:"tokenIssuerUrl,omitempty"`
+}
+```
+
+- Missing file → `LoadConfig()` returns an error (no graceful degradation to empty config).
+- Partial config → zero values for missing fields; defaults are applied later in `GetArubaClient()`.
+- `SaveConfig()` marshals to YAML and writes with `os.WriteFile(..., 0600)`.
+
+---
+
+## Context Subsystem
+
+**File:** `~/.acloud-context.yaml`
+
+**Struct:**
+```go
+type Context struct {
+    CurrentContext string             `yaml:"current-context"`
+    Contexts       map[string]CtxInfo `yaml:"contexts"`
+}
+type CtxInfo struct {
+    ProjectID string `yaml:"project-id"`
+    Name      string `yaml:"name,omitempty"`
+}
+```
+
+**Command behaviours:**
+- `context set <name> --project-id <id>` — creates/updates a named context but does **not** switch to it automatically.
+- `context use <name>` — validates the name exists, then sets `CurrentContext`.
+- `context delete <name>` — removes the context; clears `CurrentContext` if it was the active one.
+- `context list` — prints all contexts with `*` marking the current one.
+
+---
+
+## Command Registration
+
+Commands are registered in `init()` functions inside each file. Resource files register with the parent defined in the category base file:
+
+```go
+// cmd/storage.go
+func init() { rootCmd.AddCommand(storageCmd) }
+
+// cmd/storage.blockstorage.go
+func init() {
+    storageCmd.AddCommand(blockstorageCmd)
+    blockstorageCmd.AddCommand(blockstorageListCmd)
+    blockstorageCmd.AddCommand(blockstorageGetCmd)
+    // ...
+}
+```
+
+No `PreRun`, `PostRun`, or middleware hooks exist anywhere in the codebase.
+
+---
+
+## Output Patterns
+
+### Table output (primary)
+
+`PrintTable(headers []TableColumn, rows [][]string)` in `cmd/root.go`:
+- Left-justifies columns using `%-Ns` format strings.
+- Truncates values longer than `Width` with `"..."`.
+- Used in every `list` command and most `create`/`update` responses.
+
+```go
+headers := []TableColumn{
+    {Header: "NAME",    Width: 30},
+    {Header: "ID",      Width: 26},
+    {Header: "STATUS",  Width: 15},
+}
+PrintTable(headers, rows)
+```
+
+### Verbose JSON output (secondary)
+
+Only present on a few compute commands via `--verbose / -v`:
+```go
+if verbose {
+    jsonData, _ := json.MarshalIndent(resource, "", "  ")
+    fmt.Println(string(jsonData))
+}
+```
+
+There is no global `--output=json` flag — JSON is only a debug aid.
+
+### `get` command output
+
+Detail views use `fmt.Printf` with labeled fields, not `PrintTable`:
+```
+Resource Details:
+=================
+ID:    <value>
+Name:  <value>
+```
+
+---
+
+## Destructive Operation Pattern (Delete)
+
+Every delete command follows this exact flow:
+
+```go
+confirm, _ := cmd.Flags().GetBool("yes")
+if !confirm {
+    fmt.Printf("Are you sure you want to delete %s? (yes/no): ", id)
+    var response string
+    fmt.Scanln(&response)          // blocks on stdin
+    if response != "yes" && response != "y" {
+        fmt.Println("Delete cancelled")
+        return
+    }
+}
+// proceed with SDK delete call
+```
+
+The flag is registered as `BoolP("yes", "y", false, "Skip confirmation prompt")`.
+
+---
+
+## Shell Completion
+
+Completion functions live in the same file as the command they complete. Pattern:
+
+```go
+func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    projectID, err := GetProjectID(cmd)
+    if err != nil { return nil, cobra.ShellCompDirectiveNoFileComp }
+
+    client, err := GetArubaClient()
+    if err != nil { return nil, cobra.ShellCompDirectiveNoFileComp }
+
+    ctx := context.Background()
+    response, err := client.FromStorage().Volumes().List(ctx, projectID, nil)
+    if err != nil { return nil, cobra.ShellCompDirectiveNoFileComp }
+
+    var completions []string
+    for _, v := range response.Data.Values {
+        if v.Metadata.ID != nil && strings.HasPrefix(*v.Metadata.ID, toComplete) {
+            completions = append(completions, fmt.Sprintf("%s\t%s", *v.Metadata.ID, *v.Metadata.Name))
+        }
+    }
+    return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// Registered in init():
+blockstorageGetCmd.ValidArgsFunction = completeBlockStorageID
+```
+
+Always returns `cobra.ShellCompDirectiveNoFileComp`. On any error, returns `nil, cobra.ShellCompDirectiveNoFileComp` (fail silently).
+
+---
+
+## Error Handling Rules
+
+- Resource commands use `Run` (not `RunE`). Errors are printed and the function returns.
+- `os.Exit` is called only in `cmd/root.go` (if `Execute()` fails) and `cmd/config.go` (hard validation errors during initial setup). Never in resource commands.
+- SDK call errors from `err != nil` and API-level errors from `response.IsError()` are handled separately (see SDK Call Pattern above).
+
+---
+
+## Request Building
+
+SDK requests use nested struct composition with pointer-valued optional fields:
+
+```go
+types.BlockStorageRequest{
+    Metadata: types.RegionalResourceMetadataRequest{
+        ResourceMetadataRequest: types.ResourceMetadataRequest{
+            Name: name,
+            Tags: tags,
+        },
+        Location: types.LocationRequest{Value: region},
+    },
+    Properties: types.BlockStoragePropertiesRequest{
+        SizeGB:        size,
+        BillingPeriod: billingPeriod,
+        Type:          types.BlockStorageType(volumeType),
+    },
+}
+```
+
+**Update pattern** — fetch the current resource first to preserve values not being updated, then overwrite changed fields:
+```go
+getResp, _ := client.From...().Resource().Get(ctx, projectID, id, nil)
+current := getResp.Data
+updateReq := buildRequestFrom(current)    // preserve current values
+if name != "" { updateReq.Metadata.Name = name }
+if cmd.Flags().Changed("tags") { updateReq.Metadata.Tags = tags }
+```

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -1,0 +1,267 @@
+# CONVENTIONS.md — Code Conventions & Standards
+
+## File Naming
+
+- Category parent command: `cmd/<category>.go` (e.g., `cmd/storage.go`)
+- Resource command: `cmd/<category>.<resource>.go` (e.g., `cmd/storage.blockstorage.go`)
+- Tests: `cmd/<file>_test.go` and `cmd/<file>_test_enhanced.go` (extended fixtures)
+
+---
+
+## Flag Naming
+
+All flags use **kebab-case** (not camelCase or snake_case).
+
+**Standard flags reused across commands:**
+
+| Flag | Short | Type | Purpose |
+|------|-------|------|---------|
+| `--project-id` | — | string | Target project (always optional; context is fallback) |
+| `--name` | — | string | Resource name (marked required on create) |
+| `--region` | — | string | Region code (marked required on create) |
+| `--tags` | — | string slice | Comma-separated tags |
+| `--yes` | `-y` | bool | Skip delete confirmation |
+| `--verbose` | `-v` | bool | Print full JSON response |
+
+Flag descriptions follow this style:
+- `"Project ID (uses context if not specified)"`
+- `"Name for the block storage (required)"`
+- `"Skip confirmation prompt"`
+
+---
+
+## Cobra Command Struct Fields
+
+**Always set:** `Use`, `Short`, `Run`
+
+**Set when needed:**
+- `Args` — use `cobra.ExactArgs(N)` or `cobra.NoArgs` for validation
+- `Long` — set on parent/category commands, sometimes on leaf commands
+- `ValidArgsFunction` — set on get/update/delete commands that accept a resource ID
+
+**Never set:** `Aliases`, `Deprecated`, `Hidden`, `Example`, `PreRun`, `PostRun`
+
+```go
+var blockstorageGetCmd = &cobra.Command{
+    Use:   "get [volume-id]",
+    Short: "Get block storage details",
+    Args:  cobra.ExactArgs(1),
+    Run:   func(cmd *cobra.Command, args []string) { ... },
+}
+
+var blockstorageCmd = &cobra.Command{
+    Use:  "blockstorage",
+    Short: "Manage block storage",
+    Long: `Perform CRUD operations on block storage in Aruba Cloud.`,
+}
+```
+
+`Short` is imperative, verb-first: `"Create a new VPC"`, `"Get block storage details"`, `"Delete a VPC"`.
+`Long` follows the pattern: `"Perform CRUD operations on <resource> in Aruba Cloud."`.
+
+---
+
+## Import Organization
+
+```go
+import (
+    "context"          // stdlib: concurrency first
+    "encoding/json"    // stdlib: alphabetical
+    "fmt"
+    "os"
+    "strings"
+
+    "github.com/Arubacloud/sdk-go/pkg/types"  // external: alphabetical
+    "github.com/spf13/cobra"
+)
+```
+
+Two groups: stdlib, then external. Each group is alphabetically ordered.
+
+---
+
+## Variable Naming in Handlers
+
+```go
+Run: func(cmd *cobra.Command, args []string) {
+    // Always these names:
+    projectID, err := GetProjectID(cmd)
+    client, err    := GetArubaClient()
+    ctx            := context.Background()
+
+    // Flag values — match the flag name (kebab → camelCase):
+    name, _         := cmd.Flags().GetString("name")
+    region, _       := cmd.Flags().GetString("region")
+    tags, _         := cmd.Flags().GetStringSlice("tags")
+    confirm, _      := cmd.Flags().GetBool("yes")
+
+    // API response:
+    response, err := client.From...().Resource().Op(ctx, projectID, ...)
+
+    // Table rows:
+    var rows [][]string
+}
+```
+
+Single resource extracted from response: use singular noun matching the resource (`volume`, `vpc`, `server`, `dbaas`), not pluralized.
+
+---
+
+## Argument Validation
+
+- Use `cobra.ExactArgs(N)` in the command struct; do not re-validate inside `Run`.
+- Validate flags **before** calling `GetArubaClient()` so the SDK is never initialized needlessly.
+- Required flags that cannot be enforced with `MarkFlagRequired` (e.g., conditional) are checked manually with an early return:
+  ```go
+  if name == "" {
+      fmt.Println("Error: --name is required")
+      return
+  }
+  ```
+
+---
+
+## Pointer Dereferencing
+
+SDK response fields are pointers. Always nil-check before use:
+
+```go
+name := ""
+if resource.Metadata.Name != nil {
+    name = *resource.Metadata.Name
+}
+```
+
+Never dereference a response pointer without a nil guard.
+
+---
+
+## Adding a New Resource
+
+1. Create `cmd/<category>.<resource>.go`. Define all subcommand vars at package level.
+2. Register in `init()`:
+   ```go
+   func init() {
+       parentCmd.AddCommand(resourceCmd)
+       resourceCmd.AddCommand(resourceCreateCmd)
+       resourceCmd.AddCommand(resourceGetCmd)
+       resourceCmd.AddCommand(resourceUpdateCmd)
+       resourceCmd.AddCommand(resourceDeleteCmd)
+       resourceCmd.AddCommand(resourceListCmd)
+
+       // Flags
+       resourceCreateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
+       resourceCreateCmd.Flags().String("name", "", "Name (required)")
+       resourceCreateCmd.Flags().String("region", "", "Region code (required)")
+       resourceCreateCmd.MarkFlagRequired("name")
+       resourceCreateCmd.MarkFlagRequired("region")
+
+       resourceDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+
+       // Completion
+       resourceGetCmd.ValidArgsFunction    = completeResourceID
+       resourceUpdateCmd.ValidArgsFunction = completeResourceID
+       resourceDeleteCmd.ValidArgsFunction = completeResourceID
+   }
+   ```
+3. Use `GetArubaClient()` and `GetProjectID(cmd)` from `cmd/root.go` — never read flags or initialize the SDK directly.
+4. Implement `completeResourceID` following the shell completion pattern in `ARCHITECTURE.md`.
+5. Register the parent category command in `cmd/<category>.go`'s `init()` if it doesn't already exist.
+
+---
+
+## Standard Command Bodies
+
+### list
+```go
+projectID, err := GetProjectID(cmd)
+if err != nil { fmt.Printf("Error: %v\n", err); return }
+
+client, err := GetArubaClient()
+if err != nil { fmt.Printf("Error initializing client: %v\n", err); return }
+
+ctx := context.Background()
+response, err := client.From<Svc>().<Resource>().List(ctx, projectID, nil)
+if err != nil { fmt.Printf("Error listing <resources>: %v\n", err); return }
+
+if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+    headers := []TableColumn{
+        {Header: "NAME", Width: 30},
+        {Header: "ID",   Width: 26},
+        // ...
+    }
+    var rows [][]string
+    for _, r := range response.Data.Values {
+        rows = append(rows, []string{safePtrStr(r.Metadata.Name), safePtrStr(r.Metadata.ID), ...})
+    }
+    PrintTable(headers, rows)
+} else {
+    fmt.Println("No <resources> found")
+}
+```
+
+### get
+```go
+resourceID := args[0]
+// GetProjectID, GetArubaClient, context.Background() ...
+resp, err := client.From<Svc>().<Resource>().Get(ctx, projectID, resourceID, nil)
+if err != nil { ... return }
+// check resp.IsError() ...
+fmt.Println("\n<Resource> Details:")
+fmt.Println("===================")
+if resp.Data.Metadata.ID != nil { fmt.Printf("ID:   %s\n", *resp.Data.Metadata.ID) }
+// ...
+```
+
+### create
+```go
+// 1. GetProjectID
+// 2. Extract flags; validate required ones early
+// 3. GetArubaClient
+// 4. Build types.<Resource>Request{} (nested struct)
+// 5. Call .Create(ctx, projectID, request, nil)
+// 6. Check err, then response.IsError()
+// 7. PrintTable with single-row result
+```
+
+### update
+```go
+// 1. Get current resource via .Get() to preserve unmodified fields
+// 2. Build request from current values
+// 3. Overwrite only flags that were explicitly Changed:
+if name != "" { updateReq.Metadata.Name = name }
+if cmd.Flags().Changed("tags") { updateReq.Metadata.Tags = tags }
+// 4. Call .Update(ctx, projectID, id, request, nil)
+// 5. Print success with key fields
+```
+
+### delete
+```go
+// Confirmation first (before GetArubaClient):
+confirm, _ := cmd.Flags().GetBool("yes")
+if !confirm {
+    fmt.Printf("Are you sure you want to delete %s? (yes/no): ", id)
+    var r string; fmt.Scanln(&r)
+    if r != "yes" && r != "y" { fmt.Println("Delete cancelled"); return }
+}
+// Then GetProjectID, GetArubaClient, .Delete(ctx, projectID, id, nil)
+fmt.Printf("\n<Resource> %s deleted successfully!\n", id)
+```
+
+---
+
+## Test Conventions
+
+- Tests live in `package cmd` (same package as the code).
+- Use `t.TempDir()` for isolated file paths; override `HOME` (or `USERPROFILE` on Windows) to redirect config/context files.
+- Clear the client cache after each test:
+  ```go
+  clientCacheLock.Lock()
+  clientCache = nil
+  cachedClientID, cachedSecret = "", ""
+  cachedDebug = false
+  clientCacheLock.Unlock()
+  ```
+- Use `defer cleanup()` to restore environment variables.
+- Skip live-API tests with `ACLOUD_TEST_SKIP_CLIENT=true`.
+- Table-driven tests are preferred for multiple input/output cases.

--- a/ai/DEVEX.md
+++ b/ai/DEVEX.md
@@ -1,0 +1,48 @@
+# DEVEX.md — Development & Testing
+
+## Build
+
+```bash
+make build              # Build for current platform
+make build-all          # Build for all platforms (Windows, Linux, macOS Intel/ARM)
+```
+
+## Lint & Format
+
+```bash
+make lint               # Run fmt + vet
+make lint-check         # CI-mode formatting check (fails if code needs formatting)
+```
+
+## Test
+
+```bash
+make test               # Run all unit tests (verbose)
+make test-short         # Quick test run
+make test-coverage      # Generate HTML coverage report
+make test-race          # Run with race detector
+make test-skip-client   # Skip tests requiring live API credentials
+```
+
+## E2E Tests
+
+```bash
+make e2e-test           # All E2E tests (requires credentials)
+make e2e-management     # E2E tests for management resources
+make e2e-storage        # E2E tests for storage resources
+make e2e-network        # E2E tests for network resources
+```
+
+## CI
+
+```bash
+make ci                 # lint + mod-verify + test-skip-client
+make pre-commit         # fmt + vet + tests
+```
+
+## Testing Conventions
+
+- Unit tests use `t.TempDir()` for file isolation.
+- Set `ACLOUD_TEST_SKIP_CLIENT=true` to skip tests that require live API credentials (used in CI).
+- E2E tests are bash scripts under `e2e/` organized by resource category.
+- Test files: `<file>_test.go` for standard tests; `<file>_test_enhanced.go` for extended fixtures/scenarios.

--- a/ai/REPO.md
+++ b/ai/REPO.md
@@ -1,0 +1,53 @@
+# REPO.md — Repository Organization
+
+## Project Overview
+
+`acloud-cli` is the official CLI for the Aruba Cloud Management Platform, written in Go. It wraps the Aruba Cloud Go SDK (`github.com/Arubacloud/sdk-go`) to expose infrastructure resources as Cobra commands.
+
+## Top-Level Layout
+
+| Path | Purpose |
+|------|---------|
+| `main.go` | Entry point — calls `cmd.Execute()` |
+| `cmd/` | All Cobra command implementations |
+| `e2e/` | End-to-end bash test scripts, organized by category |
+| `docs/` | Docusaurus documentation site source |
+| `Makefile` | Build, test, lint, and release automation |
+| `go.mod` / `go.sum` | Go module dependencies |
+| `ai/` | Contextual guidance files for Claude Code |
+
+## `cmd/` Package Structure
+
+File naming follows a two-level convention:
+
+- `<category>.go` — registers the parent subcommand (e.g., `storage.go`)
+- `<category>.<resource>.go` — implements a specific resource (e.g., `storage.blockstorage.go`)
+
+Shared infrastructure lives in:
+- `root.go` — client caching, `GetArubaClient()`, `GetProjectID()`, `PrintTable()`
+- `config.go` — `LoadConfig()`, `SaveConfig()` for `~/.acloud.yaml`
+- `context.go` — context management for `~/.acloud-context.yaml`
+
+## CLI Command Tree
+
+```
+acloud [--debug|-d] [--project-id]
+├── config set/show
+├── context set/use/current/list/delete
+├── management project
+├── storage blockstorage / snapshot / backup / restore
+├── network vpc / subnet / securitygroup / securityrule / elasticip /
+│          loadbalancer / vpntunnel / vpnroute / vpcpeering / vpcpeeringroute
+├── compute cloudserver / keypair
+├── container kaas / containerregistry
+├── database dbaas / dbaas user / dbaas database / backup
+├── schedule job
+└── security kms
+```
+
+## User Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `~/.acloud.yaml` | Credentials: `clientId`, `clientSecret`, optional `baseUrl` / `tokenIssuerUrl` |
+| `~/.acloud-context.yaml` | Named project-ID mappings (contexts) |

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -1,0 +1,260 @@
+# TECH_DEBT.md — Technical Debt & Refactoring Backlog
+
+Issues are grouped by severity. Address Critical items before new features ship; High items before any public release.
+
+## Resolved
+
+| ID | Summary |
+|----|---------|
+| TD-001 | All `Run` handlers converted to `RunE`; `SilenceUsage: true`; `fmtAPIError` helper in `root.go` |
+| TD-002 | Nil guards added for `LocationResponse`, `Metadata.ID`, `Metadata.Name` in all list/create/update responses |
+| TD-003 | Errors propagated via `return fmt.Errorf(...)` instead of printing to stdout |
+| TD-004 | Flag read errors checked via `RunE` return paths |
+| TD-005 | `confirmDelete()` helper in `root.go` detects non-interactive stdin before prompting |
+| TD-006 | `newCtx()` helper in `root.go` applies 30-second timeout to all SDK calls |
+| TD-007 | `getContextFilePath` returns `(string, error)` instead of silently falling back to CWD |
+| TD-008 | YAML unmarshal errors wrapped with user-friendly messages in `LoadConfig` and `LoadContext` |
+| TD-013 | `Args: cobra.NoArgs` added to all `create` and `list` commands that take no positional arguments |
+| TD-014 | `cmd/constants.go` created with `StateInCreation`, `DateLayout`, `FilePermConfig`, `FilePermDirAll`; all magic strings replaced |
+
+---
+
+---
+
+## Critical
+
+### TD-001 · `Run` instead of `RunE` — CLI always exits 0 on error
+**All 50+ command handlers use `Run` instead of `RunE`.** When an error occurs the handler prints to stdout and returns, so the process exits with code 0. Scripts, CI pipelines, and automation cannot detect failures.
+
+**Fix:** Convert every `Run` to `RunE`. Return `fmt.Errorf(...)` instead of printing and returning. Let Cobra propagate exit codes.
+
+```go
+// Before
+Run: func(cmd *cobra.Command, args []string) {
+    if err != nil { fmt.Println("Error:", err); return }
+}
+// After
+RunE: func(cmd *cobra.Command, args []string) error {
+    if err != nil { return fmt.Errorf("...: %w", err) }
+    return nil
+}
+```
+
+**Files:** every file in `cmd/` that declares a command.
+
+---
+
+### TD-002 · Nil pointer dereferences on SDK response fields
+Several list and get commands dereference `LocationResponse`, `Flavor`, and similar nested structs without nil-guarding. These panic at runtime if the API returns a partial response.
+
+**Known unsafe patterns:**
+- `response.Data.Metadata.LocationResponse.Value` — `cmd/network.securitygroup.go`, `cmd/network.vpc.go`, `cmd/storage.snapshot.go`
+- `response.Data.Properties.Flavor.Name/CPU/RAM/HD` — `cmd/compute.cloudserver.go`
+- Various table-building loops that dereference `*string` response fields without checking
+
+**Fix:** Add nil guards for every nested struct and pointer field before use:
+```go
+if r.Metadata.LocationResponse != nil {
+    region = r.Metadata.LocationResponse.Value
+}
+```
+
+---
+
+### TD-003 · Error messages go to stdout, not stderr
+Every error is printed with `fmt.Printf`/`fmt.Println` to stdout. This corrupts stdout for any consumer trying to parse command output and prevents reliable stderr redirection.
+
+**Fix:** Use `fmt.Fprintln(os.Stderr, ...)` (or `cmd.PrintErr`) for all error output. Pair with TD-001 (RunE) to propagate errors rather than printing them inline.
+
+---
+
+## High
+
+### TD-004 · Swallowed errors on every flag read
+Flag reads use `_, _` almost universally:
+```go
+name, _ := cmd.Flags().GetString("name")
+```
+If the flag is not registered or has a type mismatch the returned error is silently discarded and `name` becomes `""`. This causes confusing downstream failures.
+
+**Fix:** Check the error from every `cmd.Flags().Get*()` call. With `RunE` this becomes easy — just return the error.
+
+---
+
+### TD-005 · `fmt.Scanln` blocks indefinitely in non-interactive environments
+Delete confirmations use `fmt.Scanln(&response)` which blocks forever when stdin is a pipe or `/dev/null` (CI, containers, cron). The process hangs until the parent times out.
+
+**Fix:** Detect non-interactive stdin before prompting. A minimal safe pattern:
+```go
+fi, _ := os.Stdin.Stat()
+if (fi.Mode() & os.ModeCharDevice) == 0 {
+    return fmt.Errorf("delete requires --yes in non-interactive mode")
+}
+```
+
+**Files:** all `*DeleteCmd` handlers (`cmd/compute.cloudserver.go`, `cmd/storage.blockstorage.go`, `cmd/network.vpc.go`, `cmd/database.dbaas.go`, `cmd/security.kms.go`, etc.).
+
+---
+
+### TD-006 · No API call timeout — CLI can hang indefinitely
+All SDK calls use `context.Background()` with no deadline. A slow or unresponsive API endpoint hangs the CLI forever.
+
+**Fix:** Apply a configurable default timeout (e.g. 30 s) for all SDK calls:
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+```
+Optionally expose `--timeout` as a global flag.
+
+---
+
+### TD-007 · `getContextFilePath` silently falls back to current working directory
+```go
+// cmd/context.go
+func getContextFilePath() string {
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return ".acloud-context.yaml"  // writes context file to CWD
+    }
+    ...
+}
+```
+If home-directory resolution fails, contexts are silently written to (and read from) the current directory. Any subsequent invocation from a different directory loses all contexts with no warning.
+
+**Fix:** Return an error instead of a fallback path. Callers that ignore the error should be updated to propagate it.
+
+---
+
+### TD-008 · Corrupted config/context YAML gives raw parser error
+When `~/.acloud.yaml` or `~/.acloud-context.yaml` is malformed, the user sees a raw `yaml:` parse error with no actionable guidance.
+
+**Fix:** Wrap YAML unmarshal errors with user-friendly context:
+```go
+if err := yaml.Unmarshal(data, &cfg); err != nil {
+    return nil, fmt.Errorf("config file %s is corrupted (%w). Delete it and run 'acloud config set' to reconfigure", configPath, err)
+}
+```
+
+---
+
+### TD-009 · Inconsistent use of `MarkFlagRequired`
+Several `create` commands mark required flags properly; others rely on manual validation inside `Run`. The two approaches coexist in the same codebase:
+
+- **Marked:** `cmd/storage.blockstorage.go`, `cmd/compute.cloudserver.go`, `cmd/storage.snapshot.go`
+- **Not marked (validated manually in Run):** `cmd/network.vpc.go`, `cmd/network.securitygroup.go`, `cmd/config.go`
+- **Both:** `cmd/storage.blockstorage.go` marks AND validates — redundant.
+
+**Fix:** Use `MarkFlagRequired` as the single mechanism for all truly required flags. Remove manual flag-presence checks in `Run`.
+
+---
+
+### TD-010 · No test coverage for command `Run`/`RunE` functions
+Only helper functions (`LoadConfig`, `SaveConfig`, `GetProjectID`, `PrintTable`, etc.) have tests. Zero of the 42 command files have tests that invoke an actual command handler. Every `Run` body is entirely untested.
+
+**Affected files:** All `cmd/<category>.<resource>.go` files.
+
+**Fix:** Add table-driven tests using `cobra.Command.Execute()` with flag injection. Mock the SDK client via an interface so tests don't require live credentials.
+
+---
+
+### TD-011 · Credentials passed as CLI flags — visible in shell history and `ps`
+`acloud config set --client-id X --client-secret Y` exposes the secret in:
+- Shell history files (`.bash_history`, `.zsh_history`)
+- Process listings (`ps aux`)
+- CI/CD log output
+
+**Fix:** When `--client-secret` is not provided on the command line, prompt for it interactively with echo disabled (use `golang.org/x/term.ReadPassword`).
+
+---
+
+## Medium
+
+### TD-012 · `--debug` may log credentials and tokens from HTTP traffic
+`WithNativeLogger()` enables full SDK HTTP logging to stderr. Authorization headers and request bodies potentially containing tokens or secrets are logged without sanitization.
+
+**Fix:** Add a warning to the `--debug` flag description. Investigate whether the SDK logger exposes authorization headers; if so, add a sanitizing log interceptor.
+
+---
+
+### TD-013 · Missing `Args: cobra.NoArgs` on create and list commands
+`create` and `list` commands silently ignore any positional arguments the user mistypes:
+```
+acloud storage blockstorage create accidental-extra-arg --name foo ...
+```
+The extra arg is accepted without error.
+
+**Fix:** Add `Args: cobra.NoArgs` to all `create` and `list` commands.
+
+---
+
+### TD-014 · Magic strings scattered across the codebase
+Repeated literals with no named constant:
+- State values: `"InCreation"`, `"Used"`, `"NotUsed"` — referenced in multiple network and storage files
+- Default region: `"ITBG-Bergamo"` — `cmd/storage.blockstorage.go:27`
+- Error prefix: `"Error: "` — 100+ occurrences
+- File permission modes: `0600`, `0755` — no constants defined
+- Date format: `"02-01-2006 15:04:05"` — multiple files
+
+**Fix:** Define a `constants.go` (or equivalent) in `cmd/` for shared values.
+
+---
+
+### TD-015 · Fragile raw-JSON workaround for CloudServer ID extraction
+`cmd/compute.cloudserver.go` manually unmarshals `response.RawBody` into `map[string]interface{}` to extract the resource ID because the SDK's typed response struct does not expose it. This breaks silently if the API response shape changes.
+
+**Fix:** Either update the SDK to expose the ID in its typed response, or — if the SDK cannot be changed — add a test that fails if the JSON structure changes unexpectedly.
+
+---
+
+### TD-016 · No JSON/machine-readable output format
+All output is human-readable tables and formatted strings. There is no `--output json` or `--output yaml` flag. Consumers integrating acloud-cli into scripts must parse table output with fragile text processing.
+
+**Fix:** Add a global `--output` flag supporting `table` (default) and `json`. Implement a thin output-format layer that receives structured data and serializes it in the requested format.
+
+---
+
+### TD-017 · No pagination for list commands
+List commands pass `nil` as the options parameter, fetching all resources in a single call:
+```go
+client.FromCompute().CloudServers().List(ctx, projectID, nil)
+```
+Large accounts could return thousands of resources, exhausting memory and producing slow, unusable table output.
+
+**Fix:** Add `--limit` and `--offset` flags; pass them through the SDK options struct if the API supports pagination.
+
+---
+
+### TD-018 · Global mutable state breaks parallel tests and requires manual cache reset
+Package-level variables in `cmd/root.go` (`clientCache`, `cachedClientID`, etc.) are reset manually in tests. Running tests with `-parallel` causes race conditions. Any future test that forgets the cleanup will inherit a stale client.
+
+**Fix:** Encapsulate the client and its cached state in a struct. Inject it via a package-level variable that tests can replace, or use `t.Cleanup` to reset it reliably.
+
+---
+
+## Low
+
+### TD-019 · No `--dry-run` flag on destructive operations
+Users cannot validate that a delete command would succeed (permissions, resource existence) without actually deleting the resource.
+
+**Fix:** Add `--dry-run` to all delete commands. In dry-run mode, perform a `get` to validate the resource exists and the client has access, then print what would happen without calling `delete`.
+
+---
+
+### TD-020 · Inconsistent success messages across resources
+Success messages vary: `"...created successfully!"`, `"...initiated. Use 'get' to check status."`, `"Resource created, but no details returned."`. The last form is especially confusing — it implies partial success.
+
+**Fix:** Standardise to two patterns: a definitive success message when the API confirms completion, and an async-operation message when the API returns accepted-but-pending.
+
+---
+
+### TD-021 · Many commands missing `Long` descriptions
+Most leaf commands (get, create, update, delete) have only a `Short` description. `acloud <resource> create --help` provides minimal guidance on valid flag values or usage examples.
+
+**Fix:** Add `Long` and `Example` fields to at minimum all `create` commands, documenting flag valid values and a copy-paste example invocation.
+
+---
+
+### TD-022 · Pre-release SDK version (v0.1.x)
+`go.mod` depends on `github.com/Arubacloud/sdk-go v0.1.21`. The `0.x` major version provides no semantic versioning stability guarantee — a minor-version bump may introduce breaking changes.
+
+**Fix:** Track the SDK release roadmap. When a `v1.0.0` is released, migrate and pin to it. Until then, pin to a specific minor version and treat any upgrade as potentially breaking.

--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -151,7 +151,8 @@ var cloudserverCmd = &cobra.Command{
 var cloudserverCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new cloud server",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get new network flags
 		vpcURI, _ := cmd.Flags().GetString("vpc-uri")
 		subnetURIs, _ := cmd.Flags().GetStringSlice("subnet-uri")
@@ -159,8 +160,7 @@ var cloudserverCreateCmd = &cobra.Command{
 		elasticIPURI, _ := cmd.Flags().GetString("elasticip-uri")
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -173,14 +173,12 @@ var cloudserverCreateCmd = &cobra.Command{
 		userDataFile, _ := cmd.Flags().GetString("user-data-file")
 
 		if name == "" || region == "" || flavor == "" || bootDiskURI == "" || vpcURI == "" || len(subnetURIs) == 0 || len(securityGroupURIs) == 0 {
-			fmt.Println("Error: --name, --region, --flavor, --boot-disk-uri, --vpc-uri, --subnet-uri, and --security-group-uri are required")
-			return
+			return fmt.Errorf("--name, --region, --flavor, --boot-disk-uri, --vpc-uri, --subnet-uri, and --security-group-uri are required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -238,30 +236,22 @@ var cloudserverCreateCmd = &cobra.Command{
 		if userDataFile != "" {
 			fileContent, err := os.ReadFile(userDataFile)
 			if err != nil {
-				fmt.Printf("Error reading user-data file: %v\n", err)
-				return
+				return fmt.Errorf("reading user-data file: %w", err)
 			}
 			// Encode file content to base64
 			userDataBase64 := base64.StdEncoding.EncodeToString(fileContent)
 			createRequest.Properties.UserData = &userDataBase64
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().CloudServers().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating cloud server: %v\n", err)
-			return
+			return fmt.Errorf("creating cloud server: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create cloud server - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -302,6 +292,7 @@ var cloudserverCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Cloud server created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -309,37 +300,28 @@ var cloudserverGetCmd = &cobra.Command{
 	Use:   "get [cloudserver-id]",
 	Short: "Get cloud server details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
 		if err != nil {
-			fmt.Printf("Error getting cloud server: %v\n", err)
-			return
+			return fmt.Errorf("getting cloud server: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get cloud server - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -394,6 +376,7 @@ var cloudserverGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Cloud server not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -401,39 +384,35 @@ var cloudserverUpdateCmd = &cobra.Command{
 	Use:   "update [cloudserver-id]",
 	Short: "Update a cloud server",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" && len(tags) == 0 {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
 		if err != nil {
-			fmt.Printf("Error getting cloud server details: %v\n", err)
-			return
+			return fmt.Errorf("getting cloud server details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Error: Cloud server not found")
-			return
+			return fmt.Errorf("cloud server not found")
 		}
 
 		current := getResponse.Data
@@ -444,8 +423,7 @@ var cloudserverUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for cloud server")
-			return
+			return fmt.Errorf("unable to determine region value for cloud server")
 		}
 
 		// Build the update request, preserving existing values
@@ -486,19 +464,11 @@ var cloudserverUpdateCmd = &cobra.Command{
 
 		response, err := client.FromCompute().CloudServers().Update(ctx, projectID, serverID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating cloud server: %v\n", err)
-			return
+			return fmt.Errorf("updating cloud server: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update cloud server - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -512,6 +482,7 @@ var cloudserverUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Cloud server update initiated. Use 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -519,76 +490,67 @@ var cloudserverDeleteCmd = &cobra.Command{
 	Use:   "delete [cloudserver-id]",
 	Short: "Delete a cloud server",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
-		}
 
 		// Confirmation prompt
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete cloud server '%s'? (yes/no): ", serverID)
-			var confirmation string
-			fmt.Scanln(&confirmation)
-			if confirmation != "yes" && confirmation != "y" {
-				fmt.Println("Deletion cancelled.")
-				return
+			ok, err := confirmDelete("cloud server", serverID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
-		ctx := context.Background()
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
+
+		client, err := GetArubaClient()
+		if err != nil {
+			return fmt.Errorf("initializing client: %w", err)
+		}
+
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().CloudServers().Delete(ctx, projectID, serverID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting cloud server: %v\n", err)
-			return
+			return fmt.Errorf("deleting cloud server: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to delete cloud server - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		fmt.Printf("Cloud server '%s' deleted successfully.\n", serverID)
+		return nil
 	},
 }
 
 var cloudserverListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all cloud servers",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().CloudServers().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing cloud servers: %v\n", err)
-			return
+			return fmt.Errorf("listing cloud servers: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -655,6 +617,7 @@ var cloudserverListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No cloud servers found")
 		}
+		return nil
 	},
 }
 
@@ -662,37 +625,28 @@ var cloudserverPowerOnCmd = &cobra.Command{
 	Use:   "power-on [cloudserver-id]",
 	Short: "Power on a cloud server",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().CloudServers().PowerOn(ctx, projectID, serverID, nil)
 		if err != nil {
-			fmt.Printf("Error powering on cloud server: %v\n", err)
-			return
+			return fmt.Errorf("powering on cloud server: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to power on cloud server - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -706,6 +660,7 @@ var cloudserverPowerOnCmd = &cobra.Command{
 		} else {
 			fmt.Println("Cloud server power-on initiated. Use 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -713,37 +668,28 @@ var cloudserverPowerOffCmd = &cobra.Command{
 	Use:   "power-off [cloudserver-id]",
 	Short: "Power off a cloud server",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().CloudServers().PowerOff(ctx, projectID, serverID, nil)
 		if err != nil {
-			fmt.Printf("Error powering off cloud server: %v\n", err)
-			return
+			return fmt.Errorf("powering off cloud server: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to power off cloud server - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -757,6 +703,7 @@ var cloudserverPowerOffCmd = &cobra.Command{
 		} else {
 			fmt.Println("Cloud server power-off initiated. Use 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -764,47 +711,37 @@ var cloudserverSetPasswordCmd = &cobra.Command{
 	Use:   "set-password [cloudserver-id]",
 	Short: "Set password for a cloud server",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		password, _ := cmd.Flags().GetString("password")
 		if password == "" {
-			fmt.Println("Error: --password is required")
-			return
+			return fmt.Errorf("--password is required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		passwordRequest := types.CloudServerPasswordRequest{
 			Password: password,
 		}
 
 		response, err := client.FromCompute().CloudServers().SetPassword(ctx, projectID, serverID, passwordRequest, nil)
 		if err != nil {
-			fmt.Printf("Error setting password for cloud server: %v\n", err)
-			return
+			return fmt.Errorf("setting password for cloud server: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to set password for cloud server - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -827,6 +764,7 @@ var cloudserverSetPasswordCmd = &cobra.Command{
 			fmt.Println("Cloud server password set successfully!")
 			fmt.Printf("Server ID: %s\n", serverID)
 		}
+		return nil
 	},
 }
 
@@ -834,13 +772,12 @@ var cloudserverConnectCmd = &cobra.Command{
 	Use:   "connect [cloudserver-id]",
 	Short: "Get SSH connection information for a cloud server",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		user, _ := cmd.Flags().GetString("user")
@@ -851,38 +788,30 @@ var cloudserverConnectCmd = &cobra.Command{
 			fmt.Println("  - CentOS/RHEL: centos or root")
 			fmt.Println("  - Other Linux: root or check image documentation")
 			fmt.Println("\nFor more information, see: https://kb.arubacloud.com/cmp/en/computing/cloud-server.aspx")
-			return
+			return fmt.Errorf("--user is required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		// First, get the cloud server details
 		serverResp, err := client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
 		if err != nil {
-			fmt.Printf("Error getting cloud server: %v\n", err)
-			return
+			return fmt.Errorf("getting cloud server: %w", err)
 		}
 
 		if serverResp != nil && serverResp.IsError() && serverResp.Error != nil {
-			fmt.Printf("Failed to get cloud server - Status: %d\n", serverResp.StatusCode)
-			if serverResp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *serverResp.Error.Title)
-			}
-			if serverResp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *serverResp.Error.Detail)
-			}
-			return
+			return fmtAPIError(serverResp.StatusCode, serverResp.Error.Title, serverResp.Error.Detail)
 		}
 
 		if serverResp == nil || serverResp.Data == nil {
 			fmt.Println("Cloud server not found or no data returned.")
-			return
+			return nil
 		}
 
 		server := serverResp.Data
@@ -899,46 +828,38 @@ var cloudserverConnectCmd = &cobra.Command{
 		if elasticIPURI == "" {
 			fmt.Println("No Elastic IP found for this cloud server.")
 			fmt.Println("The server must have an Elastic IP linked to use the connect command.")
-			return
+			return nil
 		}
 
 		// Extract ElasticIP ID from URI
 		elasticIPID := extractIDFromURI(elasticIPURI)
 		if elasticIPID == "" {
-			fmt.Printf("Error: Could not extract Elastic IP ID from URI: %s\n", elasticIPURI)
-			return
+			return fmt.Errorf("could not extract Elastic IP ID from URI: %s", elasticIPURI)
 		}
 
 		// Get ElasticIP details
 		eipResp, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, elasticIPID, nil)
 		if err != nil {
-			fmt.Printf("Error getting Elastic IP details: %v\n", err)
-			return
+			return fmt.Errorf("getting Elastic IP details: %w", err)
 		}
 
 		if eipResp != nil && eipResp.IsError() && eipResp.Error != nil {
-			fmt.Printf("Failed to get Elastic IP - Status: %d\n", eipResp.StatusCode)
-			if eipResp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *eipResp.Error.Title)
-			}
-			if eipResp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *eipResp.Error.Detail)
-			}
-			return
+			return fmtAPIError(eipResp.StatusCode, eipResp.Error.Title, eipResp.Error.Detail)
 		}
 
 		if eipResp == nil || eipResp.Data == nil {
 			fmt.Println("Elastic IP not found or no data returned.")
-			return
+			return nil
 		}
 
 		eip := eipResp.Data
 		if eip.Properties.Address == nil || *eip.Properties.Address == "" {
 			fmt.Println("Elastic IP address not available.")
-			return
+			return nil
 		}
 
 		// Print SSH connection command
 		fmt.Printf("Connect by running: ssh %s@%s\n", user, *eip.Properties.Address)
+		return nil
 	},
 }

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -86,25 +86,23 @@ var keypairCmd = &cobra.Command{
 var keypairCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new keypair",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
 		publicKey, _ := cmd.Flags().GetString("public-key")
 
 		if name == "" || publicKey == "" {
-			fmt.Println("Error: --name and --public-key are required")
-			return
+			return fmt.Errorf("--name and --public-key are required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -121,22 +119,15 @@ var keypairCreateCmd = &cobra.Command{
 			},
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().KeyPairs().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating keypair: %v\n", err)
-			return
+			return fmt.Errorf("creating keypair: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create keypair - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -161,6 +152,7 @@ var keypairCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Keypair created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -168,37 +160,28 @@ var keypairGetCmd = &cobra.Command{
 	Use:   "get [keypair-name]",
 	Short: "Get keypair details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		keypairName := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromCompute().KeyPairs().Get(ctx, projectID, keypairName, nil)
 		if err != nil {
-			fmt.Printf("Error getting keypair: %v\n", err)
-			return
+			return fmt.Errorf("getting keypair: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get keypair - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -220,7 +203,7 @@ var keypairGetCmd = &cobra.Command{
 			fmt.Printf("Status:          Active\n")
 
 			if !keypair.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", keypair.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", keypair.Metadata.CreationDate.Format(DateLayout))
 			}
 			if keypair.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *keypair.Metadata.CreatedBy)
@@ -237,6 +220,7 @@ var keypairGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Keypair not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -244,13 +228,14 @@ var keypairUpdateCmd = &cobra.Command{
 	Use:   "update [keypair-name]",
 	Short: "Update a keypair (not supported - delete and recreate instead)",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Error: Keypair update is not supported by the API.")
 		fmt.Println("To change a keypair's public key, delete it and create a new one with the same name.")
 		fmt.Println("")
 		fmt.Println("Example:")
 		fmt.Printf("  acloud compute keypair delete %s --yes\n", args[0])
 		fmt.Printf("  acloud compute keypair create --name %s --public-key \"<new-key>\"\n", args[0])
+		return nil
 	},
 }
 
@@ -258,76 +243,67 @@ var keypairDeleteCmd = &cobra.Command{
 	Use:   "delete [keypair-name]",
 	Short: "Delete a keypair",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		keypairName := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
-		}
 
 		// Confirmation prompt
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete keypair '%s'? (yes/no): ", keypairName)
-			var confirmation string
-			fmt.Scanln(&confirmation)
-			if confirmation != "yes" && confirmation != "y" {
-				fmt.Println("Deletion cancelled.")
-				return
+			ok, err := confirmDelete("keypair", keypairName)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
-		ctx := context.Background()
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
+
+		client, err := GetArubaClient()
+		if err != nil {
+			return fmt.Errorf("initializing client: %w", err)
+		}
+
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().KeyPairs().Delete(ctx, projectID, keypairName, nil)
 		if err != nil {
-			fmt.Printf("Error deleting keypair: %v\n", err)
-			return
+			return fmt.Errorf("deleting keypair: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to delete keypair - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		fmt.Printf("Keypair '%s' deleted successfully.\n", keypairName)
+		return nil
 	},
 }
 
 var keypairListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all keypairs",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromCompute().KeyPairs().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing keypairs: %v\n", err)
-			return
+			return fmt.Errorf("listing keypairs: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -388,5 +364,6 @@ var keypairListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No keypairs found")
 		}
+		return nil
 	},
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -37,11 +37,23 @@ var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set configuration values",
 	Long:  `Set configuration values for acloud, such as clientId and clientSecret.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		clientID, _ := cmd.Flags().GetString("client-id")
-		clientSecret, _ := cmd.Flags().GetString("client-secret")
-		baseURL, _ := cmd.Flags().GetString("base-url")
-		tokenIssuerURL, _ := cmd.Flags().GetString("token-issuer-url")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clientID, err := cmd.Flags().GetString("client-id")
+		if err != nil {
+			return err
+		}
+		clientSecret, err := cmd.Flags().GetString("client-secret")
+		if err != nil {
+			return err
+		}
+		baseURL, err := cmd.Flags().GetString("base-url")
+		if err != nil {
+			return err
+		}
+		tokenIssuerURL, err := cmd.Flags().GetString("token-issuer-url")
+		if err != nil {
+			return err
+		}
 
 		// Load existing config or create new one
 		config, err := LoadConfig()
@@ -51,17 +63,11 @@ var configSetCmd = &cobra.Command{
 		}
 
 		// Validate required fields
-		// If setting up for the first time, both client-id and client-secret are required
-		// If updating, at least one must be provided, but final config must have both
 		if config.ClientID == "" && clientID == "" {
-			fmt.Println("Error: --client-id is required")
-			fmt.Println("Please run: acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET")
-			os.Exit(1)
+			return fmt.Errorf("--client-id is required\nPlease run: acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET")
 		}
 		if config.ClientSecret == "" && clientSecret == "" {
-			fmt.Println("Error: --client-secret is required")
-			fmt.Println("Please run: acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET")
-			os.Exit(1)
+			return fmt.Errorf("--client-secret is required\nPlease run: acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET")
 		}
 
 		// Update only provided values
@@ -80,15 +86,12 @@ var configSetCmd = &cobra.Command{
 
 		// Final validation: both clientID and clientSecret must be set
 		if config.ClientID == "" || config.ClientSecret == "" {
-			fmt.Println("Error: Both --client-id and --client-secret are required")
-			fmt.Println("Please run: acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET")
-			os.Exit(1)
+			return fmt.Errorf("both --client-id and --client-secret are required\nPlease run: acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET")
 		}
 
 		// Save config
 		if err := SaveConfig(config); err != nil {
-			fmt.Printf("Error saving configuration: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("saving configuration: %w", err)
 		}
 
 		fmt.Println("Configuration updated successfully")
@@ -104,6 +107,7 @@ var configSetCmd = &cobra.Command{
 		if tokenIssuerURL != "" {
 			fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
 		}
+		return nil
 	},
 }
 
@@ -112,11 +116,11 @@ var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show current configuration",
 	Long:  `Display the current acloud configuration.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		config, err := LoadConfig()
 		if err != nil {
 			fmt.Println("No configuration found. Please run 'acloud config set' to create one.")
-			return
+			return nil
 		}
 
 		fmt.Println("Current configuration:")
@@ -136,6 +140,7 @@ var configShowCmd = &cobra.Command{
 			tokenIssuerURL = DefaultTokenIssuerURL + " (default)"
 		}
 		fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
+		return nil
 	},
 }
 
@@ -174,7 +179,7 @@ func LoadConfig() (*Config, error) {
 
 	var config Config
 	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("config file %s is corrupted (%w). Delete it and run 'acloud config set' to reconfigure", configPath, err)
 	}
 
 	return &config, nil
@@ -192,5 +197,5 @@ func SaveConfig(config *Config) error {
 		return err
 	}
 
-	return os.WriteFile(configPath, data, 0600)
+	return os.WriteFile(configPath, data, FilePermConfig)
 }

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,17 @@
+package cmd
+
+// Resource state values returned by the API.
+const (
+	StateInCreation = "InCreation"
+	StateUsed       = "Used"
+	StateNotUsed    = "NotUsed"
+)
+
+// DateLayout is the display format used for all creation/modification timestamps.
+const DateLayout = "02-01-2006 15:04:05"
+
+// File permission modes.
+const (
+	FilePermConfig  = 0600 // owner read/write only — for credential files
+	FilePermDirAll  = 0755 // owner rwx, group/other rx — for config directories
+)

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -114,11 +114,11 @@ var containerregistryCmd = &cobra.Command{
 var containerregistryCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new container registry",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get metadata flags
@@ -140,8 +140,7 @@ var containerregistryCreateCmd = &cobra.Command{
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -189,33 +188,23 @@ var containerregistryCreateCmd = &cobra.Command{
 			createRequest.Properties.ConcurrentUsers = &concurrentUsers
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		containerClient := client.FromContainer()
 		if containerClient == nil {
-			fmt.Println("Error: Container client is not available")
-			return
+			return fmt.Errorf("container client is not available")
 		}
 		registryClient := containerClient.ContainerRegistry()
 		if registryClient == nil {
-			fmt.Println("Error: Container Registry client returned nil")
-			fmt.Println("This may indicate that Container Registry is not available in your SDK version")
-			return
+			return fmt.Errorf("container Registry client returned nil — this may indicate that Container Registry is not available in your SDK version")
 		}
 		response, err := registryClient.Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating container registry: %v\n", err)
-			return
+			return fmt.Errorf("creating container registry: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create container registry - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -235,6 +224,7 @@ var containerregistryCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Container registry creation initiated. Use 'list' or 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -242,48 +232,36 @@ var containerregistryGetCmd = &cobra.Command{
 	Use:   "get [containerregistry-id]",
 	Short: "Get container registry details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		registryID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		containerClient := client.FromContainer()
 		if containerClient == nil {
-			fmt.Println("Error: Container client is not available")
-			return
+			return fmt.Errorf("container client is not available")
 		}
 		registryClient := containerClient.ContainerRegistry()
 		if registryClient == nil {
-			fmt.Println("Error: Container Registry client returned nil")
-			fmt.Println("This may indicate that Container Registry is not available in your SDK version")
-			return
+			return fmt.Errorf("container Registry client returned nil — this may indicate that Container Registry is not available in your SDK version")
 		}
 		resp, err := registryClient.Get(ctx, projectID, registryID, nil)
 		if err != nil {
-			fmt.Printf("Error getting container registry: %v\n", err)
-			return
+			return fmt.Errorf("getting container registry: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get container registry - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -336,7 +314,7 @@ var containerregistryGetCmd = &cobra.Command{
 			}
 
 			if !registry.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", registry.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", registry.Metadata.CreationDate.Format(DateLayout))
 			}
 			if registry.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *registry.Metadata.CreatedBy)
@@ -350,6 +328,7 @@ var containerregistryGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Container registry not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -357,13 +336,12 @@ var containerregistryUpdateCmd = &cobra.Command{
 	Use:   "update [containerregistry-id]",
 	Short: "Update a container registry",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		registryID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -372,40 +350,34 @@ var containerregistryUpdateCmd = &cobra.Command{
 		concurrentUsers, _ := cmd.Flags().GetString("concurrent-users")
 
 		if name == "" && len(tags) == 0 && billingPeriod == "" && concurrentUsers == "" {
-			fmt.Println("Error: at least one of --name, --tags, --billing-period, or --concurrent-users must be provided")
-			return
+			return fmt.Errorf("at least one of --name, --tags, --billing-period, or --concurrent-users must be provided")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		containerClient := client.FromContainer()
 		if containerClient == nil {
-			fmt.Println("Error: Container client is not available")
-			return
+			return fmt.Errorf("container client is not available")
 		}
 		registryClient := containerClient.ContainerRegistry()
 		if registryClient == nil {
-			fmt.Println("Error: Container Registry client returned nil")
-			fmt.Println("This may indicate that Container Registry is not available in your SDK version")
-			return
+			return fmt.Errorf("container Registry client returned nil — this may indicate that Container Registry is not available in your SDK version")
 		}
 
 		// Get current registry to preserve existing values
 		getResponse, err := registryClient.Get(ctx, projectID, registryID, nil)
 		if err != nil {
-			fmt.Printf("Error getting container registry: %v\n", err)
-			return
+			return fmt.Errorf("getting container registry: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Container registry not found")
-			return
+			return fmt.Errorf("container registry not found")
 		}
 
 		current := getResponse.Data
@@ -421,6 +393,10 @@ var containerregistryUpdateCmd = &cobra.Command{
 			updateTags = current.Metadata.Tags
 		}
 
+		registryRegion := ""
+		if current.Metadata.LocationResponse != nil {
+			registryRegion = current.Metadata.LocationResponse.Value
+		}
 		updateRequest := types.ContainerRegistryRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{
@@ -428,7 +404,7 @@ var containerregistryUpdateCmd = &cobra.Command{
 					Tags: updateTags,
 				},
 				Location: types.LocationRequest{
-					Value: current.Metadata.LocationResponse.Value,
+					Value: registryRegion,
 				},
 			},
 			Properties: types.ContainerRegistryPropertiesRequest{
@@ -464,19 +440,11 @@ var containerregistryUpdateCmd = &cobra.Command{
 
 		response, err := registryClient.Update(ctx, projectID, registryID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating container registry: %v\n", err)
-			return
+			return fmt.Errorf("updating container registry: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update container registry - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -493,6 +461,7 @@ var containerregistryUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Container registry update initiated. Use 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -500,115 +469,93 @@ var containerregistryDeleteCmd = &cobra.Command{
 	Use:   "delete [containerregistry-id]",
 	Short: "Delete a container registry",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		registryID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
-		}
 
 		// Confirmation prompt
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete container registry '%s'? (yes/no): ", registryID)
-			var confirmation string
-			fmt.Scanln(&confirmation)
-			if confirmation != "yes" && confirmation != "y" {
-				fmt.Println("Deletion cancelled.")
-				return
+			ok, err := confirmDelete("container registry", registryID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
-		ctx := context.Background()
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
+
+		client, err := GetArubaClient()
+		if err != nil {
+			return fmt.Errorf("initializing client: %w", err)
+		}
+
+		ctx, cancel := newCtx()
+		defer cancel()
 		containerClient := client.FromContainer()
 		if containerClient == nil {
-			fmt.Println("Error: Container client is not available")
-			return
+			return fmt.Errorf("container client is not available")
 		}
 		registryClient := containerClient.ContainerRegistry()
 		if registryClient == nil {
-			fmt.Println("Error: Container Registry client returned nil")
-			fmt.Println("This may indicate that Container Registry is not available in your SDK version")
-			return
+			return fmt.Errorf("container Registry client returned nil — this may indicate that Container Registry is not available in your SDK version")
 		}
 		response, err := registryClient.Delete(ctx, projectID, registryID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting container registry: %v\n", err)
-			return
+			return fmt.Errorf("deleting container registry: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to delete container registry - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		fmt.Printf("\nContainer registry '%s' deleted successfully!\n", registryID)
+		return nil
 	},
 }
 
 var containerregistryListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all container registries",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		containerClient := client.FromContainer()
 		if containerClient == nil {
-			fmt.Println("Error: Container client is not available")
-			return
+			return fmt.Errorf("container client is not available")
 		}
 		registryClient := containerClient.ContainerRegistry()
 		if registryClient == nil {
-			fmt.Println("Error: Container Registry client returned nil")
-			fmt.Println("This may indicate that Container Registry is not available in your SDK version")
-			return
+			return fmt.Errorf("container Registry client returned nil — this may indicate that Container Registry is not available in your SDK version")
 		}
 		response, err := registryClient.List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing container registries: %v\n", err)
-			return
+			return fmt.Errorf("listing container registries: %w", err)
 		}
 
 		if response == nil {
 			fmt.Println("No response received from server")
-			return
+			return nil
 		}
 
 		if response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to list container registries - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response.Data != nil && len(response.Data.Values) > 0 {
@@ -653,5 +600,6 @@ var containerregistryListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No container registries found")
 		}
+		return nil
 	},
 }

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -146,11 +146,11 @@ var kaasCmd = &cobra.Command{
 var kaasCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new KaaS cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get metadata flags
@@ -184,8 +184,7 @@ var kaasCreateCmd = &cobra.Command{
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build node pool
@@ -265,22 +264,15 @@ var kaasCreateCmd = &cobra.Command{
 			createRequest.Properties.APIServerAccessProfile = apiServerAccessProfile
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromContainer().KaaS().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating KaaS cluster: %v\n", err)
-			return
+			return fmt.Errorf("creating KaaS cluster: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create KaaS cluster - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -319,6 +311,7 @@ var kaasCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("KaaS cluster created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -326,37 +319,28 @@ var kaasGetCmd = &cobra.Command{
 	Use:   "get [kaas-id]",
 	Short: "Get KaaS cluster details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromContainer().KaaS().Get(ctx, projectID, kaasID, nil)
 		if err != nil {
-			fmt.Printf("Error getting KaaS cluster: %v\n", err)
-			return
+			return fmt.Errorf("getting KaaS cluster: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get KaaS cluster - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -385,7 +369,7 @@ var kaasGetCmd = &cobra.Command{
 			}
 
 			if !kaas.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", kaas.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", kaas.Metadata.CreationDate.Format(DateLayout))
 			}
 			if kaas.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *kaas.Metadata.CreatedBy)
@@ -408,6 +392,7 @@ var kaasGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("KaaS cluster not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -415,31 +400,28 @@ var kaasUpdateCmd = &cobra.Command{
 	Use:   "update [kaas-id]",
 	Short: "Update a KaaS cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromContainer().KaaS().Get(ctx, projectID, kaasID, nil)
 		if err != nil {
-			fmt.Printf("Error getting KaaS cluster details: %v\n", err)
-			return
+			return fmt.Errorf("getting KaaS cluster details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Error: KaaS cluster not found")
-			return
+			return fmt.Errorf("KaaS cluster not found")
 		}
 
 		current := getResponse.Data
@@ -485,8 +467,7 @@ var kaasUpdateCmd = &cobra.Command{
 			if current.Properties.KubernetesVersion.Value != nil {
 				kubernetesVersionValue = *current.Properties.KubernetesVersion.Value
 			} else {
-				fmt.Println("Error: Kubernetes version is required")
-				return
+				return fmt.Errorf("kubernetes version is required")
 			}
 		}
 
@@ -604,19 +585,11 @@ var kaasUpdateCmd = &cobra.Command{
 
 		response, err := client.FromContainer().KaaS().Update(ctx, projectID, kaasID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating KaaS cluster: %v\n", err)
-			return
+			return fmt.Errorf("updating KaaS cluster: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update KaaS cluster - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -633,6 +606,7 @@ var kaasUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("KaaS cluster update initiated. Use 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -640,76 +614,67 @@ var kaasDeleteCmd = &cobra.Command{
 	Use:   "delete [kaas-id]",
 	Short: "Delete a KaaS cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
-		}
 
 		// Confirmation prompt
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete KaaS cluster '%s'? (yes/no): ", kaasID)
-			var confirmation string
-			fmt.Scanln(&confirmation)
-			if confirmation != "yes" && confirmation != "y" {
-				fmt.Println("Deletion cancelled.")
-				return
+			ok, err := confirmDelete("KaaS cluster", kaasID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
-		ctx := context.Background()
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
+
+		client, err := GetArubaClient()
+		if err != nil {
+			return fmt.Errorf("initializing client: %w", err)
+		}
+
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromContainer().KaaS().Delete(ctx, projectID, kaasID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting KaaS cluster: %v\n", err)
-			return
+			return fmt.Errorf("deleting KaaS cluster: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to delete KaaS cluster - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		fmt.Printf("KaaS cluster '%s' deleted successfully.\n", kaasID)
+		return nil
 	},
 }
 
 var kaasListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all KaaS clusters",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromContainer().KaaS().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing KaaS clusters: %v\n", err)
-			return
+			return fmt.Errorf("listing KaaS clusters: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -757,6 +722,7 @@ var kaasListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No KaaS clusters found")
 		}
+		return nil
 	},
 }
 
@@ -764,42 +730,32 @@ var kaasConnectCmd = &cobra.Command{
 	Use:   "connect [kaas-id]",
 	Short: "Connect to a KaaS cluster and configure kubectl",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromContainer().KaaS().DownloadKubeconfig(ctx, projectID, kaasID, nil)
 		if err != nil {
-			fmt.Printf("Error downloading kubeconfig: %v\n", err)
-			return
+			return fmt.Errorf("downloading kubeconfig: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to connect to KaaS cluster - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response == nil || response.Data == nil {
-			fmt.Println("Error: No kubeconfig data returned")
-			return
+			return fmt.Errorf("no kubeconfig data returned")
 		}
 
 		kubeconfig := response.Data
@@ -807,39 +763,34 @@ var kaasConnectCmd = &cobra.Command{
 		// Decode base64 content
 		decodedContent, err := base64.StdEncoding.DecodeString(kubeconfig.Content)
 		if err != nil {
-			fmt.Printf("Error decoding kubeconfig content: %v\n", err)
-			return
+			return fmt.Errorf("decoding kubeconfig content: %w", err)
 		}
 
 		// Get home directory
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Printf("Error getting home directory: %v\n", err)
-			return
+			return fmt.Errorf("getting home directory: %w", err)
 		}
 
 		// Create .kube directory if it doesn't exist
 		kubeDir := filepath.Join(homeDir, ".kube")
 		err = os.MkdirAll(kubeDir, 0755)
 		if err != nil {
-			fmt.Printf("Error creating .kube directory: %v\n", err)
-			return
+			return fmt.Errorf("creating .kube directory: %w", err)
 		}
 
 		// Write kubeconfig file with name from response
 		kubeconfigFile := filepath.Join(kubeDir, kubeconfig.Name)
 		err = os.WriteFile(kubeconfigFile, decodedContent, 0600)
 		if err != nil {
-			fmt.Printf("Error writing kubeconfig file: %v\n", err)
-			return
+			return fmt.Errorf("writing kubeconfig file: %w", err)
 		}
 
 		// Copy to config file (overwrite if exists)
 		configFile := filepath.Join(kubeDir, "config")
 		err = os.WriteFile(configFile, decodedContent, 0600)
 		if err != nil {
-			fmt.Printf("Error writing config file: %v\n", err)
-			return
+			return fmt.Errorf("writing config file: %w", err)
 		}
 
 		// Run kubectl cluster-info
@@ -858,5 +809,6 @@ var kaasConnectCmd = &cobra.Command{
 		fmt.Println("KaaS successfully connected")
 		fmt.Printf("Kubeconfig saved to: %s\n", kubeconfigFile)
 		fmt.Printf("Default config updated: %s\n", configFile)
+		return nil
 	},
 }

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -31,13 +31,15 @@ var contextSetCmd = &cobra.Command{
 	Use:   "set [context-name]",
 	Short: "Set a context with a project ID",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		contextName := args[0]
-		projectID, _ := cmd.Flags().GetString("project-id")
+		projectID, err := cmd.Flags().GetString("project-id")
+		if err != nil {
+			return err
+		}
 
 		if projectID == "" {
-			fmt.Println("Error: --project-id is required")
-			return
+			return fmt.Errorf("--project-id is required")
 		}
 
 		// Load existing context or create new
@@ -56,11 +58,11 @@ var contextSetCmd = &cobra.Command{
 
 		// Save context
 		if err := SaveContext(ctx); err != nil {
-			fmt.Printf("Error saving context: %v\n", err)
-			return
+			return fmt.Errorf("saving context: %w", err)
 		}
 
 		fmt.Printf("Context '%s' set with project ID: %s\n", contextName, projectID)
+		return nil
 	},
 }
 
@@ -68,24 +70,22 @@ var contextUseCmd = &cobra.Command{
 	Use:   "use [context-name]",
 	Short: "Switch to a different context",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		contextName := args[0]
 
 		// Load context
 		ctx, err := LoadContext()
 		if err != nil {
-			fmt.Printf("Error loading context: %v\n", err)
-			return
+			return fmt.Errorf("loading context: %w", err)
 		}
 
 		// Check if context exists
 		if _, exists := ctx.Contexts[contextName]; !exists {
-			fmt.Printf("Context '%s' not found. Available contexts: ", contextName)
+			available := make([]string, 0, len(ctx.Contexts))
 			for name := range ctx.Contexts {
-				fmt.Printf("%s ", name)
+				available = append(available, name)
 			}
-			fmt.Println()
-			return
+			return fmt.Errorf("context '%s' not found; available contexts: %v", contextName, available)
 		}
 
 		// Set current context
@@ -93,29 +93,30 @@ var contextUseCmd = &cobra.Command{
 
 		// Save context
 		if err := SaveContext(ctx); err != nil {
-			fmt.Printf("Error saving context: %v\n", err)
-			return
+			return fmt.Errorf("saving context: %w", err)
 		}
 
 		fmt.Printf("Switched to context '%s'\n", contextName)
 		fmt.Printf("Project ID: %s\n", ctx.Contexts[contextName].ProjectID)
+		return nil
 	},
 }
 
 var contextListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all contexts",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Load context
 		ctx, err := LoadContext()
 		if err != nil {
 			fmt.Println("No contexts found")
-			return
+			return nil
 		}
 
 		if len(ctx.Contexts) == 0 {
 			fmt.Println("No contexts found")
-			return
+			return nil
 		}
 
 		fmt.Println("\nContexts:")
@@ -130,28 +131,30 @@ var contextListCmd = &cobra.Command{
 		if ctx.CurrentContext != "" {
 			fmt.Printf("\n* = current context\n")
 		}
+		return nil
 	},
 }
 
 var contextCurrentCmd = &cobra.Command{
 	Use:   "current",
 	Short: "Show current context",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Load context
 		ctx, err := LoadContext()
 		if err != nil || ctx.CurrentContext == "" {
 			fmt.Println("No current context set")
-			return
+			return nil
 		}
 
 		info, exists := ctx.Contexts[ctx.CurrentContext]
 		if !exists {
 			fmt.Println("Current context not found")
-			return
+			return nil
 		}
 
 		fmt.Printf("Current context: %s\n", ctx.CurrentContext)
 		fmt.Printf("Project ID:      %s\n", info.ProjectID)
+		return nil
 	},
 }
 
@@ -159,20 +162,18 @@ var contextDeleteCmd = &cobra.Command{
 	Use:   "delete [context-name]",
 	Short: "Delete a context",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		contextName := args[0]
 
 		// Load context
 		ctx, err := LoadContext()
 		if err != nil {
-			fmt.Printf("Error loading context: %v\n", err)
-			return
+			return fmt.Errorf("loading context: %w", err)
 		}
 
 		// Check if context exists
 		if _, exists := ctx.Contexts[contextName]; !exists {
-			fmt.Printf("Context '%s' not found\n", contextName)
-			return
+			return fmt.Errorf("context '%s' not found", contextName)
 		}
 
 		// Delete context
@@ -185,17 +186,20 @@ var contextDeleteCmd = &cobra.Command{
 
 		// Save context
 		if err := SaveContext(ctx); err != nil {
-			fmt.Printf("Error saving context: %v\n", err)
-			return
+			return fmt.Errorf("saving context: %w", err)
 		}
 
 		fmt.Printf("Context '%s' deleted\n", contextName)
+		return nil
 	},
 }
 
 // LoadContext loads the context configuration
 func LoadContext() (*Context, error) {
-	contextFile := getContextFilePath()
+	contextFile, err := getContextFilePath()
+	if err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(contextFile)
 	if err != nil {
 		return nil, err
@@ -203,7 +207,7 @@ func LoadContext() (*Context, error) {
 
 	var ctx Context
 	if err := yaml.Unmarshal(data, &ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("context file %s is corrupted (%w). Delete it and run 'acloud context set' to reconfigure", contextFile, err)
 	}
 
 	return &ctx, nil
@@ -211,11 +215,14 @@ func LoadContext() (*Context, error) {
 
 // SaveContext saves the context configuration
 func SaveContext(ctx *Context) error {
-	contextFile := getContextFilePath()
+	contextFile, err := getContextFilePath()
+	if err != nil {
+		return err
+	}
 
 	// Ensure directory exists
 	dir := filepath.Dir(contextFile)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, FilePermDirAll); err != nil {
 		return err
 	}
 
@@ -224,7 +231,7 @@ func SaveContext(ctx *Context) error {
 		return err
 	}
 
-	return os.WriteFile(contextFile, data, 0600)
+	return os.WriteFile(contextFile, data, FilePermConfig)
 }
 
 // GetCurrentProjectID returns the project ID from the current context
@@ -246,13 +253,13 @@ func GetCurrentProjectID() (string, error) {
 	return info.ProjectID, nil
 }
 
-// getContextFilePath returns the path to the context file
-func getContextFilePath() string {
+// getContextFilePath returns the path to the context file (TD-007).
+func getContextFilePath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ".acloud-context.yaml"
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return filepath.Join(home, ".acloud-context.yaml")
+	return filepath.Join(home, ".acloud-context.yaml"), nil
 }
 
 func init() {

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -92,11 +92,11 @@ var backupCmd = &cobra.Command{
 var backupCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new database backup",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -107,34 +107,30 @@ var backupCreateCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" || region == "" || dbaasID == "" || databaseName == "" {
-			fmt.Println("Error: --name, --region, --dbaas-id, and --database-name are required")
-			return
+			return fmt.Errorf("--name, --region, --dbaas-id, and --database-name are required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get DBaaS instance to get its URI
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		dbaasResp, err := client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
 		if err != nil {
-			fmt.Printf("Error getting DBaaS instance: %v\n", err)
-			return
+			return fmt.Errorf("getting DBaaS instance: %w", err)
 		}
 
 		if dbaasResp == nil || dbaasResp.Data == nil || dbaasResp.Data.Metadata.URI == nil {
-			fmt.Println("Error: DBaaS instance not found")
-			return
+			return fmt.Errorf("DBaaS instance not found")
 		}
 
 		// Get database to get its URI
 		dbResp, err := client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
 		if err != nil {
-			fmt.Printf("Error getting database: %v\n", err)
-			return
+			return fmt.Errorf("getting database: %w", err)
 		}
 
 		// Note: DatabaseResponse doesn't have a URI field, so we may need to construct it
@@ -173,19 +169,11 @@ var backupCreateCmd = &cobra.Command{
 
 		response, err := client.FromDatabase().Backups().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating backup: %v\n", err)
-			return
+			return fmt.Errorf("creating backup: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create backup - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -225,6 +213,7 @@ var backupCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Backup created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -232,37 +221,28 @@ var backupGetCmd = &cobra.Command{
 	Use:   "get [backup-id]",
 	Short: "Get backup details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error getting backup: %v\n", err)
-			return
+			return fmt.Errorf("getting backup: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get backup - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -287,7 +267,7 @@ var backupGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *backup.Status.State)
 			}
 			if !backup.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", backup.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", backup.Metadata.CreationDate.Format(DateLayout))
 			}
 			if backup.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *backup.Metadata.CreatedBy)
@@ -301,41 +281,34 @@ var backupGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Backup not found")
 		}
+		return nil
 	},
 }
 
 var backupListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all database backups",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().Backups().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing backups: %v\n", err)
-			return
+			return fmt.Errorf("listing backups: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list backups - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -380,6 +353,7 @@ var backupListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No backups found")
 		}
+		return nil
 	},
 }
 
@@ -387,9 +361,10 @@ var backupUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id]",
 	Short: "Update a backup",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Error: Database backups do not support update operations")
 		fmt.Println("You can only create, list, get, and delete database backups.")
+		return nil
 	},
 }
 
@@ -397,40 +372,39 @@ var backupDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id]",
 	Short: "Delete a backup",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete backup %s? (yes/no): ", backupID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("backup", backupID)
+			if err != nil {
+				return err
 			}
+			if !ok {
+				return nil
+			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromDatabase().Backups().Delete(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting backup: %v\n", err)
-			return
+			return fmt.Errorf("deleting backup: %w", err)
 		}
 
 		fmt.Printf("\nBackup %s deleted successfully!\n", backupID)
+		return nil
 	},
 }

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -88,59 +88,50 @@ var dbaasDatabaseCreateCmd = &cobra.Command{
 	Use:   "create [dbaas-id]",
 	Short: "Create a new database in DBaaS",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
 
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		createRequest := types.DatabaseRequest{
 			Name: name,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromDatabase().Databases().Create(ctx, projectID, dbaasID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating database: %v\n", err)
-			return
+			return fmt.Errorf("creating database: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create database - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
 			fmt.Println("\nDatabase created successfully!")
 			fmt.Printf("Name:            %s\n", response.Data.Name)
 			if response.Data.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", response.Data.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", response.Data.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println("Database created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -148,38 +139,29 @@ var dbaasDatabaseGetCmd = &cobra.Command{
 	Use:   "get [dbaas-id] [database-name]",
 	Short: "Get database details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 		databaseName := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
 		if err != nil {
-			fmt.Printf("Error getting database: %v\n", err)
-			return
+			return fmt.Errorf("getting database: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get database - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -190,7 +172,7 @@ var dbaasDatabaseGetCmd = &cobra.Command{
 
 			fmt.Printf("Name:            %s\n", db.Name)
 			if db.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", db.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", db.CreationDate.Format(DateLayout))
 			}
 			if db.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *db.CreatedBy)
@@ -199,6 +181,7 @@ var dbaasDatabaseGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Database not found")
 		}
+		return nil
 	},
 }
 
@@ -206,37 +189,28 @@ var dbaasDatabaseListCmd = &cobra.Command{
 	Use:   "list [dbaas-id]",
 	Short: "List all databases in DBaaS",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().Databases().List(ctx, projectID, dbaasID, nil)
 		if err != nil {
-			fmt.Printf("Error listing databases: %v\n", err)
-			return
+			return fmt.Errorf("listing databases: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list databases - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -252,7 +226,7 @@ var dbaasDatabaseListCmd = &cobra.Command{
 					db.Name,
 					func() string {
 						if db.CreationDate != nil {
-							return db.CreationDate.Format("02-01-2006 15:04:05")
+							return db.CreationDate.Format(DateLayout)
 						}
 						return ""
 					}(),
@@ -269,6 +243,7 @@ var dbaasDatabaseListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No databases found")
 		}
+		return nil
 	},
 }
 
@@ -276,49 +251,39 @@ var dbaasDatabaseUpdateCmd = &cobra.Command{
 	Use:   "update [dbaas-id] [database-name]",
 	Short: "Update a database",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 		databaseName := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
 
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		updateRequest := types.DatabaseRequest{
 			Name: name,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromDatabase().Databases().Update(ctx, projectID, dbaasID, databaseName, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating database: %v\n", err)
-			return
+			return fmt.Errorf("updating database: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update database - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -327,6 +292,7 @@ var dbaasDatabaseUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -334,41 +300,40 @@ var dbaasDatabaseDeleteCmd = &cobra.Command{
 	Use:   "delete [dbaas-id] [database-name]",
 	Short: "Delete a database",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 		databaseName := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete database '%s' in DBaaS instance %s? (yes/no): ", databaseName, dbaasID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete(fmt.Sprintf("database '%s' in DBaaS instance", databaseName), dbaasID)
+			if err != nil {
+				return err
 			}
+			if !ok {
+				return nil
+			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromDatabase().Databases().Delete(ctx, projectID, dbaasID, databaseName, nil)
 		if err != nil {
-			fmt.Printf("Error deleting database: %v\n", err)
-			return
+			return fmt.Errorf("deleting database: %w", err)
 		}
 
 		fmt.Printf("\nDatabase '%s' deleted successfully!\n", databaseName)
+		return nil
 	},
 }

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -92,11 +92,11 @@ var dbaasCmd = &cobra.Command{
 var dbaasCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new DBaaS instance",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -106,14 +106,12 @@ var dbaasCreateCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" || region == "" || engineID == "" || flavor == "" {
-			fmt.Println("Error: --name, --region, --engine-id, and --flavor are required")
-			return
+			return fmt.Errorf("--name, --region, --engine-id, and --flavor are required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -137,22 +135,15 @@ var dbaasCreateCmd = &cobra.Command{
 			},
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromDatabase().DBaaS().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating DBaaS instance: %v\n", err)
-			return
+			return fmt.Errorf("creating DBaaS instance: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create DBaaS instance - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -206,6 +197,7 @@ var dbaasCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("DBaaS instance created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -213,37 +205,28 @@ var dbaasGetCmd = &cobra.Command{
 	Use:   "get [dbaas-id]",
 	Short: "Get DBaaS instance details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
 		if err != nil {
-			fmt.Printf("Error getting DBaaS instance: %v\n", err)
-			return
+			return fmt.Errorf("getting DBaaS instance: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get DBaaS instance - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -282,7 +265,7 @@ var dbaasGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *dbaas.Status.State)
 			}
 			if !dbaas.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", dbaas.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", dbaas.Metadata.CreationDate.Format(DateLayout))
 			}
 			if dbaas.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *dbaas.Metadata.CreatedBy)
@@ -296,41 +279,34 @@ var dbaasGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("DBaaS instance not found")
 		}
+		return nil
 	},
 }
 
 var dbaasListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all DBaaS instances",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().DBaaS().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing DBaaS instances: %v\n", err)
-			return
+			return fmt.Errorf("listing DBaaS instances: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list DBaaS instances - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -396,6 +372,7 @@ var dbaasListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No DBaaS instances found")
 		}
+		return nil
 	},
 }
 
@@ -403,39 +380,35 @@ var dbaasUpdateCmd = &cobra.Command{
 	Use:   "update [dbaas-id]",
 	Short: "Update a DBaaS instance",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResp, err := client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
 		if err != nil {
-			fmt.Printf("Error getting DBaaS instance: %v\n", err)
-			return
+			return fmt.Errorf("getting DBaaS instance: %w", err)
 		}
 
 		if getResp == nil || getResp.Data == nil {
-			fmt.Println("DBaaS instance not found")
-			return
+			return fmt.Errorf("DBaaS instance not found")
 		}
 
 		current := getResp.Data
@@ -445,8 +418,7 @@ var dbaasUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for DBaaS instance")
-			return
+			return fmt.Errorf("unable to determine region value for DBaaS instance")
 		}
 
 		// Build update request preserving current properties
@@ -487,19 +459,11 @@ var dbaasUpdateCmd = &cobra.Command{
 
 		response, err := client.FromDatabase().DBaaS().Update(ctx, projectID, dbaasID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating DBaaS instance: %v\n", err)
-			return
+			return fmt.Errorf("updating DBaaS instance: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update DBaaS instance - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -512,6 +476,7 @@ var dbaasUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -519,40 +484,39 @@ var dbaasDeleteCmd = &cobra.Command{
 	Use:   "delete [dbaas-id]",
 	Short: "Delete a DBaaS instance",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete DBaaS instance %s? (yes/no): ", dbaasID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("DBaaS instance", dbaasID)
+			if err != nil {
+				return err
 			}
+			if !ok {
+				return nil
+			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromDatabase().DBaaS().Delete(ctx, projectID, dbaasID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting DBaaS instance: %v\n", err)
-			return
+			return fmt.Errorf("deleting DBaaS instance: %w", err)
 		}
 
 		fmt.Printf("\nDBaaS instance %s deleted successfully!\n", dbaasID)
+		return nil
 	},
 }

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -90,27 +90,24 @@ var dbaasUserCreateCmd = &cobra.Command{
 	Use:   "create [dbaas-id]",
 	Short: "Create a new user in DBaaS",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		username, _ := cmd.Flags().GetString("username")
 		password, _ := cmd.Flags().GetString("password")
 
 		if username == "" || password == "" {
-			fmt.Println("Error: --username and --password are required")
-			return
+			return fmt.Errorf("--username and --password are required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		createRequest := types.UserRequest{
@@ -118,33 +115,27 @@ var dbaasUserCreateCmd = &cobra.Command{
 			Password: password,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromDatabase().Users().Create(ctx, projectID, dbaasID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating user: %v\n", err)
-			return
+			return fmt.Errorf("creating user: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create user - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
 			fmt.Println("\nUser created successfully!")
 			fmt.Printf("Username:        %s\n", response.Data.Username)
 			if response.Data.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", response.Data.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", response.Data.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println("User created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -152,38 +143,29 @@ var dbaasUserGetCmd = &cobra.Command{
 	Use:   "get [dbaas-id] [username]",
 	Short: "Get user details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 		username := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
 		if err != nil {
-			fmt.Printf("Error getting user: %v\n", err)
-			return
+			return fmt.Errorf("getting user: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get user - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -194,7 +176,7 @@ var dbaasUserGetCmd = &cobra.Command{
 
 			fmt.Printf("Username:        %s\n", user.Username)
 			if user.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", user.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", user.CreationDate.Format(DateLayout))
 			}
 			if user.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *user.CreatedBy)
@@ -203,6 +185,7 @@ var dbaasUserGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("User not found")
 		}
+		return nil
 	},
 }
 
@@ -210,37 +193,28 @@ var dbaasUserListCmd = &cobra.Command{
 	Use:   "list [dbaas-id]",
 	Short: "List all users in DBaaS",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromDatabase().Users().List(ctx, projectID, dbaasID, nil)
 		if err != nil {
-			fmt.Printf("Error listing users: %v\n", err)
-			return
+			return fmt.Errorf("listing users: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list users - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -256,7 +230,7 @@ var dbaasUserListCmd = &cobra.Command{
 					user.Username,
 					func() string {
 						if user.CreationDate != nil {
-							return user.CreationDate.Format("02-01-2006 15:04:05")
+							return user.CreationDate.Format(DateLayout)
 						}
 						return ""
 					}(),
@@ -273,6 +247,7 @@ var dbaasUserListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No users found")
 		}
+		return nil
 	},
 }
 
@@ -280,27 +255,24 @@ var dbaasUserUpdateCmd = &cobra.Command{
 	Use:   "update [dbaas-id] [username]",
 	Short: "Update a user (change password)",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 		username := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		password, _ := cmd.Flags().GetString("password")
 
 		if password == "" {
-			fmt.Println("Error: --password is required")
-			return
+			return fmt.Errorf("--password is required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		updateRequest := types.UserRequest{
@@ -308,22 +280,15 @@ var dbaasUserUpdateCmd = &cobra.Command{
 			Password: password,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromDatabase().Users().Update(ctx, projectID, dbaasID, username, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating user: %v\n", err)
-			return
+			return fmt.Errorf("updating user: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update user - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -332,6 +297,7 @@ var dbaasUserUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -339,41 +305,40 @@ var dbaasUserDeleteCmd = &cobra.Command{
 	Use:   "delete [dbaas-id] [username]",
 	Short: "Delete a user",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 		username := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete user '%s' in DBaaS instance %s? (yes/no): ", username, dbaasID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete(fmt.Sprintf("user '%s' in DBaaS instance", username), dbaasID)
+			if err != nil {
+				return err
 			}
+			if !ok {
+				return nil
+			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromDatabase().Users().Delete(ctx, projectID, dbaasID, username, nil)
 		if err != nil {
-			fmt.Printf("Error deleting user: %v\n", err)
-			return
+			return fmt.Errorf("deleting user: %w", err)
 		}
 
 		fmt.Printf("\nUser '%s' deleted successfully!\n", username)
+		return nil
 	},
 }

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -81,7 +81,8 @@ var projectCmd = &cobra.Command{
 var projectCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new project",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		description, _ := cmd.Flags().GetString("description")
@@ -91,15 +92,13 @@ var projectCreateCmd = &cobra.Command{
 
 		// Name is required
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -133,22 +132,15 @@ var projectCreateCmd = &cobra.Command{
 		}
 
 		// Create the project using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromProject().Create(ctx, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating project: %v\n", err)
-			return
+			return fmt.Errorf("creating project: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create project - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -183,6 +175,7 @@ var projectCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Project created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -190,33 +183,25 @@ var projectGetCmd = &cobra.Command{
 	Use:   "get [project-id]",
 	Short: "Get project details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID := args[0]
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get project details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromProject().Get(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error getting project: %v\n", err)
-			return
+			return fmt.Errorf("getting project: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to get project - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -242,7 +227,7 @@ var projectGetCmd = &cobra.Command{
 			fmt.Printf("Resources:       %d\n", project.Properties.ResourcesNumber)
 
 			if !project.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", project.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", project.Metadata.CreationDate.Format(DateLayout))
 			}
 
 			if project.Metadata.CreatedBy != nil {
@@ -250,7 +235,7 @@ var projectGetCmd = &cobra.Command{
 			}
 
 			if project.Metadata.UpdateDate != nil && !project.Metadata.UpdateDate.IsZero() {
-				fmt.Printf("Update Date:     %s\n", project.Metadata.UpdateDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Update Date:     %s\n", project.Metadata.UpdateDate.Format(DateLayout))
 			}
 
 			if project.Metadata.UpdatedBy != nil {
@@ -267,6 +252,7 @@ var projectGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Project not found")
 		}
+		return nil
 	},
 }
 
@@ -274,7 +260,7 @@ var projectUpdateCmd = &cobra.Command{
 	Use:   "update [project-id]",
 	Short: "Update a project (description and/or tags only)",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID := args[0]
 
 		// Get flags
@@ -283,39 +269,29 @@ var projectUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if description == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --description or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --description or --tags must be provided")
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current project details to preserve existing values
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromProject().Get(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error fetching current project: %v\n", err)
-			return
+			return fmt.Errorf("fetching current project: %w", err)
 		}
 
 		if getResponse != nil && getResponse.IsError() && getResponse.Error != nil {
-			fmt.Printf("Failed to get project - Status: %d\n", getResponse.StatusCode)
-			if getResponse.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *getResponse.Error.Title)
-			}
-			if getResponse.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *getResponse.Error.Detail)
-			}
-			return
+			return fmtAPIError(getResponse.StatusCode, getResponse.Error.Title, getResponse.Error.Detail)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Project not found or no data returned.")
-			return
+			return fmt.Errorf("project not found or no data returned")
 		}
 
 		currentProject := getResponse.Data
@@ -346,19 +322,11 @@ var projectUpdateCmd = &cobra.Command{
 		// Update the project using the SDK
 		response, err := client.FromProject().Update(ctx, projectID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating project: %v\n", err)
-			return
+			return fmt.Errorf("updating project: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update project - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -393,6 +361,7 @@ var projectUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("Project '%s' updated.\n", projectID)
 		}
+		return nil
 	},
 }
 
@@ -400,7 +369,7 @@ var projectDeleteCmd = &cobra.Command{
 	Use:   "delete [project-id]",
 	Short: "Delete a project",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID := args[0]
 
 		// Get confirmation flag
@@ -408,40 +377,31 @@ var projectDeleteCmd = &cobra.Command{
 
 		// If not confirmed, ask for confirmation
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete project %s? This action cannot be undone.\n", projectID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("project", projectID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Delete the project using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromProject().Delete(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting project: %v\n", err)
-			return
+			return fmt.Errorf("deleting project: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete project - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		headers := []TableColumn{
@@ -450,37 +410,31 @@ var projectDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{projectID, status}})
+		return nil
 	},
 }
 
 var projectListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all projects",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// List projects using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromProject().List(ctx, nil)
 		if err != nil {
-			fmt.Printf("Error listing projects: %v\n", err)
-			return
+			return fmt.Errorf("listing projects: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to list projects - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -518,5 +472,6 @@ var projectListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No projects found")
 		}
+		return nil
 	},
 }

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -87,7 +87,7 @@ var elasticipCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new Elastic IP",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
@@ -96,26 +96,22 @@ var elasticipCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
+			return fmt.Errorf("--region is required")
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -137,22 +133,15 @@ var elasticipCreateCmd = &cobra.Command{
 		}
 
 		// Create the Elastic IP using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().ElasticIPs().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating Elastic IP: %v\n", err)
-			return
+			return fmt.Errorf("creating Elastic IP: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create Elastic IP - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -172,33 +161,33 @@ var elasticipCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Elastic IP creation initiated. Use 'list' or 'get' to check status.")
 		}
+		return nil
 	},
 }
 
 var elasticipListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all Elastic IPs",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// List Elastic IPs using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().ElasticIPs().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing Elastic IPs: %v\n", err)
-			return
+			return fmt.Errorf("listing Elastic IPs: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -224,7 +213,10 @@ var elasticipListCmd = &cobra.Command{
 					id = *eip.Metadata.ID
 				}
 
-				region := eip.Metadata.LocationResponse.Value
+				region := ""
+				if eip.Metadata.LocationResponse != nil {
+					region = eip.Metadata.LocationResponse.Value
+				}
 
 				address := ""
 				if eip.Properties.Address != nil {
@@ -244,6 +236,7 @@ var elasticipListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No Elastic IPs found")
 		}
+		return nil
 	},
 }
 
@@ -251,29 +244,27 @@ var elasticipGetCmd = &cobra.Command{
 	Use:   "get <elastic-ip-id>",
 	Short: "Get Elastic IP details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		eipID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get Elastic IP details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
 		if err != nil {
-			fmt.Printf("Error getting Elastic IP details: %v\n", err)
-			return
+			return fmt.Errorf("getting Elastic IP details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -303,7 +294,7 @@ var elasticipGetCmd = &cobra.Command{
 			fmt.Printf("Linked Resources: %d\n", len(eip.Properties.LinkedResources))
 
 			if eip.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", eip.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", eip.Metadata.CreationDate.Format(DateLayout))
 			}
 			if eip.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *eip.Metadata.CreatedBy)
@@ -319,6 +310,7 @@ var elasticipGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *eip.Status.State)
 			}
 		}
+		return nil
 	},
 }
 
@@ -326,7 +318,7 @@ var elasticipUpdateCmd = &cobra.Command{
 	Use:   "update <elastic-ip-id>",
 	Short: "Update an Elastic IP",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		eipID := args[0]
 
 		// Get flags
@@ -335,41 +327,36 @@ var elasticipUpdateCmd = &cobra.Command{
 
 		// At least one update flag must be provided
 		if name == "" && len(tags) == 0 {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current Elastic IP to preserve existing properties
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
 		if err != nil {
-			fmt.Printf("Error getting Elastic IP details: %v\n", err)
-			return
+			return fmt.Errorf("getting Elastic IP details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Error: Elastic IP not found")
-			return
+			return fmt.Errorf("Elastic IP not found")
 		}
 
 		// Check if Elastic IP is in InCreation state
-		if getResponse.Data.Status.State != nil && *getResponse.Data.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update Elastic IP while it is in 'InCreation' state. Please wait until the Elastic IP is fully created.")
-			return
+		if getResponse.Data.Status.State != nil && *getResponse.Data.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update Elastic IP while it is in 'InCreation' state. Please wait until the Elastic IP is fully created")
 		}
 
 		// Get region value
@@ -378,8 +365,7 @@ var elasticipUpdateCmd = &cobra.Command{
 			regionValue = getResponse.Data.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for Elastic IP")
-			return
+			return fmt.Errorf("unable to determine region value for Elastic IP")
 		}
 
 		// Build the update request, preserving existing values
@@ -409,8 +395,7 @@ var elasticipUpdateCmd = &cobra.Command{
 		// Update the Elastic IP using the SDK
 		response, err := client.FromNetwork().ElasticIPs().Update(ctx, projectID, eipID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating Elastic IP: %v\n", err)
-			return
+			return fmt.Errorf("updating Elastic IP: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -427,6 +412,7 @@ var elasticipUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("\nElastic IP %s update completed.\n", eipID)
 		}
+		return nil
 	},
 }
 
@@ -434,7 +420,7 @@ var elasticipDeleteCmd = &cobra.Command{
 	Use:   "delete <elastic-ip-id>",
 	Short: "Delete an Elastic IP",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		eipID := args[0]
 
 		// Get skip confirmation flag
@@ -442,38 +428,36 @@ var elasticipDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete Elastic IP %s? This action cannot be undone.\n", eipID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("Elastic IP", eipID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Delete the Elastic IP using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromNetwork().ElasticIPs().Delete(ctx, projectID, eipID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting Elastic IP: %v\n", err)
-			return
+			return fmt.Errorf("deleting Elastic IP: %w", err)
 		}
 
 		fmt.Printf("\nElastic IP %s deleted successfully!\n", eipID)
+		return nil
 	},
 }

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -70,27 +70,26 @@ var loadbalancerCmd = &cobra.Command{
 var loadbalancerListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all Load Balancers",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// List Load Balancers using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().LoadBalancers().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing Load Balancers: %v\n", err)
-			return
+			return fmt.Errorf("listing Load Balancers: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -116,7 +115,10 @@ var loadbalancerListCmd = &cobra.Command{
 					id = *lb.Metadata.ID
 				}
 
-				region := lb.Metadata.LocationResponse.Value
+				region := ""
+				if lb.Metadata.LocationResponse != nil {
+					region = lb.Metadata.LocationResponse.Value
+				}
 
 				address := ""
 				if lb.Properties.Address != nil {
@@ -136,6 +138,7 @@ var loadbalancerListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No Load Balancers found")
 		}
+		return nil
 	},
 }
 
@@ -143,29 +146,27 @@ var loadbalancerGetCmd = &cobra.Command{
 	Use:   "get <loadbalancer-id>",
 	Short: "Get Load Balancer details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		lbID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get Load Balancer details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().LoadBalancers().Get(ctx, projectID, lbID, nil)
 		if err != nil {
-			fmt.Printf("Error getting Load Balancer details: %v\n", err)
-			return
+			return fmt.Errorf("getting Load Balancer details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -194,7 +195,7 @@ var loadbalancerGetCmd = &cobra.Command{
 			fmt.Printf("Linked Resources: %d\n", len(lb.Properties.LinkedResources))
 
 			if lb.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", lb.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", lb.Metadata.CreationDate.Format(DateLayout))
 			}
 			if lb.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *lb.Metadata.CreatedBy)
@@ -210,5 +211,6 @@ var loadbalancerGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *lb.Status.State)
 			}
 		}
+		return nil
 	},
 }

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -35,26 +34,24 @@ var securitygroupCreateCmd = &cobra.Command{
 	Use:   "create [vpc-id]",
 	Short: "Create a new security group",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		if name == "" || region == "" {
-			fmt.Println("Error: --name and --region are required")
-			return
+			return fmt.Errorf("--name and --region are required")
 		}
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		req := types.SecurityGroupRequest{
 			Metadata: types.ResourceMetadataRequest{
 				Name: name,
@@ -63,18 +60,10 @@ var securitygroupCreateCmd = &cobra.Command{
 		}
 		resp, err := client.FromNetwork().SecurityGroups().Create(ctx, projectID, vpcID, req, nil)
 		if err != nil {
-			fmt.Printf("Error creating security group: %v\n", err)
-			return
+			return fmt.Errorf("creating security group: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to create security group - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
 			headers := []TableColumn{
@@ -83,10 +72,14 @@ var securitygroupCreateCmd = &cobra.Command{
 				{Header: "REGION", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
+			region := ""
+			if resp.Data.Metadata.LocationResponse != nil {
+				region = resp.Data.Metadata.LocationResponse.Value
+			}
 			row := []string{
 				name,
 				*resp.Data.Metadata.ID,
-				resp.Data.Metadata.LocationResponse.Value,
+				region,
 				func() string {
 					if resp.Data.Status.State != nil {
 						return *resp.Data.Status.State
@@ -99,6 +92,7 @@ var securitygroupCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Security group created, but no ID returned.")
 		}
+		return nil
 	},
 }
 
@@ -106,34 +100,25 @@ var securitygroupGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [securitygroup-id]",
 	Short: "Get security group details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		sgID := args[1]
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroups().Get(ctx, projectID, vpcID, sgID, nil)
 		if err != nil {
-			fmt.Printf("Error getting security group: %v\n", err)
-			return
+			return fmt.Errorf("getting security group: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get security group - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil {
 			sg := resp.Data
@@ -152,7 +137,7 @@ var securitygroupGetCmd = &cobra.Command{
 				fmt.Printf("Region:          %s\n", sg.Metadata.LocationResponse.Value)
 			}
 			if sg.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", sg.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", sg.Metadata.CreationDate.Format(DateLayout))
 			}
 			if sg.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *sg.Metadata.CreatedBy)
@@ -168,6 +153,7 @@ var securitygroupGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Security group not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -175,33 +161,24 @@ var securitygroupListCmd = &cobra.Command{
 	Use:   "list [vpc-id]",
 	Short: "List security groups for a VPC",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroups().List(ctx, projectID, vpcID, nil)
 		if err != nil {
-			fmt.Printf("Error listing security groups: %v\n", err)
-			return
+			return fmt.Errorf("listing security groups: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list security groups - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -234,6 +211,7 @@ var securitygroupListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No security groups found.")
 		}
+		return nil
 	},
 }
 
@@ -241,37 +219,33 @@ var securitygroupUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [securitygroup-id]",
 	Short: "Update a security group",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		sgID := args[1]
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		// Fetch current security group details
 		getResp, err := client.FromNetwork().SecurityGroups().Get(ctx, projectID, vpcID, sgID, nil)
 		if err != nil || getResp == nil || getResp.Data == nil {
-			fmt.Printf("Error fetching current security group: %v\n", err)
-			return
+			return fmt.Errorf("fetching current security group: %w", err)
 		}
 		current := getResp.Data
 		// Block update if security group is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update security group while it is in 'InCreation' state. Please wait until the security group is fully created.")
-			return
+		if current.Status.State != nil && *current.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update security group while it is in 'InCreation' state. Please wait until the security group is fully created")
 		}
 		// Get region value
 		regionValue := ""
@@ -279,8 +253,7 @@ var securitygroupUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for security group")
-			return
+			return fmt.Errorf("unable to determine region value for security group")
 		}
 		// Build update request by merging user input with all current valid fields
 		req := types.SecurityGroupRequest{
@@ -307,18 +280,10 @@ var securitygroupUpdateCmd = &cobra.Command{
 		}
 		resp, err := client.FromNetwork().SecurityGroups().Update(ctx, projectID, vpcID, sgID, req, nil)
 		if err != nil {
-			fmt.Printf("Error updating security group: %v\n", err)
-			return
+			return fmt.Errorf("updating security group: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update security group - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil {
 			headers := []TableColumn{
@@ -326,6 +291,10 @@ var securitygroupUpdateCmd = &cobra.Command{
 				{Header: "ID", Width: 26},
 				{Header: "REGION", Width: 18},
 				{Header: "STATUS", Width: 15},
+			}
+			updateRegion := ""
+			if resp.Data.Metadata.LocationResponse != nil {
+				updateRegion = resp.Data.Metadata.LocationResponse.Value
 			}
 			row := []string{
 				func() string {
@@ -340,7 +309,7 @@ var securitygroupUpdateCmd = &cobra.Command{
 					}
 					return ""
 				}(),
-				resp.Data.Metadata.LocationResponse.Value,
+				updateRegion,
 				func() string {
 					if resp.Data.Status.State != nil {
 						return *resp.Data.Status.State
@@ -352,6 +321,7 @@ var securitygroupUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("Security group '%s' updated.\n", sgID)
 		}
+		return nil
 	},
 }
 
@@ -359,7 +329,7 @@ var securitygroupDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [securitygroup-id]",
 	Short: "Delete a security group",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		sgID := args[1]
 
@@ -368,41 +338,31 @@ var securitygroupDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete security group %s? This action cannot be undone.\n", sgID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("security group", sgID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroups().Delete(ctx, projectID, vpcID, sgID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting security group: %v\n", err)
-			return
+			return fmt.Errorf("deleting security group: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete security group - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},
@@ -410,5 +370,6 @@ var securitygroupDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{sgID, status}})
+		return nil
 	},
 }

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -102,7 +102,7 @@ var securityruleCreateCmd = &cobra.Command{
 	Use:   "create [vpc-id] [securitygroup-id]",
 	Short: "Create a new security rule",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		securityGroupID := args[1]
 
@@ -118,40 +118,32 @@ var securityruleCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
+			return fmt.Errorf("--region is required")
 		}
 		if direction == "" {
-			fmt.Println("Error: --direction is required")
-			return
+			return fmt.Errorf("--direction is required")
 		}
 		if protocol == "" {
-			fmt.Println("Error: --protocol is required")
-			return
+			return fmt.Errorf("--protocol is required")
 		}
 		if targetKind == "" {
-			fmt.Println("Error: --target-kind is required")
-			return
+			return fmt.Errorf("--target-kind is required")
 		}
 		if targetValue == "" {
-			fmt.Println("Error: --target-value is required")
-			return
+			return fmt.Errorf("--target-value is required")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build target
@@ -195,22 +187,15 @@ var securityruleCreateCmd = &cobra.Command{
 			fmt.Println()
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroupRules().Create(ctx, projectID, vpcID, securityGroupID, req, nil)
 		if err != nil {
-			fmt.Printf("Error creating security rule: %v\n", err)
-			return
+			return fmt.Errorf("creating security rule: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to create security rule - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
@@ -239,6 +224,7 @@ var securityruleCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Security rule created, but no ID returned.")
 		}
+		return nil
 	},
 }
 
@@ -246,39 +232,30 @@ var securityruleGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [securitygroup-id] [securityrule-id]",
 	Short: "Get security rule details",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		securityGroupID := args[1]
 		securityRuleID := args[2]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroupRules().Get(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
 		if err != nil {
-			fmt.Printf("Error getting security rule: %v\n", err)
-			return
+			return fmt.Errorf("getting security rule: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get security rule - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -305,7 +282,7 @@ var securityruleGetCmd = &cobra.Command{
 				fmt.Printf("Target Value:    %s\n", rule.Properties.Target.Value)
 			}
 			if rule.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", rule.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", rule.Metadata.CreationDate.Format(DateLayout))
 			}
 			if rule.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *rule.Metadata.CreatedBy)
@@ -321,6 +298,7 @@ var securityruleGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Security rule not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -328,38 +306,29 @@ var securityruleListCmd = &cobra.Command{
 	Use:   "list [vpc-id] [securitygroup-id]",
 	Short: "List security rules for a security group",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		securityGroupID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroupRules().List(ctx, projectID, vpcID, securityGroupID, nil)
 		if err != nil {
-			fmt.Printf("Error listing security rules: %v\n", err)
-			return
+			return fmt.Errorf("listing security rules: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list security rules - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -399,6 +368,7 @@ var securityruleListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No security rules found.")
 		}
+		return nil
 	},
 }
 
@@ -406,7 +376,7 @@ var securityruleUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [securitygroup-id] [securityrule-id]",
 	Short: "Update a security rule",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		securityGroupID := args[1]
 		securityRuleID := args[2]
@@ -416,58 +386,45 @@ var securityruleUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one field (--name or --tags) must be provided for update")
-			return
+			return fmt.Errorf("at least one field (--name or --tags) must be provided for update")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		// Fetch current security rule details
 		getResp, err := client.FromNetwork().SecurityGroupRules().Get(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
 		if err != nil {
-			fmt.Printf("Error fetching current security rule: %v\n", err)
-			return
+			return fmt.Errorf("fetching current security rule: %w", err)
 		}
 
 		if getResp == nil {
-			fmt.Println("Error: No response received when fetching security rule")
-			return
+			return fmt.Errorf("no response received when fetching security rule")
 		}
 
 		if getResp.IsError() && getResp.Error != nil {
-			fmt.Printf("Failed to fetch security rule - Status: %d\n", getResp.StatusCode)
-			if getResp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *getResp.Error.Title)
-			}
-			if getResp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *getResp.Error.Detail)
-			}
-			return
+			return fmtAPIError(getResp.StatusCode, getResp.Error.Title, getResp.Error.Detail)
 		}
 
 		if getResp.Data == nil {
-			fmt.Println("Error: Security rule not found or no data returned")
-			return
+			return fmt.Errorf("security rule not found or no data returned")
 		}
 
 		current := getResp.Data
 
 		// Block update if security rule is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update security rule while it is in 'InCreation' state. Please wait until the security rule is fully created.")
-			return
+		if current.Status.State != nil && *current.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update security rule while it is in 'InCreation' state. Please wait until the security rule is fully created")
 		}
 
 		// Get region value from current rule, or fetch from VPC if not available
@@ -488,8 +445,7 @@ var securityruleUpdateCmd = &cobra.Command{
 
 		// If still no region value, we cannot proceed
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for security rule. Please ensure the VPC has a valid region.")
-			return
+			return fmt.Errorf("unable to determine region value for security rule. Please ensure the VPC has a valid region")
 		}
 
 		// Build update request - only name and tags can be updated
@@ -545,18 +501,10 @@ var securityruleUpdateCmd = &cobra.Command{
 
 		resp, err := client.FromNetwork().SecurityGroupRules().Update(ctx, projectID, vpcID, securityGroupID, securityRuleID, req, nil)
 		if err != nil {
-			fmt.Printf("Error updating security rule: %v\n", err)
-			return
+			return fmt.Errorf("updating security rule: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update security rule - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
 			if debugEnabled {
 				fmt.Fprintf(os.Stderr, "\n=== DEBUG: Error Response ===\n")
 				if resp.RawBody != nil {
@@ -565,7 +513,7 @@ var securityruleUpdateCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Status Code: %d\n", resp.StatusCode)
 				fmt.Fprintf(os.Stderr, "===========================\n\n")
 			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -604,6 +552,7 @@ var securityruleUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("Security rule '%s' updated.\n", securityRuleID)
 		}
+		return nil
 	},
 }
 
@@ -611,15 +560,14 @@ var securityruleDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [securitygroup-id] [securityrule-id]",
 	Short: "Delete a security rule",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		securityGroupID := args[1]
 		securityRuleID := args[2]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get skip confirmation flag
@@ -627,38 +575,29 @@ var securityruleDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete security rule %s? This action cannot be undone.\n", securityRuleID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("security rule", securityRuleID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().SecurityGroupRules().Delete(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting security rule: %v\n", err)
-			return
+			return fmt.Errorf("deleting security rule: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete security rule - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		headers := []TableColumn{
@@ -667,5 +606,6 @@ var securityruleDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{securityRuleID, status}})
+		return nil
 	},
 }

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -53,7 +53,7 @@ var subnetCreateCmd = &cobra.Command{
 	Short: "Create a new subnet",
 	Args:  cobra.ExactArgs(1),
 	Long:  `Create a new subnet in a VPC. Usage: acloud network subnet create <vpc-id> --name <name> --cidr <cidr>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		name, _ := cmd.Flags().GetString("name")
 		cidr, _ := cmd.Flags().GetString("cidr")
@@ -63,20 +63,18 @@ var subnetCreateCmd = &cobra.Command{
 		dhcpRoutes, _ := cmd.Flags().GetStringSlice("dhcp-routes")
 		dhcpDNS, _ := cmd.Flags().GetStringSlice("dhcp-dns")
 		if name == "" || region == "" {
-			fmt.Println("Error: --name and --region are required")
-			return
+			return fmt.Errorf("--name and --region are required")
 		}
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		// Determine SubnetType: Advanced if CIDR is provided, Basic otherwise
 		var subnetType types.SubnetType = types.SubnetTypeBasic
@@ -84,8 +82,7 @@ var subnetCreateCmd = &cobra.Command{
 			subnetType = types.SubnetTypeAdvanced
 			// For Advanced subnet type, DHCP enabled is required
 			if !dhcpEnabled {
-				fmt.Println("Error: --dhcp-enabled is required when creating an Advanced subnet (CIDR provided)")
-				return
+				return fmt.Errorf("--dhcp-enabled is required when creating an Advanced subnet (CIDR provided)")
 			}
 		}
 
@@ -147,18 +144,10 @@ var subnetCreateCmd = &cobra.Command{
 		}
 		resp, err := client.FromNetwork().Subnets().Create(ctx, projectID, vpcID, req, nil)
 		if err != nil {
-			fmt.Printf("Error creating subnet: %v\n", err)
-			return
+			return fmt.Errorf("creating subnet: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to create subnet - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
 			headers := []TableColumn{
@@ -177,10 +166,14 @@ var subnetCreateCmd = &cobra.Command{
 				displayCIDR = "N/A (Basic)"
 			}
 
+			createRegion := ""
+			if resp.Data.Metadata.LocationResponse != nil {
+				createRegion = resp.Data.Metadata.LocationResponse.Value
+			}
 			row := []string{
 				name,
 				*resp.Data.Metadata.ID,
-				resp.Data.Metadata.LocationResponse.Value,
+				createRegion,
 				displayCIDR,
 				func() string {
 					if resp.Data.Status.State != nil {
@@ -194,6 +187,7 @@ var subnetCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Subnet created, but no ID returned.")
 		}
+		return nil
 	},
 }
 
@@ -201,34 +195,25 @@ var subnetGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [subnet-id]",
 	Short: "Get subnet details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		subnetID := args[1]
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().Subnets().Get(ctx, projectID, vpcID, subnetID, nil)
 		if err != nil {
-			fmt.Printf("Error getting subnet: %v\n", err)
-			return
+			return fmt.Errorf("getting subnet: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get subnet - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil {
 			subnet := resp.Data
@@ -266,7 +251,7 @@ var subnetGetCmd = &cobra.Command{
 				}
 			}
 			if subnet.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", subnet.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", subnet.Metadata.CreationDate.Format(DateLayout))
 			}
 			if subnet.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *subnet.Metadata.CreatedBy)
@@ -282,6 +267,7 @@ var subnetGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Subnet not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -289,33 +275,24 @@ var subnetListCmd = &cobra.Command{
 	Use:   "list [vpc-id]",
 	Short: "List subnets for a VPC",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().Subnets().List(ctx, projectID, vpcID, nil)
 		if err != nil {
-			fmt.Printf("Error listing subnets: %v\n", err)
-			return
+			return fmt.Errorf("listing subnets: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list subnets - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -335,7 +312,10 @@ var subnetListCmd = &cobra.Command{
 				if subnet.Metadata.ID != nil {
 					id = *subnet.Metadata.ID
 				}
-				region := subnet.Metadata.LocationResponse.Value
+				region := ""
+				if subnet.Metadata.LocationResponse != nil {
+					region = subnet.Metadata.LocationResponse.Value
+				}
 				cidr := ""
 				if subnet.Properties.Network != nil {
 					cidr = subnet.Properties.Network.Address
@@ -350,6 +330,7 @@ var subnetListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No subnets found.")
 		}
+		return nil
 	},
 }
 
@@ -357,7 +338,7 @@ var subnetUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [subnet-id]",
 	Short: "Update a subnet",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		subnetID := args[1]
 		name, _ := cmd.Flags().GetString("name")
@@ -367,35 +348,31 @@ var subnetUpdateCmd = &cobra.Command{
 		dhcpRoutes, _ := cmd.Flags().GetStringSlice("dhcp-routes")
 		dhcpDNS, _ := cmd.Flags().GetStringSlice("dhcp-dns")
 		if name == "" && cidr == "" && !cmd.Flags().Changed("tags") && !cmd.Flags().Changed("dhcp-enabled") && len(dhcpRoutes) == 0 && len(dhcpDNS) == 0 {
-			fmt.Println("Error: at least one of --name, --cidr, --tags, --dhcp-enabled, --dhcp-routes, or --dhcp-dns must be provided")
-			return
+			return fmt.Errorf("at least one of --name, --cidr, --tags, --dhcp-enabled, --dhcp-routes, or --dhcp-dns must be provided")
 		}
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 		// Enable debug logging if supported
 		if logger, ok := interface{}(client).(interface{ SetDebug(bool) }); ok {
 			logger.SetDebug(true)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		// Fetch current subnet details
 		getResp, err := client.FromNetwork().Subnets().Get(ctx, projectID, vpcID, subnetID, nil)
 		if err != nil || getResp == nil || getResp.Data == nil {
-			fmt.Printf("Error fetching current subnet: %v\n", err)
-			return
+			return fmt.Errorf("fetching current subnet: %w", err)
 		}
 		current := getResp.Data
 		// Block update if subnet is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update subnet while it is in 'InCreation' state. Please wait until the subnet is fully created.")
-			return
+		if current.Status.State != nil && *current.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update subnet while it is in 'InCreation' state. Please wait until the subnet is fully created")
 		}
 
 		// Get region value
@@ -404,8 +381,7 @@ var subnetUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for subnet")
-			return
+			return fmt.Errorf("unable to determine region value for subnet")
 		}
 
 		// Determine if this is an Advanced subnet
@@ -501,18 +477,10 @@ var subnetUpdateCmd = &cobra.Command{
 
 		resp, err := client.FromNetwork().Subnets().Update(ctx, projectID, vpcID, subnetID, req, nil)
 		if err != nil {
-			fmt.Printf("Error updating subnet: %v\n", err)
-			return
+			return fmt.Errorf("updating subnet: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update subnet - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil {
 			headers := []TableColumn{
@@ -541,6 +509,7 @@ var subnetUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("Subnet '%s' updated.\n", subnetID)
 		}
+		return nil
 	},
 }
 
@@ -548,7 +517,7 @@ var subnetDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [subnet-id]",
 	Short: "Delete a subnet",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		subnetID := args[1]
 
@@ -557,41 +526,31 @@ var subnetDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete subnet %s? This action cannot be undone.\n", subnetID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("subnet", subnetID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().Subnets().Delete(ctx, projectID, vpcID, subnetID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting subnet: %v\n", err)
-			return
+			return fmt.Errorf("deleting subnet: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete subnet - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},
@@ -599,5 +558,6 @@ var subnetDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{subnetID, status}})
+		return nil
 	},
 }

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -86,7 +86,7 @@ var vpcCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new VPC",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
@@ -94,26 +94,22 @@ var vpcCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
+			return fmt.Errorf("--region is required")
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request (default and preset are always false)
@@ -138,22 +134,15 @@ var vpcCreateCmd = &cobra.Command{
 		}
 
 		// Create the VPC using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPCs().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating VPC: %v\n", err)
-			return
+			return fmt.Errorf("creating VPC: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create VPC - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -171,6 +160,7 @@ var vpcCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPC creation initiated. Use 'list' or 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -178,40 +168,31 @@ var vpcGetCmd = &cobra.Command{
 	Use:   "get <vpc-id>",
 	Short: "Get VPC details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get VPC details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPC details: %v\n", err)
-			return
+			return fmt.Errorf("getting VPC details: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to get VPC - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -237,7 +218,7 @@ var vpcGetCmd = &cobra.Command{
 			fmt.Printf("Linked Resources: %d\n", len(vpc.Properties.LinkedResources))
 
 			if vpc.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", vpc.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", vpc.Metadata.CreationDate.Format(DateLayout))
 			}
 			if vpc.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *vpc.Metadata.CreatedBy)
@@ -255,6 +236,7 @@ var vpcGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPC not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -262,7 +244,7 @@ var vpcUpdateCmd = &cobra.Command{
 	Use:   "update <vpc-id>",
 	Short: "Update a VPC",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 
 		// Get flags
@@ -271,41 +253,36 @@ var vpcUpdateCmd = &cobra.Command{
 
 		// At least one update flag must be provided
 		if name == "" && len(tags) == 0 {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current VPC to preserve existing properties
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPC details: %v\n", err)
-			return
+			return fmt.Errorf("getting VPC details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Error: VPC not found")
-			return
+			return fmt.Errorf("VPC not found")
 		}
 
 		// Check if VPC is in InCreation state
-		if getResponse.Data.Status.State != nil && *getResponse.Data.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update VPC while it is in 'InCreation' state. Please wait until the VPC is fully created.")
-			return
+		if getResponse.Data.Status.State != nil && *getResponse.Data.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update VPC while it is in 'InCreation' state. Please wait until the VPC is fully created")
 		}
 
 		// Get region value
@@ -314,8 +291,7 @@ var vpcUpdateCmd = &cobra.Command{
 			regionValue = getResponse.Data.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for VPC")
-			return
+			return fmt.Errorf("unable to determine region value for VPC")
 		}
 
 		// Build the update request, preserving existing values
@@ -347,8 +323,7 @@ var vpcUpdateCmd = &cobra.Command{
 		// Update the VPC using the SDK
 		response, err := client.FromNetwork().VPCs().Update(ctx, projectID, vpcID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating VPC: %v\n", err)
-			return
+			return fmt.Errorf("updating VPC: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -365,6 +340,7 @@ var vpcUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("\nVPC %s update completed.\n", vpcID)
 		}
+		return nil
 	},
 }
 
@@ -372,7 +348,7 @@ var vpcDeleteCmd = &cobra.Command{
 	Use:   "delete <vpc-id>",
 	Short: "Delete a VPC",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 
 		// Get skip confirmation flag
@@ -380,66 +356,63 @@ var vpcDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete VPC %s? This action cannot be undone.\n", vpcID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("VPC", vpcID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Delete the VPC using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromNetwork().VPCs().Delete(ctx, projectID, vpcID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting VPC: %v\n", err)
-			return
+			return fmt.Errorf("deleting VPC: %w", err)
 		}
 
 		fmt.Printf("\nVPC %s deleted successfully!\n", vpcID)
+		return nil
 	},
 }
 
 var vpcListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all VPCs",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get projectID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// List VPCs using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPCs().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing VPCs: %v\n", err)
-			return
+			return fmt.Errorf("listing VPCs: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -465,7 +438,10 @@ var vpcListCmd = &cobra.Command{
 					id = *vpc.Metadata.ID
 				}
 
-				region := vpc.Metadata.LocationResponse.Value
+				region := ""
+				if vpc.Metadata.LocationResponse != nil {
+					region = vpc.Metadata.LocationResponse.Value
+				}
 
 				subnets := fmt.Sprintf("%d", len(vpc.Properties.LinkedResources))
 
@@ -482,5 +458,6 @@ var vpcListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No VPCs found")
 		}
+		return nil
 	},
 }

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -48,27 +47,25 @@ var vpcpeeringCreateCmd = &cobra.Command{
 	Use:   "create [vpc-id]",
 	Short: "Create a new VPC peering",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		name, _ := cmd.Flags().GetString("name")
 		peerVPCID, _ := cmd.Flags().GetString("peer-vpc-id")
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		if name == "" || peerVPCID == "" || region == "" {
-			fmt.Println("Error: --name, --peer-vpc-id, and --region are required")
-			return
+			return fmt.Errorf("--name, --peer-vpc-id, and --region are required")
 		}
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		req := types.VPCPeeringRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{
@@ -83,18 +80,10 @@ var vpcpeeringCreateCmd = &cobra.Command{
 		}
 		resp, err := client.FromNetwork().VPCPeerings().Create(ctx, projectID, vpcID, req, nil)
 		if err != nil {
-			fmt.Printf("Error creating VPC peering: %v\n", err)
-			return
+			return fmt.Errorf("creating VPC peering: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to create VPC peering - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
 			headers := []TableColumn{
@@ -131,6 +120,7 @@ var vpcpeeringCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPC peering created, but no ID returned.")
 		}
+		return nil
 	},
 }
 
@@ -138,34 +128,25 @@ var vpcpeeringGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [peering-id]",
 	Short: "Get VPC peering details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPC peering: %v\n", err)
-			return
+			return fmt.Errorf("getting VPC peering: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get VPC peering - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil {
 			peering := resp.Data
@@ -184,7 +165,7 @@ var vpcpeeringGetCmd = &cobra.Command{
 				fmt.Printf("Region:          %s\n", peering.Metadata.LocationResponse.Value)
 			}
 			if peering.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", peering.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", peering.Metadata.CreationDate.Format(DateLayout))
 			}
 			if peering.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *peering.Metadata.CreatedBy)
@@ -200,6 +181,7 @@ var vpcpeeringGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPC peering not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -207,33 +189,24 @@ var vpcpeeringListCmd = &cobra.Command{
 	Use:   "list [vpc-id]",
 	Short: "List VPC peerings for a VPC",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeerings().List(ctx, projectID, vpcID, nil)
 		if err != nil {
-			fmt.Printf("Error listing VPC peerings: %v\n", err)
-			return
+			return fmt.Errorf("listing VPC peerings: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list VPC peerings - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -271,6 +244,7 @@ var vpcpeeringListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No VPC peerings found.")
 		}
+		return nil
 	},
 }
 
@@ -278,37 +252,33 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [peering-id]",
 	Short: "Update a VPC peering",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		// Fetch current peering details
 		getResp, err := client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
 		if err != nil || getResp == nil || getResp.Data == nil {
-			fmt.Printf("Error fetching current VPC peering: %v\n", err)
-			return
+			return fmt.Errorf("fetching current VPC peering: %w", err)
 		}
 		current := getResp.Data
 		// Block update if peering is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update VPC peering while it is in 'InCreation' state. Please wait until the VPC peering is fully created.")
-			return
+		if current.Status.State != nil && *current.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update VPC peering while it is in 'InCreation' state. Please wait until the VPC peering is fully created")
 		}
 		// Build update request by merging user input with all current valid fields
 		req := types.VPCPeeringRequest{
@@ -348,18 +318,10 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 		}
 		resp, err := client.FromNetwork().VPCPeerings().Update(ctx, projectID, vpcID, peeringID, req, nil)
 		if err != nil {
-			fmt.Printf("Error updating VPC peering: %v\n", err)
-			return
+			return fmt.Errorf("updating VPC peering: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update VPC peering - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		if resp != nil && resp.Data != nil {
 			headers := []TableColumn{
@@ -405,6 +367,7 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("VPC peering '%s' updated.\n", peeringID)
 		}
+		return nil
 	},
 }
 
@@ -412,7 +375,7 @@ var vpcpeeringDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [peering-id]",
 	Short: "Delete a VPC peering",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 
@@ -421,41 +384,31 @@ var vpcpeeringDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete VPC peering %s? This action cannot be undone.\n", peeringID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("VPC peering", peeringID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeerings().Delete(ctx, projectID, vpcID, peeringID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting VPC peering: %v\n", err)
-			return
+			return fmt.Errorf("deleting VPC peering: %w", err)
 		}
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete VPC peering - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},
@@ -463,5 +416,6 @@ var vpcpeeringDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{peeringID, status}})
+		return nil
 	},
 }

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -94,7 +94,7 @@ var vpcpeeringrouteCreateCmd = &cobra.Command{
 	Use:   "create [vpc-id] [peering-id]",
 	Short: "Create a new VPC peering route",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 
@@ -107,28 +107,23 @@ var vpcpeeringrouteCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if localNetwork == "" {
-			fmt.Println("Error: --local-network is required")
-			return
+			return fmt.Errorf("--local-network is required")
 		}
 		if remoteNetwork == "" {
-			fmt.Println("Error: --remote-network is required")
-			return
+			return fmt.Errorf("--remote-network is required")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -159,22 +154,15 @@ var vpcpeeringrouteCreateCmd = &cobra.Command{
 			fmt.Println()
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeeringRoutes().Create(ctx, projectID, vpcID, peeringID, req, nil)
 		if err != nil {
-			fmt.Printf("Error creating VPC peering route: %v\n", err)
-			return
+			return fmt.Errorf("creating VPC peering route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to create VPC peering route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -199,6 +187,7 @@ var vpcpeeringrouteCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPC peering route created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -206,39 +195,30 @@ var vpcpeeringrouteGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [peering-id] [route-id]",
 	Short: "Get VPC peering route details",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 		routeID := args[2]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPC peering route: %v\n", err)
-			return
+			return fmt.Errorf("getting VPC peering route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get VPC peering route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -263,6 +243,7 @@ var vpcpeeringrouteGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPC peering route not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -270,38 +251,29 @@ var vpcpeeringrouteListCmd = &cobra.Command{
 	Use:   "list [vpc-id] [peering-id]",
 	Short: "List VPC peering routes",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, projectID, vpcID, peeringID, nil)
 		if err != nil {
-			fmt.Printf("Error listing VPC peering routes: %v\n", err)
-			return
+			return fmt.Errorf("listing VPC peering routes: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list VPC peering routes - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -326,6 +298,7 @@ var vpcpeeringrouteListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No VPC peering routes found.")
 		}
+		return nil
 	},
 }
 
@@ -333,7 +306,7 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [peering-id] [route-id]",
 	Short: "Update a VPC peering route",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 		routeID := args[2]
@@ -346,37 +319,33 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") && localNetwork == "" && remoteNetwork == "" && billingPeriod == "" {
-			fmt.Println("Error: at least one field must be provided for update")
-			return
+			return fmt.Errorf("at least one field must be provided for update")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		// Fetch current VPC peering route details
 		getResp, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
 		if err != nil || getResp == nil || getResp.Data == nil {
-			fmt.Printf("Error fetching current VPC peering route: %v\n", err)
-			return
+			return fmt.Errorf("fetching current VPC peering route: %w", err)
 		}
 
 		current := getResp.Data
 
 		// Block update if VPC peering route is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update VPC peering route while it is in 'InCreation' state. Please wait until the VPC peering route is fully created.")
-			return
+		if current.Status.State != nil && *current.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update VPC peering route while it is in 'InCreation' state. Please wait until the VPC peering route is fully created")
 		}
 
 		// Build update request by merging user input with current values
@@ -424,19 +393,11 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 
 		resp, err := client.FromNetwork().VPCPeeringRoutes().Update(ctx, projectID, vpcID, peeringID, routeID, req, nil)
 		if err != nil {
-			fmt.Printf("Error updating VPC peering route: %v\n", err)
-			return
+			return fmt.Errorf("updating VPC peering route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update VPC peering route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -461,6 +422,7 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("VPC peering route '%s' updated.\n", routeID)
 		}
+		return nil
 	},
 }
 
@@ -468,15 +430,14 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [peering-id] [route-id]",
 	Short: "Delete a VPC peering route",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 		peeringID := args[1]
 		routeID := args[2]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get skip confirmation flag
@@ -484,38 +445,29 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete VPC peering route %s? This action cannot be undone.\n", routeID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("VPC peering route", routeID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPCPeeringRoutes().Delete(ctx, projectID, vpcID, peeringID, routeID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting VPC peering route: %v\n", err)
-			return
+			return fmt.Errorf("deleting VPC peering route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete VPC peering route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		headers := []TableColumn{
@@ -524,5 +476,6 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{routeID, status}})
+		return nil
 	},
 }

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -97,7 +97,7 @@ var vpnrouteCreateCmd = &cobra.Command{
 	Use:   "create [vpn-tunnel-id]",
 	Short: "Create a new VPN tunnel route",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 
 		name, _ := cmd.Flags().GetString("name")
@@ -109,32 +109,26 @@ var vpnrouteCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
+			return fmt.Errorf("--region is required")
 		}
 		if cloudSubnet == "" {
-			fmt.Println("Error: --cloud-subnet is required")
-			return
+			return fmt.Errorf("--cloud-subnet is required")
 		}
 		if onPremSubnet == "" {
-			fmt.Println("Error: --onprem-subnet is required")
-			return
+			return fmt.Errorf("--onprem-subnet is required")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -167,22 +161,15 @@ var vpnrouteCreateCmd = &cobra.Command{
 			fmt.Println()
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPNRoutes().Create(ctx, projectID, vpnTunnelID, req, nil)
 		if err != nil {
-			fmt.Printf("Error creating VPN route: %v\n", err)
-			return
+			return fmt.Errorf("creating VPN route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to create VPN route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
@@ -209,6 +196,7 @@ var vpnrouteCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPN route created, but no ID returned.")
 		}
+		return nil
 	},
 }
 
@@ -216,38 +204,29 @@ var vpnrouteGetCmd = &cobra.Command{
 	Use:   "get [vpn-tunnel-id] [route-id]",
 	Short: "Get VPN tunnel route details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 		routeID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPN route: %v\n", err)
-			return
+			return fmt.Errorf("getting VPN route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get VPN route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -269,7 +248,7 @@ var vpnrouteGetCmd = &cobra.Command{
 			fmt.Printf("Cloud Subnet:    %s\n", route.Properties.CloudSubnet)
 			fmt.Printf("OnPrem Subnet:   %s\n", route.Properties.OnPremSubnet)
 			if route.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", route.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", route.Metadata.CreationDate.Format(DateLayout))
 			}
 			if route.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *route.Metadata.CreatedBy)
@@ -285,6 +264,7 @@ var vpnrouteGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPN route not found or no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -292,37 +272,28 @@ var vpnrouteListCmd = &cobra.Command{
 	Use:   "list [vpn-tunnel-id]",
 	Short: "List VPN tunnel routes",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPNRoutes().List(ctx, projectID, vpnTunnelID, nil)
 		if err != nil {
-			fmt.Printf("Error listing VPN routes: %v\n", err)
-			return
+			return fmt.Errorf("listing VPN routes: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list VPN routes - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -355,6 +326,7 @@ var vpnrouteListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No VPN routes found.")
 		}
+		return nil
 	},
 }
 
@@ -362,7 +334,7 @@ var vpnrouteUpdateCmd = &cobra.Command{
 	Use:   "update [vpn-tunnel-id] [route-id]",
 	Short: "Update a VPN tunnel route",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 		routeID := args[1]
 
@@ -373,37 +345,33 @@ var vpnrouteUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") && cloudSubnet == "" && onPremSubnet == "" {
-			fmt.Println("Error: at least one field must be provided for update")
-			return
+			return fmt.Errorf("at least one field must be provided for update")
 		}
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		// Fetch current VPN route details
 		getResp, err := client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
 		if err != nil || getResp == nil || getResp.Data == nil {
-			fmt.Printf("Error fetching current VPN route: %v\n", err)
-			return
+			return fmt.Errorf("fetching current VPN route: %w", err)
 		}
 
 		current := getResp.Data
 
 		// Block update if VPN route is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update VPN route while it is in 'InCreation' state. Please wait until the VPN route is fully created.")
-			return
+		if current.Status.State != nil && *current.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update VPN route while it is in 'InCreation' state. Please wait until the VPN route is fully created")
 		}
 
 		// Normalize region code if needed
@@ -412,8 +380,7 @@ var vpnrouteUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for VPN route")
-			return
+			return fmt.Errorf("unable to determine region value for VPN route")
 		}
 
 		// Build update request by merging user input with current values
@@ -461,19 +428,11 @@ var vpnrouteUpdateCmd = &cobra.Command{
 
 		resp, err := client.FromNetwork().VPNRoutes().Update(ctx, projectID, vpnTunnelID, routeID, req, nil)
 		if err != nil {
-			fmt.Printf("Error updating VPN route: %v\n", err)
-			return
+			return fmt.Errorf("updating VPN route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update VPN route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -510,6 +469,7 @@ var vpnrouteUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("VPN route '%s' updated.\n", routeID)
 		}
+		return nil
 	},
 }
 
@@ -517,14 +477,13 @@ var vpnrouteDeleteCmd = &cobra.Command{
 	Use:   "delete [vpn-tunnel-id] [route-id]",
 	Short: "Delete a VPN tunnel route",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 		routeID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get skip confirmation flag
@@ -532,38 +491,29 @@ var vpnrouteDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete VPN route %s? This action cannot be undone.\n", routeID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("VPN route", routeID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromNetwork().VPNRoutes().Delete(ctx, projectID, vpnTunnelID, routeID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting VPN route: %v\n", err)
-			return
+			return fmt.Errorf("deleting VPN route: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to delete VPN route - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		headers := []TableColumn{
@@ -572,5 +522,6 @@ var vpnrouteDeleteCmd = &cobra.Command{
 		}
 		status := "deleted"
 		PrintTable(headers, [][]string{{routeID, status}})
+		return nil
 	},
 }

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -110,27 +110,26 @@ var vpntunnelCmd = &cobra.Command{
 var vpntunnelListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all VPN tunnels",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get projectID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// List VPN tunnels using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPNTunnels().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing VPN tunnels: %v\n", err)
-			return
+			return fmt.Errorf("listing VPN tunnels: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -175,6 +174,7 @@ var vpntunnelListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No VPN tunnels found")
 		}
+		return nil
 	},
 }
 
@@ -182,29 +182,27 @@ var vpntunnelGetCmd = &cobra.Command{
 	Use:   "get <vpn-tunnel-id>",
 	Short: "Get VPN tunnel details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get VPN tunnel details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPNTunnels().Get(ctx, projectID, vpnID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPN tunnel details: %v\n", err)
-			return
+			return fmt.Errorf("getting VPN tunnel details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -258,7 +256,7 @@ var vpntunnelGetCmd = &cobra.Command{
 			}
 
 			if vpn.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", vpn.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", vpn.Metadata.CreationDate.Format(DateLayout))
 			}
 			if vpn.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *vpn.Metadata.CreatedBy)
@@ -274,6 +272,7 @@ var vpntunnelGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *vpn.Status.State)
 			}
 		}
+		return nil
 	},
 }
 
@@ -281,7 +280,7 @@ var vpntunnelCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new VPN tunnel",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
@@ -318,42 +317,34 @@ var vpntunnelCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
+			return fmt.Errorf("--region is required")
 		}
 		if peerIP == "" {
-			fmt.Println("Error: --peer-ip is required")
-			return
+			return fmt.Errorf("--peer-ip is required")
 		}
 		if vpcURI == "" {
-			fmt.Println("Error: --vpc-uri is required (e.g., /projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id})")
-			return
+			return fmt.Errorf("--vpc-uri is required (e.g., /projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id})")
 		}
 		if subnetCIDR == "" && subnetName == "" {
-			fmt.Println("Error: --subnet-cidr or --subnet-name is required")
-			return
+			return fmt.Errorf("--subnet-cidr or --subnet-name is required")
 		}
 		if publicIPURI == "" {
-			fmt.Println("Error: --elastic-ip-uri is required (e.g., /projects/{project-id}/providers/Aruba.Network/elasticIps/{ip-id})")
-			return
+			return fmt.Errorf("--elastic-ip-uri is required (e.g., /projects/{project-id}/providers/Aruba.Network/elasticIps/{ip-id})")
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build subnet object with both CIDR and Name fields
@@ -460,22 +451,15 @@ var vpntunnelCreateCmd = &cobra.Command{
 		}
 
 		// Create the VPN tunnel using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPNTunnels().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating VPN tunnel: %v\n", err)
-			return
+			return fmt.Errorf("creating VPN tunnel: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create VPN tunnel - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -501,6 +485,7 @@ var vpntunnelCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("VPN Tunnel creation initiated. Use 'list' or 'get' to check status.")
 		}
+		return nil
 	},
 }
 
@@ -508,7 +493,7 @@ var vpntunnelUpdateCmd = &cobra.Command{
 	Use:   "update <vpn-tunnel-id>",
 	Short: "Update a VPN tunnel",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 
 		// Get flags
@@ -517,52 +502,40 @@ var vpntunnelUpdateCmd = &cobra.Command{
 
 		// At least one update flag must be provided
 		if name == "" && len(tags) == 0 {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		// Get project ID
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get Aruba Cloud client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get current VPN tunnel configuration
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResp, err := client.FromNetwork().VPNTunnels().Get(ctx, projectID, vpnTunnelID, nil)
 		if err != nil {
-			fmt.Printf("Error getting VPN tunnel: %v\n", err)
-			return
+			return fmt.Errorf("getting VPN tunnel: %w", err)
 		}
 
 		if getResp != nil && getResp.IsError() && getResp.Error != nil {
-			fmt.Printf("Error getting VPN tunnel - Status: %d\n", getResp.StatusCode)
-			if getResp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *getResp.Error.Title)
-			}
-			if getResp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *getResp.Error.Detail)
-			}
-			return
+			return fmtAPIError(getResp.StatusCode, getResp.Error.Title, getResp.Error.Detail)
 		}
 
 		if getResp.Data == nil {
-			fmt.Println("Error: VPN tunnel not found")
-			return
+			return fmt.Errorf("VPN tunnel not found")
 		}
 
 		// Check if VPN tunnel is in "InCreation" state
-		if getResp.Data.Status.State != nil && *getResp.Data.Status.State == "InCreation" {
-			fmt.Println("Error: Cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created.")
-			return
+		if getResp.Data.Status.State != nil && *getResp.Data.Status.State == StateInCreation {
+			return fmt.Errorf("cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created")
 		}
 
 		// Get region value
@@ -571,8 +544,7 @@ var vpntunnelUpdateCmd = &cobra.Command{
 			regionValue = getResp.Data.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for VPN tunnel")
-			return
+			return fmt.Errorf("unable to determine region value for VPN tunnel")
 		}
 
 		// Build update request, preserving current values
@@ -607,19 +579,11 @@ var vpntunnelUpdateCmd = &cobra.Command{
 		// Update VPN tunnel
 		resp, err := client.FromNetwork().VPNTunnels().Update(ctx, projectID, vpnTunnelID, updateReq, nil)
 		if err != nil {
-			fmt.Printf("Error updating VPN tunnel: %v\n", err)
-			return
+			return fmt.Errorf("updating VPN tunnel: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to update VPN tunnel - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp.Data != nil {
@@ -636,6 +600,7 @@ var vpntunnelUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Printf("\nVPN Tunnel %s update completed.\n", vpnTunnelID)
 		}
+		return nil
 	},
 }
 
@@ -643,7 +608,7 @@ var vpntunnelDeleteCmd = &cobra.Command{
 	Use:   "delete <vpn-tunnel-id>",
 	Short: "Delete a VPN tunnel",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 
 		// Get skip confirmation flag
@@ -651,49 +616,40 @@ var vpntunnelDeleteCmd = &cobra.Command{
 
 		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
-			fmt.Printf("Are you sure you want to delete VPN tunnel %s? This action cannot be undone.\n", vpnTunnelID)
-			fmt.Print("Type 'yes' to confirm: ")
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("VPN tunnel", vpnTunnelID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Delete the VPN tunnel using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromNetwork().VPNTunnels().Delete(ctx, projectID, vpnTunnelID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting VPN tunnel: %v\n", err)
-			return
+			return fmt.Errorf("deleting VPN tunnel: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to delete VPN tunnel - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		fmt.Printf("VPN tunnel %s has been successfully deleted.\n", vpnTunnelID)
+		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -23,14 +25,12 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "acloud",
-	Short: "CLI for Aruba Cloud APIs",
+	Use:          "acloud",
+	Short:        "CLI for Aruba Cloud APIs",
+	SilenceUsage: true, // Don't print usage on runtime errors
 	Long: `acloud is a command-line interface for interacting with Aruba Cloud APIs.
 It provides a simple and intuitive way to manage your Aruba Cloud resources
 directly from your terminal.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -152,6 +152,40 @@ func GetProjectID(cmd *cobra.Command) (string, error) {
 	}
 
 	return projectID, nil
+}
+
+// newCtx returns a context with a 30-second timeout for SDK calls (TD-006).
+func newCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 30*time.Second)
+}
+
+// fmtAPIError formats an SDK API error response into a Go error (TD-001/TD-003).
+func fmtAPIError(statusCode int, title, detail *string) error {
+	msg := fmt.Sprintf("API error (status %d)", statusCode)
+	if title != nil {
+		msg += ": " + *title
+	}
+	if detail != nil {
+		msg += " — " + *detail
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+// confirmDelete prompts the user for confirmation before a destructive operation.
+// Returns true if the user confirmed, false if they declined or stdin is non-interactive (TD-005).
+func confirmDelete(resourceType, id string) (bool, error) {
+	fi, err := os.Stdin.Stat()
+	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return false, fmt.Errorf("delete requires --yes/-y in non-interactive mode")
+	}
+	fmt.Printf("Are you sure you want to delete %s %s? (yes/no): ", resourceType, id)
+	var response string
+	fmt.Scanln(&response)
+	if response != "yes" && response != "y" {
+		fmt.Println("Delete cancelled")
+		return false, nil
+	}
+	return true, nil
 }
 
 // TableColumn represents a column definition for the table printer

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -93,11 +93,11 @@ var jobCmd = &cobra.Command{
 var jobCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new scheduled job",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -110,37 +110,31 @@ var jobCreateCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" || region == "" || jobType == "" {
-			fmt.Println("Error: --name, --region, and --job-type are required")
-			return
+			return fmt.Errorf("--name, --region, and --job-type are required")
 		}
 
 		// Validate job type
 		if jobType != "OneShot" && jobType != "Recurring" {
-			fmt.Println("Error: --job-type must be either 'OneShot' or 'Recurring'")
-			return
+			return fmt.Errorf("--job-type must be either 'OneShot' or 'Recurring'")
 		}
 
 		// Validate required fields based on job type
 		if jobType == "OneShot" && scheduleAt == "" {
-			fmt.Println("Error: --schedule-at is required for OneShot jobs")
-			return
+			return fmt.Errorf("--schedule-at is required for OneShot jobs")
 		}
 
 		if jobType == "Recurring" {
 			if cron == "" {
-				fmt.Println("Error: --cron is required for Recurring jobs")
-				return
+				return fmt.Errorf("--cron is required for Recurring jobs")
 			}
 			if executeUntil == "" {
-				fmt.Println("Error: --execute-until is required for Recurring jobs")
-				return
+				return fmt.Errorf("--execute-until is required for Recurring jobs")
 			}
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		properties := types.JobPropertiesRequest{
@@ -168,22 +162,15 @@ var jobCreateCmd = &cobra.Command{
 			Properties: properties,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromSchedule().Jobs().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating job: %v\n", err)
-			return
+			return fmt.Errorf("creating job: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create job - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -230,6 +217,7 @@ var jobCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Job created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -237,37 +225,28 @@ var jobGetCmd = &cobra.Command{
 	Use:   "get [job-id]",
 	Short: "Get job details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		jobID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromSchedule().Jobs().Get(ctx, projectID, jobID, nil)
 		if err != nil {
-			fmt.Printf("Error getting job: %v\n", err)
-			return
+			return fmt.Errorf("getting job: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get job - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -303,7 +282,7 @@ var jobGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *job.Status.State)
 			}
 			if !job.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", job.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", job.Metadata.CreationDate.Format(DateLayout))
 			}
 			if job.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *job.Metadata.CreatedBy)
@@ -317,41 +296,34 @@ var jobGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Job not found")
 		}
+		return nil
 	},
 }
 
 var jobListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all scheduled jobs",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromSchedule().Jobs().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing jobs: %v\n", err)
-			return
+			return fmt.Errorf("listing jobs: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list jobs - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -410,6 +382,7 @@ var jobListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No jobs found")
 		}
+		return nil
 	},
 }
 
@@ -417,13 +390,12 @@ var jobUpdateCmd = &cobra.Command{
 	Use:   "update [job-id]",
 	Short: "Update a job",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		jobID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -432,26 +404,23 @@ var jobUpdateCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" && !enabledSet && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name, --enabled, or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name, --enabled, or --tags must be provided")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResp, err := client.FromSchedule().Jobs().Get(ctx, projectID, jobID, nil)
 		if err != nil {
-			fmt.Printf("Error getting job: %v\n", err)
-			return
+			return fmt.Errorf("getting job: %w", err)
 		}
 
 		if getResp == nil || getResp.Data == nil {
-			fmt.Println("Job not found")
-			return
+			return fmt.Errorf("job not found")
 		}
 
 		current := getResp.Data
@@ -461,8 +430,7 @@ var jobUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for job")
-			return
+			return fmt.Errorf("unable to determine region value for job")
 		}
 
 		updateRequest := types.JobRequest{
@@ -499,19 +467,11 @@ var jobUpdateCmd = &cobra.Command{
 
 		response, err := client.FromSchedule().Jobs().Update(ctx, projectID, jobID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating job: %v\n", err)
-			return
+			return fmt.Errorf("updating job: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update job - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -525,6 +485,7 @@ var jobUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -532,40 +493,39 @@ var jobDeleteCmd = &cobra.Command{
 	Use:   "delete [job-id]",
 	Short: "Delete a job",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		jobID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete job %s? (yes/no): ", jobID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("job", jobID)
+			if err != nil {
+				return err
 			}
+			if !ok {
+				return nil
+			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromSchedule().Jobs().Delete(ctx, projectID, jobID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting job: %v\n", err)
-			return
+			return fmt.Errorf("deleting job: %w", err)
 		}
 
 		fmt.Printf("\nJob %s deleted successfully!\n", jobID)
+		return nil
 	},
 }

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -87,11 +87,11 @@ var kmsCmd = &cobra.Command{
 var kmsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new KMS resource",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
@@ -100,14 +100,12 @@ var kmsCreateCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" || region == "" {
-			fmt.Println("Error: --name and --region are required")
-			return
+			return fmt.Errorf("--name and --region are required")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		createRequest := types.KmsRequest{
@@ -125,22 +123,15 @@ var kmsCreateCmd = &cobra.Command{
 			},
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromSecurity().KMS().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating KMS: %v\n", err)
-			return
+			return fmt.Errorf("creating KMS: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create KMS - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -180,6 +171,7 @@ var kmsCreateCmd = &cobra.Command{
 		} else {
 			fmt.Println("KMS created, but no data returned.")
 		}
+		return nil
 	},
 }
 
@@ -187,37 +179,28 @@ var kmsGetCmd = &cobra.Command{
 	Use:   "get [kms-id]",
 	Short: "Get KMS resource details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kmsID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromSecurity().KMS().Get(ctx, projectID, kmsID, nil)
 		if err != nil {
-			fmt.Printf("Error getting KMS: %v\n", err)
-			return
+			return fmt.Errorf("getting KMS: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to get KMS - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -242,7 +225,7 @@ var kmsGetCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *kms.Status.State)
 			}
 			if !kms.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", kms.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", kms.Metadata.CreationDate.Format(DateLayout))
 			}
 			if kms.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *kms.Metadata.CreatedBy)
@@ -256,41 +239,34 @@ var kmsGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("KMS not found")
 		}
+		return nil
 	},
 }
 
 var kmsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all KMS resources",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		resp, err := client.FromSecurity().KMS().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing KMS: %v\n", err)
-			return
+			return fmt.Errorf("listing KMS: %w", err)
 		}
 
 		if resp != nil && resp.IsError() && resp.Error != nil {
-			fmt.Printf("Failed to list KMS - Status: %d\n", resp.StatusCode)
-			if resp.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *resp.Error.Title)
-			}
-			if resp.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *resp.Error.Detail)
-			}
-			return
+			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -335,6 +311,7 @@ var kmsListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No KMS resources found")
 		}
+		return nil
 	},
 }
 
@@ -342,39 +319,35 @@ var kmsUpdateCmd = &cobra.Command{
 	Use:   "update [kms-id]",
 	Short: "Update a KMS resource",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kmsID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResp, err := client.FromSecurity().KMS().Get(ctx, projectID, kmsID, nil)
 		if err != nil {
-			fmt.Printf("Error getting KMS: %v\n", err)
-			return
+			return fmt.Errorf("getting KMS: %w", err)
 		}
 
 		if getResp == nil || getResp.Data == nil {
-			fmt.Println("KMS not found")
-			return
+			return fmt.Errorf("KMS not found")
 		}
 
 		current := getResp.Data
@@ -384,8 +357,7 @@ var kmsUpdateCmd = &cobra.Command{
 			regionValue = current.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for KMS")
-			return
+			return fmt.Errorf("unable to determine region value for KMS")
 		}
 
 		updateRequest := types.KmsRequest{
@@ -413,19 +385,11 @@ var kmsUpdateCmd = &cobra.Command{
 
 		response, err := client.FromSecurity().KMS().Update(ctx, projectID, kmsID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating KMS: %v\n", err)
-			return
+			return fmt.Errorf("updating KMS: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update KMS - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -438,6 +402,7 @@ var kmsUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -445,40 +410,39 @@ var kmsDeleteCmd = &cobra.Command{
 	Use:   "delete [kms-id]",
 	Short: "Delete a KMS resource",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kmsID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
-		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete KMS %s? (yes/no): ", kmsID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("KMS", kmsID)
+			if err != nil {
+				return err
 			}
+			if !ok {
+				return nil
+			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromSecurity().KMS().Delete(ctx, projectID, kmsID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting KMS: %v\n", err)
-			return
+			return fmt.Errorf("deleting KMS: %w", err)
 		}
 
 		fmt.Printf("\nKMS %s deleted successfully!\n", kmsID)
+		return nil
 	},
 }

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -86,14 +86,13 @@ var storageBackupCmd = &cobra.Command{
 	Short: "Create a storage backup of a block storage volume",
 	Long:  `Create a storage backup resource (Aruba.Storage/backup) for a block storage volume.`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -104,34 +103,22 @@ var storageBackupCmd = &cobra.Command{
 		billingPeriod, _ := cmd.Flags().GetString("billing-period")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// Validate required fields
-		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
-		}
-		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
-		}
-
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the volume details to get the full URI
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		volumeResponse, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
 		if err != nil {
-			fmt.Printf("Error getting volume details: %v\n", err)
-			return
+			return fmt.Errorf("getting volume details: %w", err)
 		}
 
 		if volumeResponse == nil || volumeResponse.Data == nil {
-			fmt.Println("Volume not found")
-			return
+			return fmt.Errorf("volume not found")
 		}
 
 		volumeURI := *volumeResponse.Data.Metadata.URI
@@ -189,27 +176,17 @@ var storageBackupCmd = &cobra.Command{
 		// Create the backup using the SDK
 		response, err := client.FromStorage().Backups().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating backup: %v\n", err)
-			return
+			return fmt.Errorf("creating backup: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create backup - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			if verbose {
-				if response.RawBody != nil {
-					var errorDetail map[string]interface{}
-					if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
-						fmt.Printf("Full Error Response: %+v\n", errorDetail)
-					}
+			if verbose && response.RawBody != nil {
+				var errorDetail map[string]interface{}
+				if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
+					fmt.Printf("Full Error Response: %+v\n", errorDetail)
 				}
 			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response.Data != nil {
@@ -218,9 +195,10 @@ var storageBackupCmd = &cobra.Command{
 			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
 			fmt.Printf("Type:            %s\n", response.Data.Properties.Type)
 			if !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
 			}
 		}
+		return nil
 	},
 }
 
@@ -228,24 +206,23 @@ var storageBackupCmd = &cobra.Command{
 var storageBackupListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List storage backups",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Backups().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing backups: %v\n", err)
-			return
+			return fmt.Errorf("listing backups: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -282,6 +259,7 @@ var storageBackupListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No backups found")
 		}
+		return nil
 	},
 }
 
@@ -290,26 +268,24 @@ var storageBackupGetCmd = &cobra.Command{
 	Use:   "get [backup-id]",
 	Short: "Get storage backup details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error getting backup details: %v\n", err)
-			return
+			return fmt.Errorf("getting backup details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -349,7 +325,7 @@ var storageBackupGetCmd = &cobra.Command{
 			}
 
 			if !backup.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", backup.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", backup.Metadata.CreationDate.Format(DateLayout))
 			}
 
 			if backup.Metadata.CreatedBy != nil {
@@ -364,6 +340,7 @@ var storageBackupGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Backup not found")
 		}
+		return nil
 	},
 }
 
@@ -372,13 +349,12 @@ var storageBackupUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id]",
 	Short: "Update a storage backup (name and/or tags)",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -387,27 +363,24 @@ var storageBackupUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current backup details
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error getting backup details: %v\n", err)
-			return
+			return fmt.Errorf("getting backup details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Backup not found")
-			return
+			return fmt.Errorf("backup not found")
 		}
 
 		currentBackup := getResponse.Data
@@ -418,8 +391,7 @@ var storageBackupUpdateCmd = &cobra.Command{
 			regionValue = currentBackup.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for backup")
-			return
+			return fmt.Errorf("unable to determine region value for backup")
 		}
 
 		// Build the update request with current values as defaults
@@ -461,19 +433,11 @@ var storageBackupUpdateCmd = &cobra.Command{
 		// Update the backup using the SDK
 		response, err := client.FromStorage().Backups().Update(ctx, projectID, backupID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating backup: %v\n", err)
-			return
+			return fmt.Errorf("updating backup: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update backup - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -486,6 +450,7 @@ var storageBackupUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -494,39 +459,38 @@ var storageBackupDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id]",
 	Short: "Delete a storage backup",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete backup %s? (yes/no): ", backupID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("backup", backupID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromStorage().Backups().Delete(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting backup: %v\n", err)
-			return
+			return fmt.Errorf("deleting backup: %w", err)
 		}
 
 		fmt.Printf("\nBackup %s deleted successfully!\n", backupID)
+		return nil
 	},
 }

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -101,12 +101,12 @@ var blockstorageCmd = &cobra.Command{
 var blockstorageCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new block storage",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -123,23 +123,19 @@ var blockstorageCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
+			return fmt.Errorf("--region is required")
 		}
 		if size <= 0 {
-			fmt.Println("Error: --size must be greater than 0")
-			return
+			return fmt.Errorf("--size must be greater than 0")
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -181,11 +177,6 @@ var blockstorageCreateCmd = &cobra.Command{
 			createRequest.Properties.Image = &image
 		}
 
-		// Add zone only if provided
-		if zone != "" {
-			createRequest.Properties.Zone = &zone
-		}
-
 		// Get verbose flag
 		verbose, _ := cmd.Flags().GetBool("verbose")
 
@@ -214,25 +205,18 @@ var blockstorageCreateCmd = &cobra.Command{
 		}
 
 		// Create the block storage using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Volumes().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating block storage: %v\n", err)
-			return
+			return fmt.Errorf("creating block storage: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create block storage - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
+		if response != nil && response.IsError() {
+			if response.Error != nil {
+				return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			if verbose {
-				fmt.Printf("Full Error Response: %+v\n", response.Error)
-			}
-			return
+			return fmt.Errorf("API error (status %d)", response.StatusCode)
 		}
 
 		if response.Data != nil {
@@ -247,11 +231,12 @@ var blockstorageCreateCmd = &cobra.Command{
 				fmt.Printf("Status:          %s\n", *response.Data.Status.State)
 			}
 			if !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println("Block storage created but no details returned")
 		}
+		return nil
 	},
 }
 
@@ -259,29 +244,27 @@ var blockstorageGetCmd = &cobra.Command{
 	Use:   "get [volume-id]",
 	Short: "Get block storage details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get block storage details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
 		if err != nil {
-			fmt.Printf("Error getting block storage details: %v\n", err)
-			return
+			return fmt.Errorf("getting block storage details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -320,7 +303,7 @@ var blockstorageGetCmd = &cobra.Command{
 			}
 
 			if !volume.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", volume.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", volume.Metadata.CreationDate.Format(DateLayout))
 			}
 
 			if volume.Metadata.CreatedBy != nil {
@@ -337,6 +320,7 @@ var blockstorageGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Block storage not found")
 		}
+		return nil
 	},
 }
 
@@ -344,14 +328,13 @@ var blockstorageUpdateCmd = &cobra.Command{
 	Use:   "update [volume-id]",
 	Short: "Update block storage (name and/or tags)",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -362,27 +345,26 @@ var blockstorageUpdateCmd = &cobra.Command{
 		if name == "" && !cmd.Flags().Changed("tags") {
 			fmt.Println("Error: at least one of --name or --tags must be provided")
 			fmt.Println("Note: Size update is not supported by the API yet")
-			return
+			return nil
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current volume details to preserve existing values
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
 		if err != nil {
-			fmt.Printf("Error getting block storage details: %v\n", err)
-			return
+			return fmt.Errorf("getting block storage details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
 			fmt.Println("Block storage not found")
-			return
+			return nil
 		}
 
 		currentVolume := getResponse.Data
@@ -391,9 +373,7 @@ var blockstorageUpdateCmd = &cobra.Command{
 		if currentVolume.Status.State != nil {
 			status := *currentVolume.Status.State
 			if status != "Used" && status != "NotUsed" {
-				fmt.Printf("Error: Cannot update block storage with status '%s'\n", status)
-				fmt.Println("Block storage can only be updated when status is 'Used' or 'NotUsed'")
-				return
+				return fmt.Errorf("cannot update block storage with status '%s': block storage can only be updated when status is 'Used' or 'NotUsed'", status)
 			}
 		}
 
@@ -403,8 +383,7 @@ var blockstorageUpdateCmd = &cobra.Command{
 			regionValue = currentVolume.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for block storage")
-			return
+			return fmt.Errorf("unable to determine region value for block storage")
 		}
 
 		// Handle zone - if empty, set to nil
@@ -444,19 +423,14 @@ var blockstorageUpdateCmd = &cobra.Command{
 		// Update the block storage using the SDK
 		response, err := client.FromStorage().Volumes().Update(ctx, projectID, volumeID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating block storage: %v\n", err)
-			return
+			return fmt.Errorf("updating block storage: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update block storage - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
+		if response != nil && response.IsError() {
+			if response.Error != nil {
+				return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmt.Errorf("API error (status %d)", response.StatusCode)
 		}
 
 		if response != nil && response.Data != nil {
@@ -471,6 +445,7 @@ var blockstorageUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -478,14 +453,13 @@ var blockstorageDeleteCmd = &cobra.Command{
 	Use:   "delete [volume-id]",
 	Short: "Delete block storage",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -493,61 +467,60 @@ var blockstorageDeleteCmd = &cobra.Command{
 
 		// If not confirmed, ask for confirmation
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete block storage %s? (yes/no): ", volumeID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("block storage", volumeID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Delete the block storage using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromStorage().Volumes().Delete(ctx, projectID, volumeID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting block storage: %v\n", err)
-			return
+			return fmt.Errorf("deleting block storage: %w", err)
 		}
 
 		fmt.Printf("\nBlock storage %s deleted successfully!\n", volumeID)
+		return nil
 	},
 }
 
 var blockstorageListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all block storage",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get flags
 		verbose, _ := cmd.Flags().GetBool("verbose")
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// List block storage using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Volumes().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing block storage: %v\n", err)
-			return
+			return fmt.Errorf("listing block storage: %w", err)
 		}
 
 		// Debug output
@@ -628,5 +601,6 @@ var blockstorageListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No block storage found")
 		}
+		return nil
 	},
 }

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -92,15 +92,14 @@ var storageRestoreCmd = &cobra.Command{
 	Short: "Restore a block storage volume from a backup",
 	Long:  `Create a restore operation (Aruba.Storage/restore) to restore a volume from a backup.`,
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 		volumeID := args[1]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -108,35 +107,23 @@ var storageRestoreCmd = &cobra.Command{
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// Validate required fields
-		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
-		}
-		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
-		}
-
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 
 		// Get the backup details
 		backupResponse, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error getting backup details: %v\n", err)
-			return
+			return fmt.Errorf("getting backup details: %w", err)
 		}
 
 		if backupResponse == nil || backupResponse.Data == nil {
-			fmt.Println("Backup not found")
-			return
+			return fmt.Errorf("backup not found")
 		}
 
 		backupURI := *backupResponse.Data.Metadata.URI
@@ -144,13 +131,11 @@ var storageRestoreCmd = &cobra.Command{
 		// Get the volume details
 		volumeResponse, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
 		if err != nil {
-			fmt.Printf("Error getting volume details: %v\n", err)
-			return
+			return fmt.Errorf("getting volume details: %w", err)
 		}
 
 		if volumeResponse == nil || volumeResponse.Data == nil {
-			fmt.Println("Volume not found")
-			return
+			return fmt.Errorf("volume not found")
 		}
 
 		volumeURI := *volumeResponse.Data.Metadata.URI
@@ -194,27 +179,17 @@ var storageRestoreCmd = &cobra.Command{
 		// Create the restore using the SDK
 		response, err := client.FromStorage().Restores().Create(ctx, projectID, backupID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating restore: %v\n", err)
-			return
+			return fmt.Errorf("creating restore: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to create restore - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			if verbose {
-				if response.RawBody != nil {
-					var errorDetail map[string]interface{}
-					if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
-						fmt.Printf("Full Error Response: %+v\n", errorDetail)
-					}
+			if verbose && response.RawBody != nil {
+				var errorDetail map[string]interface{}
+				if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
+					fmt.Printf("Full Error Response: %+v\n", errorDetail)
 				}
 			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response.Data != nil {
@@ -222,12 +197,13 @@ var storageRestoreCmd = &cobra.Command{
 			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
 			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
 			if !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
 			}
 			if response.Data.Status.State != nil {
 				fmt.Printf("Status:          %s\n", *response.Data.Status.State)
 			}
 		}
+		return nil
 	},
 }
 
@@ -236,26 +212,24 @@ var storageRestoreListCmd = &cobra.Command{
 	Use:   "list [backup-id]",
 	Short: "List restore operations for a backup",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Restores().List(ctx, projectID, backupID, nil)
 		if err != nil {
-			fmt.Printf("Error listing restores: %v\n", err)
-			return
+			return fmt.Errorf("listing restores: %w", err)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -289,6 +263,7 @@ var storageRestoreListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No restores found for this backup")
 		}
+		return nil
 	},
 }
 
@@ -297,27 +272,25 @@ var storageRestoreGetCmd = &cobra.Command{
 	Use:   "get [backup-id] [restore-id]",
 	Short: "Get restore operation details",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 		restoreID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)
 		if err != nil {
-			fmt.Printf("Error getting restore details: %v\n", err)
-			return
+			return fmt.Errorf("getting restore details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -347,7 +320,7 @@ var storageRestoreGetCmd = &cobra.Command{
 			}
 
 			if !restore.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", restore.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", restore.Metadata.CreationDate.Format(DateLayout))
 			}
 
 			if restore.Metadata.CreatedBy != nil {
@@ -362,6 +335,7 @@ var storageRestoreGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Restore operation not found")
 		}
+		return nil
 	},
 }
 
@@ -370,14 +344,13 @@ var storageRestoreUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id] [restore-id]",
 	Short: "Update a restore operation (name and/or tags)",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 		restoreID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -386,27 +359,24 @@ var storageRestoreUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current restore details
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)
 		if err != nil {
-			fmt.Printf("Error getting restore details: %v\n", err)
-			return
+			return fmt.Errorf("getting restore details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Restore operation not found")
-			return
+			return fmt.Errorf("restore operation not found")
 		}
 
 		currentRestore := getResponse.Data
@@ -417,8 +387,7 @@ var storageRestoreUpdateCmd = &cobra.Command{
 			regionValue = currentRestore.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for restore operation")
-			return
+			return fmt.Errorf("unable to determine region value for restore operation")
 		}
 
 		// Build the update request with current values as defaults
@@ -451,19 +420,11 @@ var storageRestoreUpdateCmd = &cobra.Command{
 		// Update the restore using the SDK
 		response, err := client.FromStorage().Restores().Update(ctx, projectID, backupID, restoreID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating restore: %v\n", err)
-			return
+			return fmt.Errorf("updating restore: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update restore - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -476,6 +437,7 @@ var storageRestoreUpdateCmd = &cobra.Command{
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -484,40 +446,39 @@ var storageRestoreDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id] [restore-id]",
 	Short: "Delete a restore operation",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 		restoreID := args[1]
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		confirm, _ := cmd.Flags().GetBool("yes")
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete restore operation %s? (yes/no): ", restoreID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("restore operation", restoreID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromStorage().Restores().Delete(ctx, projectID, backupID, restoreID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting restore: %v\n", err)
-			return
+			return fmt.Errorf("deleting restore: %w", err)
 		}
 
 		fmt.Printf("\nRestore operation %s deleted successfully!\n", restoreID)
+		return nil
 	},
 }

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -96,12 +96,12 @@ var snapshotCmd = &cobra.Command{
 var snapshotCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new snapshot",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -110,25 +110,10 @@ var snapshotCreateCmd = &cobra.Command{
 		volumeURI, _ := cmd.Flags().GetString("volume-uri")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// Validate required fields
-		if name == "" {
-			fmt.Println("Error: --name is required")
-			return
-		}
-		if region == "" {
-			fmt.Println("Error: --region is required")
-			return
-		}
-		if volumeURI == "" {
-			fmt.Println("Error: --volume-uri is required")
-			return
-		}
-
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Build the create request
@@ -163,23 +148,32 @@ var snapshotCreateCmd = &cobra.Command{
 		}
 
 		// Create the snapshot using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Snapshots().Create(ctx, projectID, createRequest, nil)
 		if err != nil {
-			fmt.Printf("Error creating snapshot: %v\n", err)
-			return
+			return fmt.Errorf("creating snapshot: %w", err)
+		}
+
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
 			fmt.Println("\nSnapshot created successfully!")
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
+			if response.Data.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
+			}
+			if response.Data.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
+			}
 			if !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println("Warning: Snapshot may have been created but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -187,29 +181,27 @@ var snapshotGetCmd = &cobra.Command{
 	Use:   "get [snapshot-id]",
 	Short: "Get snapshot details",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		snapshotID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Get snapshot details using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Snapshots().Get(ctx, projectID, snapshotID, nil)
 		if err != nil {
-			fmt.Printf("Error getting snapshot details: %v\n", err)
-			return
+			return fmt.Errorf("getting snapshot details: %w", err)
 		}
 
 		if response != nil && response.Data != nil {
@@ -248,7 +240,7 @@ var snapshotGetCmd = &cobra.Command{
 			fmt.Printf("Status:          %s\n", status)
 
 			if !snapshot.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", snapshot.Metadata.CreationDate.Format("02-01-2006 15:04:05"))
+				fmt.Printf("Creation Date:   %s\n", snapshot.Metadata.CreationDate.Format(DateLayout))
 			}
 
 			if snapshot.Metadata.CreatedBy != nil {
@@ -265,6 +257,7 @@ var snapshotGetCmd = &cobra.Command{
 		} else {
 			fmt.Println("Snapshot not found")
 		}
+		return nil
 	},
 }
 
@@ -272,14 +265,13 @@ var snapshotUpdateCmd = &cobra.Command{
 	Use:   "update [snapshot-id]",
 	Short: "Update a snapshot (name and/or tags only)",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		snapshotID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -288,28 +280,25 @@ var snapshotUpdateCmd = &cobra.Command{
 
 		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
-			fmt.Println("Error: at least one of --name or --tags must be provided")
-			return
+			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// First, get the current snapshot details to preserve existing values
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		getResponse, err := client.FromStorage().Snapshots().Get(ctx, projectID, snapshotID, nil)
 		if err != nil {
-			fmt.Printf("Error getting snapshot details: %v\n", err)
-			return
+			return fmt.Errorf("getting snapshot details: %w", err)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
-			fmt.Println("Snapshot not found")
-			return
+			return fmt.Errorf("snapshot not found")
 		}
 
 		currentSnapshot := getResponse.Data
@@ -320,8 +309,7 @@ var snapshotUpdateCmd = &cobra.Command{
 			regionValue = currentSnapshot.Metadata.LocationResponse.Value
 		}
 		if regionValue == "" {
-			fmt.Println("Error: Unable to determine region value for snapshot")
-			return
+			return fmt.Errorf("unable to determine region value for snapshot")
 		}
 
 		// Build the update request with current values as defaults
@@ -330,10 +318,14 @@ var snapshotUpdateCmd = &cobra.Command{
 			volumeURI = *currentSnapshot.Properties.Volume.URI
 		}
 
+		currentName := ""
+		if currentSnapshot.Metadata.Name != nil {
+			currentName = *currentSnapshot.Metadata.Name
+		}
 		updateRequest := types.SnapshotRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *currentSnapshot.Metadata.Name,
+					Name: currentName,
 					Tags: currentSnapshot.Metadata.Tags,
 				},
 				Location: types.LocationRequest{
@@ -359,31 +351,28 @@ var snapshotUpdateCmd = &cobra.Command{
 		// Update the snapshot using the SDK
 		response, err := client.FromStorage().Snapshots().Update(ctx, projectID, snapshotID, updateRequest, nil)
 		if err != nil {
-			fmt.Printf("Error updating snapshot: %v\n", err)
-			return
+			return fmt.Errorf("updating snapshot: %w", err)
 		}
 
 		if response != nil && response.IsError() && response.Error != nil {
-			fmt.Printf("Failed to update snapshot - Status: %d\n", response.StatusCode)
-			if response.Error.Title != nil {
-				fmt.Printf("Error: %s\n", *response.Error.Title)
-			}
-			if response.Error.Detail != nil {
-				fmt.Printf("Detail: %s\n", *response.Error.Detail)
-			}
-			return
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
 			fmt.Println("\nSnapshot updated successfully!")
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
+			if response.Data.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
+			}
+			if response.Data.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
+			}
 			if len(response.Data.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", response.Data.Metadata.Tags)
 			}
 		} else {
 			fmt.Println("Warning: Update may have succeeded but response is empty")
 		}
+		return nil
 	},
 }
 
@@ -391,14 +380,13 @@ var snapshotDeleteCmd = &cobra.Command{
 	Use:   "delete [snapshot-id]",
 	Short: "Delete a snapshot",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		snapshotID := args[0]
 
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get flags
@@ -406,66 +394,60 @@ var snapshotDeleteCmd = &cobra.Command{
 
 		// If not confirmed, ask for confirmation
 		if !confirm {
-			fmt.Printf("Are you sure you want to delete snapshot %s? (yes/no): ", snapshotID)
-			var response string
-			fmt.Scanln(&response)
-			if response != "yes" && response != "y" {
-				fmt.Println("Delete cancelled")
-				return
+			ok, err := confirmDelete("snapshot", snapshotID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// Delete the snapshot using the SDK
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		_, err = client.FromStorage().Snapshots().Delete(ctx, projectID, snapshotID, nil)
 		if err != nil {
-			fmt.Printf("Error deleting snapshot: %v\n", err)
-			return
+			return fmt.Errorf("deleting snapshot: %w", err)
 		}
 
 		fmt.Printf("\nSnapshot %s deleted successfully!\n", snapshotID)
+		return nil
 	},
 }
 
 var snapshotListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List snapshots for a block storage volume",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
 		// Get block storage URI flag
 		volumeURI, _ := cmd.Flags().GetString("volume-uri")
-		if volumeURI == "" {
-			fmt.Println("Error: --volume-uri is required")
-			fmt.Println("Use: acloud storage snapshot list --volume-uri <block-storage-uri>")
-			return
-		}
 
 		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
-			fmt.Printf("Error initializing client: %v\n", err)
-			return
+			return fmt.Errorf("initializing client: %w", err)
 		}
 
 		// List snapshots using the SDK (filter by volume URI on client side)
-		ctx := context.Background()
+		ctx, cancel := newCtx()
+		defer cancel()
 		response, err := client.FromStorage().Snapshots().List(ctx, projectID, nil)
 		if err != nil {
-			fmt.Printf("Error listing snapshots: %v\n", err)
-			return
+			return fmt.Errorf("listing snapshots: %w", err)
 		}
 
 		// Check verbose flag
@@ -486,7 +468,7 @@ var snapshotListCmd = &cobra.Command{
 
 			if len(filteredSnapshots) == 0 {
 				fmt.Printf("No snapshots found for volume: %s\n", volumeURI)
-				return
+				return nil
 			}
 
 			// Define table columns
@@ -525,5 +507,6 @@ var snapshotListCmd = &cobra.Command{
 		} else {
 			fmt.Println("No snapshots found")
 		}
+		return nil
 	},
 }


### PR DESCRIPTION
| ID | Summary |
|----|---------|
| TD-001 | All `Run` handlers converted to `RunE`; `SilenceUsage: true`; `fmtAPIError` helper in `root.go` |
| TD-002 | Nil guards added for `LocationResponse`, `Metadata.ID`, `Metadata.Name` in all list/create/update responses |
| TD-003 | Errors propagated via `return fmt.Errorf(...)` instead of printing to stdout |
| TD-004 | Flag read errors checked via `RunE` return paths |
| TD-005 | `confirmDelete()` helper in `root.go` detects non-interactive stdin before prompting |
| TD-006 | `newCtx()` helper in `root.go` applies 30-second timeout to all SDK calls |
| TD-007 | `getContextFilePath` returns `(string, error)` instead of silently falling back to CWD |
| TD-008 | YAML unmarshal errors wrapped with user-friendly messages in `LoadConfig` and `LoadContext` |
| TD-013 | `Args: cobra.NoArgs` added to all `create` and `list` commands that take no positional arguments |
| TD-014 | `cmd/constants.go` created with `StateInCreation`, `DateLayout`, `FilePermConfig`, `FilePermDirAll`; all magic strings replaced |

Fixes #31 
Fixes #32 
Fixes #33 
Fixes #34 
Fixes #35 
Fixes #36 
Fixes #37 
Fixes #38 
Fixes #43 
Fixes #44 