### PR TITLE
fix(test): set USERPROFILE alongside HOME to fix 6 failing tests on Windows

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -7,18 +7,17 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	// Save original home dir
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE") // Windows
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
 
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+	}()
 
 	// Test with non-existent config
 	config, err := LoadConfig()
@@ -31,18 +30,17 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestSaveConfig(t *testing.T) {
-	// Save original home dir
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE") // Windows
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
 
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+	}()
 
 	// Create test config
 	testConfig := &Config{
@@ -78,18 +76,17 @@ func TestSaveConfig(t *testing.T) {
 }
 
 func TestConfigPath(t *testing.T) {
-	// Save original home dir
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE") // Windows
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
 
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+	}()
 
 	// Get config path
 	configPath, err := GetConfigPath()

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -7,18 +7,17 @@ import (
 )
 
 func TestLoadContext(t *testing.T) {
-	// Save original home dir
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE") // Windows
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
 
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+	}()
 
 	// Test with non-existent context
 	ctx, err := LoadContext()
@@ -31,18 +30,17 @@ func TestLoadContext(t *testing.T) {
 }
 
 func TestSaveContext(t *testing.T) {
-	// Save original home dir
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE") // Windows
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
 
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+	}()
 
 	// Create test context
 	testContext := &Context{
@@ -82,18 +80,17 @@ func TestSaveContext(t *testing.T) {
 }
 
 func TestGetCurrentProjectID(t *testing.T) {
-	// Save original home dir
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE") // Windows
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
 
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+	}()
 
 	// Test with no context
 	projectID, err := GetCurrentProjectID()


### PR DESCRIPTION
## Summary

- `config_test.go` and `context_test.go` set only `HOME` to redirect file paths in tests, but `os.UserHomeDir()` on Windows reads `USERPROFILE` first — so the helpers still resolved to the real user home, causing false failures
- Applied the same save/restore pattern already used in `root_test.go`: capture both `HOME` and `USERPROFILE`, set both to `t.TempDir()`, restore via `defer`

Fixes #60, part of epic #65.

## Test plan

- [x] `go test ./cmd/... -run "TestLoadConfig|TestSaveConfig|TestConfigPath|TestLoadContext|TestSaveContext|TestGetCurrentProjectID"` — all 6 pass
- [x] `go test ./cmd/...` — full suite passes, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)