### PR TITLE
fix(storage): use typed Error + MarshalIndent for verbose error dump

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -27,6 +27,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-021 | `Long` and `Example` fields added to all 23 create commands across 22 cmd files; subnet already had a minimal `Long` which was replaced with a richer version |
 | TD-019 | `--dry-run` flag added to all 24 delete commands; in dry-run mode a `Get` validates existence and access then prints `[dry-run] Would delete …` without calling `Delete`; `msgDryRun` helper added to `cmd/root.go` |
 | TD-015 | Raw-JSON `response.RawBody` ID extraction removed from `cloudserver` and `keypair` list commands; typed `Metadata.ID` used directly; entries with nil/empty ID are discarded (SDK bumped to v0.1.26) |
+| TD-023 | Verbose error-body dump in `storage.backup` / `storage.restore` now uses `json.MarshalIndent(response.Error, …)`; generic `map[string]interface{}` unmarshal removed |
 
 ---
 

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -189,12 +189,10 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating backup: %w", err)
 		}
 
-		if response != nil && response.IsError() {
-			if verbose && response.RawBody != nil {
-				var errorDetail map[string]interface{}
-				if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
-					fmt.Printf("Full Error Response: %+v\n", errorDetail)
-				}
+		if response != nil && response.IsError() && response.Error != nil {
+			if verbose {
+				jsonData, _ := json.MarshalIndent(response.Error, "", "  ")
+				fmt.Printf("Full Error Response:\n%s\n", string(jsonData))
 			}
 			return apiErrFromResp(response.StatusCode, response.Error)
 		}

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -190,12 +190,10 @@ idle before starting a restore to avoid data corruption.`,
 			return fmt.Errorf("creating restore: %w", err)
 		}
 
-		if response != nil && response.IsError() {
-			if verbose && response.RawBody != nil {
-				var errorDetail map[string]interface{}
-				if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
-					fmt.Printf("Full Error Response: %+v\n", errorDetail)
-				}
+		if response != nil && response.IsError() && response.Error != nil {
+			if verbose {
+				jsonData, _ := json.MarshalIndent(response.Error, "", "  ")
+				fmt.Printf("Full Error Response:\n%s\n", string(jsonData))
 			}
 			return apiErrFromResp(response.StatusCode, response.Error)
 		}


### PR DESCRIPTION
## Summary

- Replace the `map[string]interface{}` unmarshal in the `--verbose` error path of both `storage backup create` and `storage restore create` with `json.MarshalIndent(response.Error, "", "  ")`
- The SDK already populates `response.Error` as a fully-typed `*types.ErrorResponse` (RFC 7807 fields + `Extensions` for unknown keys with proper `MarshalJSON` roundtrip), so the extra raw-body parse was redundant
- Output is now well-indented JSON instead of Go `%+v` map syntax

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./cmd/...` — all tests pass
- No new tests needed: this only changes verbose debug output format, not behaviour

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)