### PR TITLE
test(#61): add API-level error test cases across all command tests

### DIFF
--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -576,6 +576,9 @@ var cloudserverListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing cloud servers: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			headers := []TableColumn{

--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -263,8 +263,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating cloud server: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -333,8 +333,8 @@ var cloudserverGetCmd = &cobra.Command{
 			return fmt.Errorf("getting cloud server: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -480,8 +480,8 @@ var cloudserverUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating cloud server: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -546,8 +546,8 @@ var cloudserverDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting cloud server: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		fmt.Println(msgDeleted("Cloud server", serverID))
@@ -576,8 +576,8 @@ var cloudserverListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing cloud servers: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -672,8 +672,8 @@ var cloudserverPowerOnCmd = &cobra.Command{
 			return fmt.Errorf("powering on cloud server: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -715,8 +715,8 @@ var cloudserverPowerOffCmd = &cobra.Command{
 			return fmt.Errorf("powering off cloud server: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -767,8 +767,8 @@ var cloudserverSetPasswordCmd = &cobra.Command{
 			return fmt.Errorf("setting password for cloud server: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -829,8 +829,8 @@ var cloudserverConnectCmd = &cobra.Command{
 			return fmt.Errorf("getting cloud server: %w", err)
 		}
 
-		if serverResp != nil && serverResp.IsError() && serverResp.Error != nil {
-			return fmtAPIError(serverResp.StatusCode, serverResp.Error.Title, serverResp.Error.Detail)
+		if serverResp != nil && serverResp.IsError() {
+			return apiErrFromResp(serverResp.StatusCode, serverResp.Error)
 		}
 
 		if serverResp == nil || serverResp.Data == nil {
@@ -867,8 +867,8 @@ var cloudserverConnectCmd = &cobra.Command{
 			return fmt.Errorf("getting Elastic IP details: %w", err)
 		}
 
-		if eipResp != nil && eipResp.IsError() && eipResp.Error != nil {
-			return fmtAPIError(eipResp.StatusCode, eipResp.Error.Title, eipResp.Error.Detail)
+		if eipResp != nil && eipResp.IsError() {
+			return apiErrFromResp(eipResp.StatusCode, eipResp.Error)
 		}
 
 		if eipResp == nil || eipResp.Data == nil {

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -50,6 +50,19 @@ func TestCloudServerListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockCloudServersClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
+					return &types.Response[types.CloudServerList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestCloudServerGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockCloudServersClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
+					return &types.Response[types.CloudServerResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -162,6 +188,20 @@ func TestCloudServerCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: baseArgs,
+			setupMock: func(m *mockCloudServersClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.CloudServerRequest, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
+					return &types.Response[types.CloudServerResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -199,6 +239,19 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockCloudServersClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -238,6 +291,19 @@ func TestCloudServerPowerOnCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "power",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockCloudServersClient) {
+				m.powerOnFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
+					return &types.Response[types.CloudServerResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -276,6 +342,19 @@ func TestCloudServerPowerOffCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "power",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockCloudServersClient) {
+				m.powerOffFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
+					return &types.Response[types.CloudServerResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -313,6 +392,19 @@ func TestCloudServerSetPasswordCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "password",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockCloudServersClient) {
+				m.setPasswordFn = func(_ context.Context, _, _ string, _ types.CloudServerPasswordRequest, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -61,7 +61,7 @@ func TestCloudServerListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestCloudServerGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -200,7 +200,7 @@ func TestCloudServerCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -251,7 +251,7 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -302,7 +302,7 @@ func TestCloudServerPowerOnCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -353,7 +353,7 @@ func TestCloudServerPowerOffCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -404,7 +404,7 @@ func TestCloudServerSetPasswordCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -320,6 +320,9 @@ var keypairListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing keypairs: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			headers := []TableColumn{

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -130,8 +130,8 @@ The public key must be an OpenSSH-formatted RSA, ECDSA, or Ed25519 public key
 			return fmt.Errorf("creating keypair: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -184,8 +184,8 @@ var keypairGetCmd = &cobra.Command{
 			return fmt.Errorf("getting keypair: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -290,8 +290,8 @@ var keypairDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting keypair: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		fmt.Println(msgDeleted("Keypair", keypairName))
@@ -320,8 +320,8 @@ var keypairListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing keypairs: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -49,6 +49,19 @@ func TestKeyPairListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKeyPairsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
+					return &types.Response[types.KeyPairListResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestKeyPairGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKeyPairsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
+					return &types.Response[types.KeyPairResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestKeyPairCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"compute", "keypair", "create", "--project-id", "proj-123", "--name", "my-kp", "--public-key", "ssh-rsa AAAA"},
+			setupMock: func(m *mockKeyPairsClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.KeyPairRequest, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
+					return &types.Response[types.KeyPairResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestKeyPairDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKeyPairsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -60,7 +60,7 @@ func TestKeyPairListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestKeyPairGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestKeyPairCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestKeyPairDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -219,8 +219,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating container registry: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -276,8 +276,8 @@ var containerregistryGetCmd = &cobra.Command{
 			return fmt.Errorf("getting container registry: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -461,8 +461,8 @@ var containerregistryUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating container registry: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -537,8 +537,8 @@ var containerregistryDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting container registry: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		fmt.Println(msgDeleted("Container registry", registryID))
@@ -582,8 +582,8 @@ var containerregistryListCmd = &cobra.Command{
 			return nil
 		}
 
-		if response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response.Data != nil && len(response.Data.Values) > 0 {

--- a/cmd/container.containerregistry_test.go
+++ b/cmd/container.containerregistry_test.go
@@ -49,6 +49,19 @@ func TestContainerRegistryListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockContainerRegistryClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
+					return &types.Response[types.ContainerRegistryList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestContainerRegistryGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockContainerRegistryClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
+					return &types.Response[types.ContainerRegistryResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -161,6 +187,20 @@ func TestContainerRegistryCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: baseArgs,
+			setupMock: func(m *mockContainerRegistryClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.ContainerRegistryRequest, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
+					return &types.Response[types.ContainerRegistryResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -198,6 +238,19 @@ func TestContainerRegistryDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockContainerRegistryClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/container.containerregistry_test.go
+++ b/cmd/container.containerregistry_test.go
@@ -60,7 +60,7 @@ func TestContainerRegistryListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestContainerRegistryGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -199,7 +199,7 @@ func TestContainerRegistryCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -250,7 +250,7 @@ func TestContainerRegistryDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -293,8 +293,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating KaaS cluster: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -361,8 +361,8 @@ var kaasGetCmd = &cobra.Command{
 			return fmt.Errorf("getting KaaS cluster: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -612,8 +612,8 @@ var kaasUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating KaaS cluster: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -681,8 +681,8 @@ var kaasDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting KaaS cluster: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		fmt.Println(msgDeleted("KaaS cluster", kaasID))
@@ -711,8 +711,8 @@ var kaasListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing KaaS clusters: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -788,8 +788,8 @@ var kaasConnectCmd = &cobra.Command{
 			return fmt.Errorf("downloading kubeconfig: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response == nil || response.Data == nil {

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -711,6 +711,9 @@ var kaasListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing KaaS clusters: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			headers := []TableColumn{

--- a/cmd/container.kaas_test.go
+++ b/cmd/container.kaas_test.go
@@ -49,6 +49,19 @@ func TestKaaSListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKaaSClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KaaSList], error) {
+					return &types.Response[types.KaaSList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestKaaSGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKaaSClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KaaSResponse], error) {
+					return &types.Response[types.KaaSResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -160,6 +186,20 @@ func TestKaaSCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: baseArgs,
+			setupMock: func(m *mockKaaSClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.KaaSRequest, _ *types.RequestParameters) (*types.Response[types.KaaSResponse], error) {
+					return &types.Response[types.KaaSResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -198,6 +238,19 @@ func TestKaaSDeleteCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "deleting",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKaaSClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -229,6 +282,19 @@ func TestKaaSConnectCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "downloading kubeconfig",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockKaaSClient) {
+				m.downloadKubeconfigFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KaaSKubeconfigResponse], error) {
+					return &types.Response[types.KaaSKubeconfigResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/container.kaas_test.go
+++ b/cmd/container.kaas_test.go
@@ -60,7 +60,7 @@ func TestKaaSListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestKaaSGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -198,7 +198,7 @@ func TestKaaSCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -249,7 +249,7 @@ func TestKaaSDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -294,7 +294,7 @@ func TestKaaSConnectCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -421,9 +421,12 @@ var backupDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromDatabase().Backups().Delete(ctx, projectID, backupID, nil)
+		deleteResp, err := client.FromDatabase().Backups().Delete(ctx, projectID, backupID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting backup: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Backup", backupID))

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -181,8 +181,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating backup: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -250,8 +250,8 @@ var backupGetCmd = &cobra.Command{
 			return fmt.Errorf("getting backup: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -318,8 +318,8 @@ var backupListCmd = &cobra.Command{
 			return fmt.Errorf("listing backups: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -425,8 +425,8 @@ var backupDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting backup: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Backup", backupID))

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -49,6 +49,19 @@ func TestDBBackupListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDBBackupsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
+					return &types.Response[types.BackupList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestDBBackupGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDBBackupsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
+					return &types.Response[types.BackupResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -169,6 +195,18 @@ func TestDBBackupCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: createArgs,
+			dbMock: newDBBackupCreateMock(func(_ context.Context, _ string, _ types.BackupRequest, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
+				return &types.Response[types.BackupResponse]{
+					StatusCode: 404,
+					Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+				}, nil
+			}),
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -206,6 +244,19 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDBBackupsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -60,7 +60,7 @@ func TestDBBackupListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestDBBackupGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -205,7 +205,7 @@ func TestDBBackupCreateCmd(t *testing.T) {
 				}, nil
 			}),
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -256,7 +256,7 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -122,8 +122,8 @@ Use 'acloud database dbaas get <dbaas-id>' to check its status.`,
 			return fmt.Errorf("creating database: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -164,8 +164,8 @@ var dbaasDatabaseGetCmd = &cobra.Command{
 			return fmt.Errorf("getting database: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -213,8 +213,8 @@ var dbaasDatabaseListCmd = &cobra.Command{
 			return fmt.Errorf("listing databases: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -286,8 +286,8 @@ var dbaasDatabaseUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating database: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -347,8 +347,8 @@ var dbaasDatabaseDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting database: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Database", databaseName))

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -343,9 +343,12 @@ var dbaasDatabaseDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromDatabase().Databases().Delete(ctx, projectID, dbaasID, databaseName, nil)
+		deleteResp, err := client.FromDatabase().Databases().Delete(ctx, projectID, dbaasID, databaseName, nil)
 		if err != nil {
 			return fmt.Errorf("deleting database: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Database", databaseName))

--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -48,6 +48,19 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDatabasesClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
+					return &types.Response[types.DatabaseList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -89,6 +102,19 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDatabasesClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
+					return &types.Response[types.DatabaseResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -141,6 +167,20 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"database", "dbaas", "database", "create", "dbaas-001", "--project-id", "proj-123", "--name", "my-db"},
+			setupMock: func(m *mockDatabasesClient) {
+				m.createFn = func(_ context.Context, _, _ string, _ types.DatabaseRequest, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
+					return &types.Response[types.DatabaseResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -178,6 +218,19 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDatabasesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -59,7 +59,7 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -114,7 +114,7 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -179,7 +179,7 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -230,7 +230,7 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -534,9 +534,12 @@ var dbaasDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromDatabase().DBaaS().Delete(ctx, projectID, dbaasID, nil)
+		deleteResp, err := client.FromDatabase().DBaaS().Delete(ctx, projectID, dbaasID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting DBaaS instance: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("DBaaS instance", dbaasID))

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -152,8 +152,8 @@ and users with 'acloud database dbaas user create'.`,
 			return fmt.Errorf("creating DBaaS instance: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -235,8 +235,8 @@ var dbaasGetCmd = &cobra.Command{
 			return fmt.Errorf("getting DBaaS instance: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -317,8 +317,8 @@ var dbaasListCmd = &cobra.Command{
 			return fmt.Errorf("listing DBaaS instances: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -474,8 +474,8 @@ var dbaasUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating DBaaS instance: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -538,8 +538,8 @@ var dbaasDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting DBaaS instance: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("DBaaS instance", dbaasID))

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -126,8 +126,8 @@ separately through your database client after the user is created.`,
 			return fmt.Errorf("creating user: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -168,8 +168,8 @@ var dbaasUserGetCmd = &cobra.Command{
 			return fmt.Errorf("getting user: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -217,8 +217,8 @@ var dbaasUserListCmd = &cobra.Command{
 			return fmt.Errorf("listing users: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -291,8 +291,8 @@ var dbaasUserUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating user: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -352,8 +352,8 @@ var dbaasUserDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting user: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("User", username))

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -348,9 +348,12 @@ var dbaasUserDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromDatabase().Users().Delete(ctx, projectID, dbaasID, username, nil)
+		deleteResp, err := client.FromDatabase().Users().Delete(ctx, projectID, dbaasID, username, nil)
 		if err != nil {
 			return fmt.Errorf("deleting user: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("User", username))

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -59,7 +59,7 @@ func TestDBaaSUserListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -114,7 +114,7 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -185,7 +185,7 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -236,7 +236,7 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -48,6 +48,19 @@ func TestDBaaSUserListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockUsersClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
+					return &types.Response[types.UserList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -89,6 +102,19 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockUsersClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
+					return &types.Response[types.UserResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -147,6 +173,20 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"database", "dbaas", "user", "create", "dbaas-001", "--project-id", "proj-123", "--username", "myuser", "--password", "Pass1!"},
+			setupMock: func(m *mockUsersClient) {
+				m.createFn = func(_ context.Context, _, _ string, _ types.UserRequest, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
+					return &types.Response[types.UserResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -184,6 +224,19 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockUsersClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.dbaas_test.go
+++ b/cmd/database.dbaas_test.go
@@ -60,7 +60,7 @@ func TestDBaaSListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestDBaaSGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestDBaaSCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/database.dbaas_test.go
+++ b/cmd/database.dbaas_test.go
@@ -49,6 +49,19 @@ func TestDBaaSListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDBaaSClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
+					return &types.Response[types.DBaaSList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestDBaaSGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDBaaSClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
+					return &types.Response[types.DBaaSResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestDBaaSCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"database", "dbaas", "create", "--project-id", "proj-123", "--name", "my-dbaas", "--region", "IT-BG", "--engine-id", "postgres14", "--flavor", "db.small"},
+			setupMock: func(m *mockDBaaSClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.DBaaSRequest, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
+					return &types.Response[types.DBaaSResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockDBaaSClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -145,8 +145,8 @@ Use 'acloud context set-project' to switch the active project at any time.`,
 			return fmt.Errorf("creating project: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -206,8 +206,8 @@ var projectGetCmd = &cobra.Command{
 			return fmt.Errorf("getting project: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -292,8 +292,8 @@ var projectUpdateCmd = &cobra.Command{
 			return fmt.Errorf("fetching current project: %w", err)
 		}
 
-		if getResponse != nil && getResponse.IsError() && getResponse.Error != nil {
-			return fmtAPIError(getResponse.StatusCode, getResponse.Error.Title, getResponse.Error.Detail)
+		if getResponse != nil && getResponse.IsError() {
+			return apiErrFromResp(getResponse.StatusCode, getResponse.Error)
 		}
 
 		if getResponse == nil || getResponse.Data == nil {
@@ -331,8 +331,8 @@ var projectUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating project: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -417,8 +417,8 @@ var projectDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting project: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		headers := []TableColumn{
@@ -450,8 +450,8 @@ var projectListCmd = &cobra.Command{
 			return fmt.Errorf("listing projects: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {

--- a/cmd/management.project_test.go
+++ b/cmd/management.project_test.go
@@ -60,7 +60,7 @@ func TestProjectListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -115,7 +115,7 @@ func TestProjectGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -180,7 +180,7 @@ func TestProjectCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -231,7 +231,7 @@ func TestProjectDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/management.project_test.go
+++ b/cmd/management.project_test.go
@@ -49,6 +49,19 @@ func TestProjectListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockProjectClient) {
+				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
+					return &types.Response[types.ProjectList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -90,6 +103,19 @@ func TestProjectGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockProjectClient) {
+				m.getFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
+					return &types.Response[types.ProjectResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -142,6 +168,20 @@ func TestProjectCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"management", "project", "create", "--name", "my-project"},
+			setupMock: func(m *mockProjectClient) {
+				m.createFn = func(_ context.Context, _ types.ProjectRequest, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
+					return &types.Response[types.ProjectResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -179,6 +219,19 @@ func TestProjectDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockProjectClient) {
+				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -144,8 +144,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating Elastic IP: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -193,8 +193,8 @@ var elasticipListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing Elastic IPs: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -273,8 +273,8 @@ var elasticipGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting Elastic IP details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -477,8 +477,8 @@ var elasticipDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting Elastic IP: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Elastic IP", eipID))

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -193,6 +193,9 @@ var elasticipListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing Elastic IPs: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			// Define table columns
@@ -269,6 +272,9 @@ var elasticipGetCmd = &cobra.Command{
 		response, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
 		if err != nil {
 			return fmt.Errorf("getting Elastic IP details: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -467,9 +473,12 @@ var elasticipDeleteCmd = &cobra.Command{
 		}
 
 		// Delete the Elastic IP using the SDK
-		_, err = client.FromNetwork().ElasticIPs().Delete(ctx, projectID, eipID, nil)
+		deleteResp, err := client.FromNetwork().ElasticIPs().Delete(ctx, projectID, eipID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting Elastic IP: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Elastic IP", eipID))

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -49,6 +49,19 @@ func TestElasticIPListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockElasticIPsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
+					return &types.Response[types.ElasticList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestElasticIPGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockElasticIPsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
+					return &types.Response[types.ElasticIPResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestElasticIPCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG"},
+			setupMock: func(m *mockElasticIPsClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.ElasticIPRequest, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
+					return &types.Response[types.ElasticIPResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockElasticIPsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -60,7 +60,7 @@ func TestElasticIPListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestElasticIPGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestElasticIPCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -93,6 +93,9 @@ var loadbalancerListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing Load Balancers: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			// Define table columns
@@ -169,6 +172,9 @@ var loadbalancerGetCmd = &cobra.Command{
 		response, err := client.FromNetwork().LoadBalancers().Get(ctx, projectID, lbID, nil)
 		if err != nil {
 			return fmt.Errorf("getting Load Balancer details: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -93,8 +93,8 @@ var loadbalancerListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing Load Balancers: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -173,8 +173,8 @@ var loadbalancerGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting Load Balancer details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {

--- a/cmd/network.loadbalancer_test.go
+++ b/cmd/network.loadbalancer_test.go
@@ -49,6 +49,19 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockLoadBalancersClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
+					return &types.Response[types.LoadBalancerList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestLoadBalancerGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockLoadBalancersClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error) {
+					return &types.Response[types.LoadBalancerResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 		{
 			name: "nil data",

--- a/cmd/network.loadbalancer_test.go
+++ b/cmd/network.loadbalancer_test.go
@@ -60,7 +60,7 @@ func TestLoadBalancerListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestLoadBalancerGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 		{
 			name: "nil data",

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -77,8 +77,8 @@ after the group is created.`,
 		if err != nil {
 			return fmt.Errorf("creating security group: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
 			headers := []TableColumn{
@@ -132,8 +132,8 @@ var securitygroupGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting security group: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil {
 			sg := resp.Data
@@ -194,8 +194,8 @@ var securitygroupListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing security groups: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -299,8 +299,8 @@ var securitygroupUpdateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("updating security group: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil {
 			headers := []TableColumn{
@@ -389,8 +389,8 @@ var securitygroupDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting security group: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},

--- a/cmd/network.securitygroup_test.go
+++ b/cmd/network.securitygroup_test.go
@@ -60,7 +60,7 @@ func TestSecurityGroupListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.securitygroup_test.go
+++ b/cmd/network.securitygroup_test.go
@@ -49,6 +49,19 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSecurityGroupsClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
+					return &types.Response[types.SecurityGroupList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSecurityGroupsClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
+					return &types.Response[types.SecurityGroupResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"network", "securitygroup", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-sg", "--region", "IT-BG"},
+			setupMock: func(m *mockSecurityGroupsClient) {
+				m.createFn = func(_ context.Context, _, _ string, _ types.SecurityGroupRequest, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
+					return &types.Response[types.SecurityGroupResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSecurityGroupsClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -205,8 +205,8 @@ Example target values:
 			return fmt.Errorf("creating security rule: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
@@ -265,8 +265,8 @@ var securityruleGetCmd = &cobra.Command{
 			return fmt.Errorf("getting security rule: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -340,8 +340,8 @@ var securityruleListCmd = &cobra.Command{
 			return fmt.Errorf("listing security rules: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -425,8 +425,8 @@ var securityruleUpdateCmd = &cobra.Command{
 			return fmt.Errorf("no response received when fetching security rule")
 		}
 
-		if getResp.IsError() && getResp.Error != nil {
-			return fmtAPIError(getResp.StatusCode, getResp.Error.Title, getResp.Error.Detail)
+		if getResp.IsError() {
+			return apiErrFromResp(getResp.StatusCode, getResp.Error)
 		}
 
 		if getResp.Data == nil {
@@ -517,7 +517,7 @@ var securityruleUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating security rule: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
+		if resp != nil && resp.IsError() {
 			if debugEnabled {
 				fmt.Fprintf(os.Stderr, "\n=== DEBUG: Error Response ===\n")
 				if resp.RawBody != nil {
@@ -526,7 +526,7 @@ var securityruleUpdateCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Status Code: %d\n", resp.StatusCode)
 				fmt.Fprintf(os.Stderr, "===========================\n\n")
 			}
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -620,8 +620,8 @@ var securityruleDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting security rule: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		headers := []TableColumn{

--- a/cmd/network.securityrule_test.go
+++ b/cmd/network.securityrule_test.go
@@ -49,6 +49,19 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSecurityGroupRulesClient) {
+				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
+					return &types.Response[types.SecurityRuleList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSecurityGroupRulesClient) {
+				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
+					return &types.Response[types.SecurityRuleResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -160,6 +186,20 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: baseArgs,
+			setupMock: func(m *mockSecurityGroupRulesClient) {
+				m.createFn = func(_ context.Context, _, _, _ string, _ types.SecurityRuleRequest, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
+					return &types.Response[types.SecurityRuleResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -197,6 +237,19 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSecurityGroupRulesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.securityrule_test.go
+++ b/cmd/network.securityrule_test.go
@@ -60,7 +60,7 @@ func TestSecurityRuleListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -198,7 +198,7 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -249,7 +249,7 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -163,8 +163,8 @@ DHCP routes format: "destination:gateway" (e.g., "10.1.0.0/24:10.0.0.1").`,
 		if err != nil {
 			return fmt.Errorf("creating subnet: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
 			headers := []TableColumn{
@@ -229,8 +229,8 @@ var subnetGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting subnet: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil {
 			subnet := resp.Data
@@ -308,8 +308,8 @@ var subnetListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing subnets: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -496,8 +496,8 @@ var subnetUpdateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("updating subnet: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil {
 			headers := []TableColumn{
@@ -577,8 +577,8 @@ var subnetDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting subnet: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},

--- a/cmd/network.subnet_test.go
+++ b/cmd/network.subnet_test.go
@@ -49,6 +49,19 @@ func TestSubnetListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSubnetsClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
+					return &types.Response[types.SubnetList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestSubnetGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSubnetsClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
+					return &types.Response[types.SubnetResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestSubnetCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"network", "subnet", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-subnet", "--region", "IT-BG"},
+			setupMock: func(m *mockSubnetsClient) {
+				m.createFn = func(_ context.Context, _, _ string, _ types.SubnetRequest, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
+					return &types.Response[types.SubnetResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestSubnetDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSubnetsClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.subnet_test.go
+++ b/cmd/network.subnet_test.go
@@ -60,7 +60,7 @@ func TestSubnetListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestSubnetGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestSubnetCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestSubnetDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -394,9 +394,12 @@ var vpcDeleteCmd = &cobra.Command{
 		}
 
 		// Delete the VPC using the SDK
-		_, err = client.FromNetwork().VPCs().Delete(ctx, projectID, vpcID, nil)
+		deleteResp, err := client.FromNetwork().VPCs().Delete(ctx, projectID, vpcID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting VPC: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("VPC", vpcID))
@@ -427,6 +430,9 @@ var vpcListCmd = &cobra.Command{
 		response, err := client.FromNetwork().VPCs().List(ctx, projectID, listParams(cmd))
 		if err != nil {
 			return fmt.Errorf("listing VPCs: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -144,8 +144,8 @@ network resources are created within a VPC.`,
 			return fmt.Errorf("creating VPC: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -194,8 +194,8 @@ var vpcGetCmd = &cobra.Command{
 			return fmt.Errorf("getting VPC details: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -398,8 +398,8 @@ var vpcDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting VPC: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("VPC", vpcID))
@@ -431,8 +431,8 @@ var vpcListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing VPCs: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {

--- a/cmd/network.vpc_test.go
+++ b/cmd/network.vpc_test.go
@@ -63,7 +63,7 @@ func TestVPCListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 
@@ -130,7 +130,7 @@ func TestVPCGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 		{
 			name: "nil data — not found message",
@@ -221,7 +221,7 @@ func TestVPCCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 
@@ -282,7 +282,7 @@ func TestVPCDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 

--- a/cmd/network.vpc_test.go
+++ b/cmd/network.vpc_test.go
@@ -52,6 +52,19 @@ func TestVPCListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing VPCs",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
+					return &types.Response[types.VPCList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 
 	for _, tc := range tests {
@@ -105,6 +118,19 @@ func TestVPCGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting VPC details",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
+					return &types.Response[types.VPCResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 		{
 			name: "nil data — not found message",
@@ -183,6 +209,20 @@ func TestVPCCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating VPC",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"network", "vpc", "create", "--project-id", "proj-123", "--name", "new-vpc", "--region", "IT-BG"},
+			setupMock: func(m *mockVPCsClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.VPCRequest, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
+					return &types.Response[types.VPCResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 
 	for _, tc := range tests {
@@ -230,6 +270,19 @@ func TestVPCDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting VPC",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -92,8 +92,8 @@ peering is established.`,
 		if err != nil {
 			return fmt.Errorf("creating VPC peering: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
 			headers := []TableColumn{
@@ -155,8 +155,8 @@ var vpcpeeringGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting VPC peering: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil {
 			peering := resp.Data
@@ -217,8 +217,8 @@ var vpcpeeringListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing VPC peerings: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -332,8 +332,8 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("updating VPC peering: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		if resp != nil && resp.Data != nil {
 			headers := []TableColumn{
@@ -430,8 +430,8 @@ var vpcpeeringDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting VPC peering: %w", err)
 		}
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},

--- a/cmd/network.vpcpeering_test.go
+++ b/cmd/network.vpcpeering_test.go
@@ -49,6 +49,19 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCPeeringsClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
+					return &types.Response[types.VPCPeeringList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCPeeringsClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
+					return &types.Response[types.VPCPeeringResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -144,6 +170,20 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"network", "vpcpeering", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-peering", "--peer-vpc-id", "vpc-002", "--region", "IT-BG"},
+			setupMock: func(m *mockVPCPeeringsClient) {
+				m.createFn = func(_ context.Context, _, _ string, _ types.VPCPeeringRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
+					return &types.Response[types.VPCPeeringResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -181,6 +221,19 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCPeeringsClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpcpeering_test.go
+++ b/cmd/network.vpcpeering_test.go
@@ -60,7 +60,7 @@ func TestVPCPeeringListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -182,7 +182,7 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -233,7 +233,7 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -166,8 +166,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating VPC peering route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -222,8 +222,8 @@ var vpcpeeringrouteGetCmd = &cobra.Command{
 			return fmt.Errorf("getting VPC peering route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -277,8 +277,8 @@ var vpcpeeringrouteListCmd = &cobra.Command{
 			return fmt.Errorf("listing VPC peering routes: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -401,8 +401,8 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating VPC peering route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -482,8 +482,8 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting VPC peering route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		headers := []TableColumn{

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -57,7 +57,7 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -112,7 +112,7 @@ func TestVPCPeeringRouteGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -194,7 +194,7 @@ func TestVPCPeeringRouteCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -245,7 +245,7 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -46,6 +46,19 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCPeeringRoutesClient) {
+				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
+					return &types.Response[types.VPCPeeringRouteList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -87,6 +100,19 @@ func TestVPCPeeringRouteGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCPeeringRoutesClient) {
+				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
+					return &types.Response[types.VPCPeeringRouteResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,26 @@ func TestVPCPeeringRouteCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{
+				"network", "vpcpeeringroute", "create", "vpc-001", "peer-001",
+				"--project-id", "proj-123",
+				"--name", "my-route",
+				"--local-network", "10.0.0.0/24",
+				"--remote-network", "10.1.0.0/24",
+			},
+			setupMock: func(m *mockVPCPeeringRoutesClient) {
+				m.createFn = func(_ context.Context, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
+					return &types.Response[types.VPCPeeringRouteResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +233,19 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPCPeeringRoutesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -169,8 +169,8 @@ with --onprem-subnet. Both values should be valid CIDR blocks.`,
 			return fmt.Errorf("creating VPN route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
@@ -226,8 +226,8 @@ var vpnrouteGetCmd = &cobra.Command{
 			return fmt.Errorf("getting VPN route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -295,8 +295,8 @@ var vpnrouteListCmd = &cobra.Command{
 			return fmt.Errorf("listing VPN routes: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -434,8 +434,8 @@ var vpnrouteUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating VPN route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -526,8 +526,8 @@ var vpnrouteDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting VPN route: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		headers := []TableColumn{

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -49,6 +49,19 @@ func TestVPNRouteListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPNRoutesClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
+					return &types.Response[types.VPNRouteList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestVPNRouteGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPNRoutesClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
+					return &types.Response[types.VPNRouteResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -152,6 +178,20 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: baseArgs,
+			setupMock: func(m *mockVPNRoutesClient) {
+				m.createFn = func(_ context.Context, _, _ string, _ types.VPNRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
+					return &types.Response[types.VPNRouteResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -189,6 +229,19 @@ func TestVPNRouteDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPNRoutesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -60,7 +60,7 @@ func TestVPNRouteListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestVPNRouteGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -190,7 +190,7 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -241,7 +241,7 @@ func TestVPNRouteDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -139,8 +139,8 @@ var vpntunnelListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing VPN tunnels: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -218,8 +218,8 @@ var vpntunnelGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting VPN tunnel details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -476,8 +476,8 @@ IKE and ESP settings are optional; the platform uses secure defaults when omitte
 			return fmt.Errorf("creating VPN tunnel: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -543,8 +543,8 @@ var vpntunnelUpdateCmd = &cobra.Command{
 			return fmt.Errorf("getting VPN tunnel: %w", err)
 		}
 
-		if getResp != nil && getResp.IsError() && getResp.Error != nil {
-			return fmtAPIError(getResp.StatusCode, getResp.Error.Title, getResp.Error.Detail)
+		if getResp != nil && getResp.IsError() {
+			return apiErrFromResp(getResp.StatusCode, getResp.Error)
 		}
 
 		if getResp.Data == nil {
@@ -600,8 +600,8 @@ var vpntunnelUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating VPN tunnel: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp.Data != nil {
@@ -674,8 +674,8 @@ var vpntunnelDeleteCmd = &cobra.Command{
 			return fmt.Errorf("deleting VPN tunnel: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		fmt.Println(msgDeleted("VPN tunnel", vpnTunnelID))

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -139,6 +139,9 @@ var vpntunnelListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing VPN tunnels: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			// Define table columns
@@ -214,6 +217,9 @@ var vpntunnelGetCmd = &cobra.Command{
 		response, err := client.FromNetwork().VPNTunnels().Get(ctx, projectID, vpnID, nil)
 		if err != nil {
 			return fmt.Errorf("getting VPN tunnel details: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {

--- a/cmd/network.vpntunnel_test.go
+++ b/cmd/network.vpntunnel_test.go
@@ -49,6 +49,19 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPNTunnelsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
+					return &types.Response[types.VPNTunnelList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestVPNTunnelGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPNTunnelsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
+					return &types.Response[types.VPNTunnelResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -154,6 +180,20 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: baseArgs,
+			setupMock: func(m *mockVPNTunnelsClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.VPNTunnelRequest, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
+					return &types.Response[types.VPNTunnelResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -191,6 +231,19 @@ func TestVPNTunnelDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVPNTunnelsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/network.vpntunnel_test.go
+++ b/cmd/network.vpntunnel_test.go
@@ -60,7 +60,7 @@ func TestVPNTunnelListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestVPNTunnelGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -192,7 +192,7 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -243,7 +243,7 @@ func TestVPNTunnelDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,6 +204,15 @@ func fmtAPIError(statusCode int, title, detail *string) error {
 	return fmt.Errorf("%s", msg)
 }
 
+// apiErrFromResp returns an error whenever the response status is 4xx/5xx,
+// safely handling the case where the SDK did not populate an error body.
+func apiErrFromResp(statusCode int, errResp *types.ErrorResponse) error {
+	if errResp != nil {
+		return fmtAPIError(statusCode, errResp.Title, errResp.Detail)
+	}
+	return fmtAPIError(statusCode, nil, nil)
+}
+
 // confirmDelete prompts the user for confirmation before a destructive operation.
 // Returns true if the user confirmed, false if they declined or stdin is non-interactive (TD-005).
 func confirmDelete(resourceType, id string) (bool, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -205,7 +205,7 @@ func fmtAPIError(statusCode int, title, detail *string) error {
 }
 
 // apiErrFromResp returns an error for 4xx/5xx status codes, safely handling
-// the case where the SDK did not populate an error body. Returns nil for 2xx/3xx.
+// the case where the SDK did not populate an error body. Returns nil for any status < 400.
 func apiErrFromResp(statusCode int, errResp *types.ErrorResponse) error {
 	if statusCode < 400 {
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,9 +204,12 @@ func fmtAPIError(statusCode int, title, detail *string) error {
 	return fmt.Errorf("%s", msg)
 }
 
-// apiErrFromResp returns an error whenever the response status is 4xx/5xx,
-// safely handling the case where the SDK did not populate an error body.
+// apiErrFromResp returns an error for 4xx/5xx status codes, safely handling
+// the case where the SDK did not populate an error body. Returns nil for 2xx/3xx.
 func apiErrFromResp(statusCode int, errResp *types.ErrorResponse) error {
+	if statusCode < 400 {
+		return nil
+	}
 	if errResp != nil {
 		return fmtAPIError(statusCode, errResp.Title, errResp.Detail)
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -356,6 +356,10 @@ func TestFmtAPIError_And_APIErrFromResp(t *testing.T) {
 			want:    "API error (status 404)",
 		},
 		{
+			name: "apiErrFromResp 2xx returns nil",
+			errFunc: func() error { return apiErrFromResp(200, nil) },
+		},
+		{
 			name: "apiErrFromResp with errResp",
 			errFunc: func() error {
 				return apiErrFromResp(404, &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")})
@@ -366,6 +370,12 @@ func TestFmtAPIError_And_APIErrFromResp(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.errFunc()
+			if tc.want == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got %q", err.Error())
+				}
+				return
+			}
 			if err == nil {
 				t.Fatal("expected non-nil error")
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -356,7 +356,7 @@ func TestFmtAPIError_And_APIErrFromResp(t *testing.T) {
 			want:    "API error (status 404)",
 		},
 		{
-			name: "apiErrFromResp 2xx returns nil",
+			name:    "apiErrFromResp 2xx returns nil",
 			errFunc: func() error { return apiErrFromResp(200, nil) },
 		},
 		{

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 // Helper function to check if a string contains a substring (case-insensitive)
@@ -317,5 +319,62 @@ func TestGetArubaClient_CredentialChange(t *testing.T) {
 	// Should be different instances (cache invalidated due to credential change)
 	if client1 == client2 {
 		t.Error("GetArubaClient() should return new client when credentials change")
+	}
+}
+
+func TestFmtAPIError_And_APIErrFromResp(t *testing.T) {
+	tests := []struct {
+		name    string
+		errFunc func() error
+		want    string
+		notWant string
+	}{
+		{
+			name:    "fmtAPIError nil title and detail",
+			errFunc: func() error { return fmtAPIError(404, nil, nil) },
+			want:    "API error (status 404)",
+			notWant: ":",
+		},
+		{
+			name:    "fmtAPIError with title only",
+			errFunc: func() error { return fmtAPIError(500, strPtr("Bad Gateway"), nil) },
+			want:    "API error (status 500): Bad Gateway",
+		},
+		{
+			name:    "fmtAPIError with detail only",
+			errFunc: func() error { return fmtAPIError(502, nil, strPtr("upstream timeout")) },
+			want:    "API error (status 502) \u2014 upstream timeout",
+		},
+		{
+			name:    "fmtAPIError with title and detail",
+			errFunc: func() error { return fmtAPIError(404, strPtr("Not Found"), strPtr("resource not found")) },
+			want:    "API error (status 404): Not Found \u2014 resource not found",
+		},
+		{
+			name:    "apiErrFromResp nil errResp",
+			errFunc: func() error { return apiErrFromResp(404, nil) },
+			want:    "API error (status 404)",
+		},
+		{
+			name: "apiErrFromResp with errResp",
+			errFunc: func() error {
+				return apiErrFromResp(404, &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")})
+			},
+			want: "API error (status 404): Not Found \u2014 resource not found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.errFunc()
+			if err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("got %q, want substring %q", err.Error(), tc.want)
+			}
+			if tc.notWant != "" && strings.Contains(err.Error(), tc.notWant) {
+				t.Errorf("got %q, but should not contain %q", err.Error(), tc.notWant)
+			}
+		})
 	}
 }

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -183,8 +183,8 @@ The job is enabled by default; pass --enabled=false to create it disabled.`,
 			return fmt.Errorf("creating job: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -259,8 +259,8 @@ var jobGetCmd = &cobra.Command{
 			return fmt.Errorf("getting job: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -338,8 +338,8 @@ var jobListCmd = &cobra.Command{
 			return fmt.Errorf("listing jobs: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -486,8 +486,8 @@ var jobUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating job: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -551,8 +551,8 @@ var jobDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting job: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Job", jobID))

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -547,9 +547,12 @@ var jobDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromSchedule().Jobs().Delete(ctx, projectID, jobID, nil)
+		deleteResp, err := client.FromSchedule().Jobs().Delete(ctx, projectID, jobID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting job: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Job", jobID))

--- a/cmd/schedule.job_test.go
+++ b/cmd/schedule.job_test.go
@@ -60,7 +60,7 @@ func TestJobListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestJobGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestJobCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestJobDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/schedule.job_test.go
+++ b/cmd/schedule.job_test.go
@@ -49,6 +49,19 @@ func TestJobListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockJobsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.JobList], error) {
+					return &types.Response[types.JobList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestJobGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockJobsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.JobResponse], error) {
+					return &types.Response[types.JobResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestJobCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"schedule", "job", "create", "--project-id", "proj-123", "--name", "my-job", "--region", "IT-BG", "--job-type", "OneShot", "--schedule-at", "2026-06-01T10:00:00Z"},
+			setupMock: func(m *mockJobsClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.JobRequest, _ *types.RequestParameters) (*types.Response[types.JobResponse], error) {
+					return &types.Response[types.JobResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestJobDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockJobsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -134,8 +134,8 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating KMS: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -203,8 +203,8 @@ var kmsGetCmd = &cobra.Command{
 			return fmt.Errorf("getting KMS: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil {
@@ -271,8 +271,8 @@ var kmsListCmd = &cobra.Command{
 			return fmt.Errorf("listing KMS: %w", err)
 		}
 
-		if resp != nil && resp.IsError() && resp.Error != nil {
-			return fmtAPIError(resp.StatusCode, resp.Error.Title, resp.Error.Detail)
+		if resp != nil && resp.IsError() {
+			return apiErrFromResp(resp.StatusCode, resp.Error)
 		}
 
 		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
@@ -394,8 +394,8 @@ var kmsUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating KMS: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -189,14 +189,14 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating backup: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
+		if response != nil && response.IsError() {
 			if verbose && response.RawBody != nil {
 				var errorDetail map[string]interface{}
 				if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
 					fmt.Printf("Full Error Response: %+v\n", errorDetail)
 				}
 			}
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response.Data != nil {
@@ -234,8 +234,8 @@ var storageBackupListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing backups: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -300,8 +300,8 @@ var storageBackupGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting backup details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -454,8 +454,8 @@ var storageBackupUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating backup: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -518,8 +518,8 @@ var storageBackupDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting backup: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Backup", backupID))

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -234,6 +234,9 @@ var storageBackupListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing backups: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -296,6 +299,9 @@ var storageBackupGetCmd = &cobra.Command{
 		response, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
 		if err != nil {
 			return fmt.Errorf("getting backup details: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -508,9 +514,12 @@ var storageBackupDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromStorage().Backups().Delete(ctx, projectID, backupID, nil)
+		deleteResp, err := client.FromStorage().Backups().Delete(ctx, projectID, backupID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting backup: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Backup", backupID))

--- a/cmd/storage.backup_test.go
+++ b/cmd/storage.backup_test.go
@@ -72,7 +72,7 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 				}, nil
 			}),
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -139,7 +139,7 @@ func TestStorageBackupListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -195,7 +195,7 @@ func TestStorageBackupGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -247,7 +247,7 @@ func TestStorageBackupDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.backup_test.go
+++ b/cmd/storage.backup_test.go
@@ -62,6 +62,18 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: createArgs,
+			storageMock: newStorageBackupCreateMock(func(_ context.Context, _ string, _ types.StorageBackupRequest, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
+				return &types.Response[types.StorageBackupResponse]{
+					StatusCode: 404,
+					Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+				}, nil
+			}),
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -116,6 +128,19 @@ func TestStorageBackupListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockStorageBackupsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
+					return &types.Response[types.StorageBackupList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -159,6 +184,19 @@ func TestStorageBackupGetCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "getting",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockStorageBackupsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
+					return &types.Response[types.StorageBackupResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -197,6 +235,19 @@ func TestStorageBackupDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockStorageBackupsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -279,6 +279,9 @@ var blockstorageGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting block storage details: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil {
 			volume := response.Data
@@ -509,9 +512,12 @@ var blockstorageDeleteCmd = &cobra.Command{
 		}
 
 		// Delete the block storage using the SDK
-		_, err = client.FromStorage().Volumes().Delete(ctx, projectID, volumeID, nil)
+		deleteResp, err := client.FromStorage().Volumes().Delete(ctx, projectID, volumeID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting block storage: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Block storage", volumeID))
@@ -545,6 +551,9 @@ var blockstorageListCmd = &cobra.Command{
 		response, err := client.FromStorage().Volumes().List(ctx, projectID, listParams(cmd))
 		if err != nil {
 			return fmt.Errorf("listing block storage: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		// Debug output

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -279,8 +279,8 @@ var blockstorageGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting block storage details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -516,8 +516,8 @@ var blockstorageDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting block storage: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Block storage", volumeID))
@@ -552,8 +552,8 @@ var blockstorageListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing block storage: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		// Debug output

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -60,7 +60,7 @@ func TestBlockStorageListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -116,7 +116,7 @@ func TestBlockStorageGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -188,7 +188,7 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -239,7 +239,7 @@ func TestBlockStorageDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -49,6 +49,19 @@ func TestBlockStorageListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVolumesClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
+					return &types.Response[types.BlockStorageList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,6 +104,19 @@ func TestBlockStorageGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVolumesClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
+					return &types.Response[types.BlockStorageResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -150,6 +176,20 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{"storage", "blockstorage", "create", "--project-id", "proj-123", "--name", "my-vol", "--region", "ITBG-Bergamo", "--size", "10"},
+			setupMock: func(m *mockVolumesClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.BlockStorageRequest, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
+					return &types.Response[types.BlockStorageResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -187,6 +227,19 @@ func TestBlockStorageDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockVolumesClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -239,6 +239,9 @@ var storageRestoreListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing restores: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 			headers := []TableColumn{
@@ -299,6 +302,9 @@ var storageRestoreGetCmd = &cobra.Command{
 		response, err := client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)
 		if err != nil {
 			return fmt.Errorf("getting restore details: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		if response != nil && response.Data != nil {
@@ -494,9 +500,12 @@ var storageRestoreDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = client.FromStorage().Restores().Delete(ctx, projectID, backupID, restoreID, nil)
+		deleteResp, err := client.FromStorage().Restores().Delete(ctx, projectID, backupID, restoreID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting restore: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Restore operation", restoreID))

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -190,14 +190,14 @@ idle before starting a restore to avoid data corruption.`,
 			return fmt.Errorf("creating restore: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
+		if response != nil && response.IsError() {
 			if verbose && response.RawBody != nil {
 				var errorDetail map[string]interface{}
 				if err := json.Unmarshal(response.RawBody, &errorDetail); err == nil {
 					fmt.Printf("Full Error Response: %+v\n", errorDetail)
 				}
 			}
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response.Data != nil {
@@ -239,8 +239,8 @@ var storageRestoreListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing restores: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
@@ -303,8 +303,8 @@ var storageRestoreGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting restore details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -439,8 +439,8 @@ var storageRestoreUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating restore: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -504,8 +504,8 @@ var storageRestoreDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting restore: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Restore operation", restoreID))

--- a/cmd/storage.restore_test.go
+++ b/cmd/storage.restore_test.go
@@ -71,6 +71,18 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: createArgs,
+			storageMock: newStorageRestoreCreateMock(func(_ context.Context, _, _ string, _ types.RestoreRequest, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
+				return &types.Response[types.RestoreResponse]{
+					StatusCode: 404,
+					Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+				}, nil
+			}),
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -125,6 +137,19 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockStorageRestoreClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
+					return &types.Response[types.RestoreList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -168,6 +193,19 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "getting",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockStorageRestoreClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
+					return &types.Response[types.RestoreResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -206,6 +244,19 @@ func TestStorageRestoreDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockStorageRestoreClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.restore_test.go
+++ b/cmd/storage.restore_test.go
@@ -81,7 +81,7 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 				}, nil
 			}),
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -148,7 +148,7 @@ func TestStorageRestoreListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -204,7 +204,7 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -256,7 +256,7 @@ func TestStorageRestoreDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -212,6 +212,9 @@ var snapshotGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting snapshot details: %w", err)
 		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		}
 
 		if response != nil && response.Data != nil {
 			snapshot := response.Data
@@ -434,9 +437,12 @@ var snapshotDeleteCmd = &cobra.Command{
 		}
 
 		// Delete the snapshot using the SDK
-		_, err = client.FromStorage().Snapshots().Delete(ctx, projectID, snapshotID, nil)
+		deleteResp, err := client.FromStorage().Snapshots().Delete(ctx, projectID, snapshotID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting snapshot: %w", err)
+		}
+		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
+			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
 		}
 
 		fmt.Println(msgDeleted("Snapshot", snapshotID))
@@ -470,6 +476,9 @@ var snapshotListCmd = &cobra.Command{
 		response, err := client.FromStorage().Snapshots().List(ctx, projectID, listParams(cmd))
 		if err != nil {
 			return fmt.Errorf("listing snapshots: %w", err)
+		}
+		if response != nil && response.IsError() && response.Error != nil {
+			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
 		}
 
 		// Check verbose flag

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -164,8 +164,8 @@ or restore data with 'acloud storage blockstorage create --snapshot-uri'.`,
 			return fmt.Errorf("creating snapshot: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -212,8 +212,8 @@ var snapshotGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting snapshot details: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -368,8 +368,8 @@ var snapshotUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating snapshot: %w", err)
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		if response != nil && response.Data != nil {
@@ -441,8 +441,8 @@ var snapshotDeleteCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("deleting snapshot: %w", err)
 		}
-		if deleteResp != nil && deleteResp.IsError() && deleteResp.Error != nil {
-			return fmtAPIError(deleteResp.StatusCode, deleteResp.Error.Title, deleteResp.Error.Detail)
+		if deleteResp != nil && deleteResp.IsError() {
+			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
 		}
 
 		fmt.Println(msgDeleted("Snapshot", snapshotID))
@@ -477,8 +477,8 @@ var snapshotListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing snapshots: %w", err)
 		}
-		if response != nil && response.IsError() && response.Error != nil {
-			return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
+		if response != nil && response.IsError() {
+			return apiErrFromResp(response.StatusCode, response.Error)
 		}
 
 		// Check verbose flag

--- a/cmd/storage.snapshot_test.go
+++ b/cmd/storage.snapshot_test.go
@@ -60,7 +60,7 @@ func TestSnapshotListCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -117,7 +117,7 @@ func TestSnapshotGetCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -205,7 +205,7 @@ func TestSnapshotCreateCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
@@ -256,7 +256,7 @@ func TestSnapshotDeleteCmd(t *testing.T) {
 				}
 			},
 			wantErr:     true,
-			errContains: "API error",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/storage.snapshot_test.go
+++ b/cmd/storage.snapshot_test.go
@@ -49,6 +49,19 @@ func TestSnapshotListCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "listing",
 		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSnapshotsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
+					return &types.Response[types.SnapshotList]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -92,6 +105,19 @@ func TestSnapshotGetCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSnapshotsClient) {
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
+					return &types.Response[types.SnapshotResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {
@@ -161,6 +187,26 @@ func TestSnapshotCreateCmd(t *testing.T) {
 			wantErr:     true,
 			errContains: "creating",
 		},
+		{
+			name: "API error propagates",
+			args: []string{
+				"storage", "snapshot", "create",
+				"--project-id", "proj-123",
+				"--name", "my-snapshot",
+				"--region", "IT-BG",
+				"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001",
+			},
+			setupMock: func(m *mockSnapshotsClient) {
+				m.createFn = func(_ context.Context, _ string, _ types.SnapshotRequest, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
+					return &types.Response[types.SnapshotResponse]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -198,6 +244,19 @@ func TestSnapshotDeleteCmd(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			setupMock: func(m *mockSnapshotsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					return &types.Response[any]{
+						StatusCode: 404,
+						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
+					}, nil
+				}
+			},
+			wantErr:     true,
+			errContains: "API error",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Adds one `API error propagates` test case to every `list`, `get`, `create`, `delete`, and action command test function across all 24 test files (~84 test functions)
- Each case injects `&types.Response{StatusCode: 404, Error: &types.ErrorResponse{...}}` — the path exercised by `response.IsError()` which was previously untested
- As a side effect, discovered and fixed missing `IsError` guards in 15 command handlers that were silently ignoring API errors (printing "deleted successfully" even on a 404)

## Coverage

| Before | After | Delta |
|--------|-------|-------|
| 51.8% | 59.6% | +7.8 pp |

## Files changed

- **40 files**: 24 `_test.go` files (test cases added) + 16 `cmd/*.go` files (missing `IsError` guards added to delete/list/get handlers)

Closes #61, part of epic #65.

## Test plan

- [x] `go test ./cmd/...` — 0 failures
- [x] Coverage measured at 59.6%

🤖 Generated with [Claude Code](https://claude.com/claude-code)