### PR TITLE
fix(compute): replace raw-JSON ID extraction with typed Metadata.ID

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -26,23 +26,13 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-020 | Six helper functions added to `cmd/root.go` (`msgCreated`, `msgCreatedAsync`, `msgUpdated`, `msgUpdatedAsync`, `msgDeleted`, `msgAction`); all ~91 success `fmt.Print*` calls replaced across 20 cmd files; one double-nil-check fixed in `container.containerregistry.go` as a side effect |
 | TD-021 | `Long` and `Example` fields added to all 23 create commands across 22 cmd files; subnet already had a minimal `Long` which was replaced with a richer version |
 | TD-019 | `--dry-run` flag added to all 24 delete commands; in dry-run mode a `Get` validates existence and access then prints `[dry-run] Would delete …` without calling `Delete`; `msgDryRun` helper added to `cmd/root.go` |
-
----
-
-## Medium
-
-### TD-015 · Fragile raw-JSON workaround for CloudServer ID extraction
-`cmd/compute.cloudserver.go` manually unmarshals `response.RawBody` into `map[string]interface{}` to extract the resource ID because the SDK's typed response struct does not expose it. This breaks silently if the API response shape changes.
-
-**Status:** Blocked on SDK — the typed response struct does not expose the resource ID field.
-
-**Fix:** When the SDK exposes the ID in its typed response, remove the raw-JSON workaround. Until then, the raw-JSON path must be preserved; a comment in the code documents the dependency.
+| TD-015 | Raw-JSON `response.RawBody` ID extraction removed from `cloudserver` and `keypair` list commands; typed `Metadata.ID` used directly; entries with nil/empty ID are discarded (SDK bumped to v0.1.25) |
 
 ---
 
 ## Low
 
 ### TD-022 · Pre-release SDK version (v0.1.x)
-`go.mod` depends on `github.com/Arubacloud/sdk-go v0.1.21`. The `0.x` major version provides no semantic versioning stability guarantee — a minor-version bump may introduce breaking changes.
+`go.mod` depends on `github.com/Arubacloud/sdk-go v0.1.25`. The `0.x` major version provides no semantic versioning stability guarantee — a minor-version bump may introduce breaking changes.
 
 **Fix:** Track the SDK release roadmap. When a `v1.0.0` is released, migrate and pin to it. Until then, pin to a specific minor version and treat any upgrade as potentially breaking.

--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -120,23 +120,16 @@ func completeCloudServerID(cmd *cobra.Command, args []string, toComplete string)
 	var completions []string
 	if response != nil && response.Data != nil {
 		for _, server := range response.Data.Values {
+			if server.Metadata.ID == nil || *server.Metadata.ID == "" {
+				continue
+			}
+			id := *server.Metadata.ID
 			var name string
 			if server.Metadata.Name != nil {
 				name = *server.Metadata.Name
 			}
-			// Try to extract ID from BootVolume URI or other URI fields
-			id := name // Default to name
-			if server.Properties.BootVolume.URI != "" {
-				// Try to extract from a URI pattern if available
-				// For now, use name as identifier
-				id = name
-			}
-			if name != "" {
-				// For completion, we can use name or try to extract ID from URI if available
-				// The response structure may vary, so we'll use name as the primary identifier
-				if toComplete == "" || strings.HasPrefix(name, toComplete) || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\tCloud Server", id))
-				}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
@@ -236,7 +229,7 @@ Billing period: Hour (default), Month, or Year.`,
 
 		// Optionally set Elastic IP
 		if elasticIPURI != "" {
-			createRequest.Properties.ElastcIP = types.ReferenceResource{URI: elasticIPURI}
+			createRequest.Properties.ElasticIP = types.ReferenceResource{URI: elasticIPURI}
 		}
 
 		if keypairURI != "" {
@@ -277,12 +270,12 @@ Billing period: Hour (default), Month, or Year.`,
 				{Header: "HD(GB)", Width: 15},
 				{Header: "REGION", Width: 20},
 			}
-			// CloudServer response may not expose ID in metadata
-			// Use name or extract from URI if needed
 			var id, name string
+			if response.Data.Metadata.ID != nil {
+				id = *response.Data.Metadata.ID
+			}
 			if response.Data.Metadata.Name != nil {
 				name = *response.Data.Metadata.Name
-				id = name // Fallback to name for display
 			}
 			flavorName := response.Data.Properties.Flavor.Name
 			cpu := response.Data.Properties.Flavor.CPU
@@ -343,8 +336,9 @@ var cloudserverGetCmd = &cobra.Command{
 			fmt.Println("\nCloud Server Details:")
 			fmt.Println("====================")
 
-			// CloudServer response metadata may not expose ID directly
-			// ID can be extracted from URI if needed
+			if server.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *server.Metadata.ID)
+			}
 			if server.Metadata.Name != nil {
 				fmt.Printf("Name:            %s\n", *server.Metadata.Name)
 			}
@@ -586,28 +580,12 @@ var cloudserverListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 
-			// Extract IDs from raw JSON response if available
-			// The SDK type definition uses Request types but actual response has ID fields
-			idMap := make(map[int]string) // Map server index to ID
-			if response.RawBody != nil {
-				var rawResponse map[string]interface{}
-				if err := json.Unmarshal(response.RawBody, &rawResponse); err == nil {
-					if values, ok := rawResponse["values"].([]interface{}); ok {
-						for i, val := range values {
-							if serverMap, ok := val.(map[string]interface{}); ok {
-								if metadata, ok := serverMap["metadata"].(map[string]interface{}); ok {
-									if idVal, ok := metadata["id"].(string); ok && idVal != "" {
-										idMap[i] = idVal
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-
 			var rows [][]string
-			for idx, server := range response.Data.Values {
+			for _, server := range response.Data.Values {
+				if server.Metadata.ID == nil || *server.Metadata.ID == "" {
+					continue
+				}
+				id := *server.Metadata.ID
 				var name string
 				if server.Metadata.Name != nil {
 					name = *server.Metadata.Name
@@ -621,13 +599,6 @@ var cloudserverListCmd = &cobra.Command{
 				if server.Status.State != nil {
 					status = *server.Status.State
 				}
-
-				// Get ID from raw JSON map, fallback to name
-				id := idMap[idx]
-				if id == "" {
-					id = name
-				}
-
 				rows = append(rows, []string{
 					name,
 					id,
@@ -637,6 +608,10 @@ var cloudserverListCmd = &cobra.Command{
 				})
 			}
 
+			if len(rows) == 0 {
+				fmt.Println("No cloud servers found")
+				return nil
+			}
 			PrintTable(headers, rows)
 		} else {
 			fmt.Println("No cloud servers found")

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -41,6 +41,23 @@ func TestCloudServerListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "skips entries with nil ID",
+			setupMock: func(m *mockCloudServersClient) {
+				id, name := "cs-001", "my-server"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
+					return &types.Response[types.CloudServerList]{
+						StatusCode: 200,
+						Data: &types.CloudServerList{
+							Values: []types.CloudServerResponse{
+								{Metadata: types.ResourceMetadataResponse{Name: &name}},
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+		},
+		{
 			name: "SDK error propagates",
 			setupMock: func(m *mockCloudServersClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -329,39 +329,16 @@ var keypairListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 10},
 			}
 
-			// Extract IDs from raw JSON response if available
-			// The SDK type definition uses Request types but actual response has ID fields
-			idMap := make(map[int]string) // Map keypair index to ID
-			if response.RawBody != nil {
-				var rawResponse map[string]interface{}
-				if err := json.Unmarshal(response.RawBody, &rawResponse); err == nil {
-					if values, ok := rawResponse["values"].([]interface{}); ok {
-						for i, val := range values {
-							if keypairMap, ok := val.(map[string]interface{}); ok {
-								if metadata, ok := keypairMap["metadata"].(map[string]interface{}); ok {
-									if idVal, ok := metadata["id"].(string); ok && idVal != "" {
-										idMap[i] = idVal
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-
 			var rows [][]string
-			for idx, keypair := range response.Data.Values {
+			for _, keypair := range response.Data.Values {
+				if keypair.Metadata.ID == nil || *keypair.Metadata.ID == "" {
+					continue
+				}
+				id := *keypair.Metadata.ID
 				name := ""
 				if keypair.Metadata.Name != nil {
 					name = *keypair.Metadata.Name
 				}
-
-				// Get ID from raw JSON map, fallback to name
-				id := idMap[idx]
-				if id == "" {
-					id = name
-				}
-
 				publicKey := ""
 				if keypair.Properties.Value != "" {
 					publicKey = keypair.Properties.Value
@@ -369,12 +346,14 @@ var keypairListCmd = &cobra.Command{
 						publicKey = publicKey[:50] + "..."
 					}
 				}
-
-				// Show status as 'Active' for all keypairs (API does not provide status)
 				status := "Active"
 				rows = append(rows, []string{name, id, publicKey, status})
 			}
 
+			if len(rows) == 0 {
+				fmt.Println("No keypairs found")
+				return nil
+			}
 			PrintTable(headers, rows)
 		} else {
 			fmt.Println("No keypairs found")

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -18,13 +18,13 @@ func TestKeyPairListCmd(t *testing.T) {
 		{
 			name: "success with results",
 			setupMock: func(m *mockKeyPairsClient) {
-				kpName := "my-kp"
+				kpID, kpName := "kp-001", "my-kp"
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
 					return &types.Response[types.KeyPairListResponse]{
 						StatusCode: 200,
 						Data: &types.KeyPairListResponse{
 							Values: []types.KeyPairResponse{
-								{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
+								{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
 							},
 						},
 					}, nil
@@ -36,6 +36,23 @@ func TestKeyPairListCmd(t *testing.T) {
 			setupMock: func(m *mockKeyPairsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
 					return &types.Response[types.KeyPairListResponse]{StatusCode: 200, Data: &types.KeyPairListResponse{}}, nil
+				}
+			},
+		},
+		{
+			name: "skips entries with nil ID",
+			setupMock: func(m *mockKeyPairsClient) {
+				kpID, kpName := "kp-001", "my-kp"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
+					return &types.Response[types.KeyPairListResponse]{
+						StatusCode: 200,
+						Data: &types.KeyPairListResponse{
+							Values: []types.KeyPairResponse{
+								{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
+								{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+							},
+						},
+					}, nil
 				}
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module acloud
 go 1.25.0
 
 require (
-	github.com/Arubacloud/sdk-go v0.1.21
+	github.com/Arubacloud/sdk-go v0.1.25
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -29,7 +30,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/redis/go-redis/v9 v9.17.2 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arubacloud/sdk-go v0.1.21 h1:vMHAFak7BRBCmV4nZ7o8G3g/MBmXCjrLDaB9zC088QM=
-github.com/Arubacloud/sdk-go v0.1.21/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
+github.com/Arubacloud/sdk-go v0.1.25 h1:bfuVf+1o/1sdUR4U4G+wZGDmEcaQs3666Is8l+wb9ww=
+github.com/Arubacloud/sdk-go v0.1.25/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
## Summary

- Remove the fragile `response.RawBody` → `map[string]interface{}` workaround from **cloudserver** and **keypair** list commands; both were manually parsing JSON to extract `metadata.id` because the typed SDK field was assumed unavailable
- Iterate `response.Data.Values` directly and read `server.Metadata.ID` / `keypair.Metadata.ID` from the typed `ResourceMetadataResponse`; entries with `nil` or empty ID are **discarded** (no name fallback)
- Cloudserver create and get commands also updated to use `Metadata.ID` consistently
- Shell completion (`completeCloudServerID`) now offers IDs instead of names
- Bump `sdk-go` v0.1.21 → **v0.1.25** (includes [sdk-go#176](https://github.com/Arubacloud/sdk-go/pull/176) which validates that `id`/`uri`/`name` are present in every Create response)
- Mark **TD-015** resolved in `ai/TECH_DEBT.md`; update **TD-022** SDK version reference

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./cmd/...` — all existing tests pass
- [x] New `"skips entries with nil ID"` subtest added for both cloudserver and keypair list commands

Closes #45
Upstream enabler: Arubacloud/sdk-go#176

🤖 Generated with [Claude Code](https://claude.com/claude-code)