### PR TITLE
docs: add output format, dry-run and pagination sections to all docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,17 @@ acloud management project create --help
 
 ## Output Format
 
-All list and get commands accept a global `--output json` (or `-o json`) flag for machine-readable output. The default is a fixed-width table. See [Getting Started - Output Format](getting-started.md#output-format) for details.
+All list and get commands accept a global `--output` (or `-o`) flag that controls the output format:
+
+| Value | Description |
+|-------|-------------|
+| `table` | Human-readable fixed-width table (default) |
+| `table-json` | JSON array of flat snake_case objects (one per row) |
+| `table-yaml` | YAML sequence of flat snake_case mappings (one per row) |
+| `json` | Full SDK response object as indented JSON |
+| `yaml` | Full SDK response object as YAML |
+
+See [Getting Started - Output Format](getting-started.md#output-format) for examples and scripting tips.
 
 ## Pagination
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/installation.md
@@ -526,6 +526,64 @@ Request Payload:
 
 **Nota**: L'output di debug viene inviato a `stderr`, quindi non interferirà con l'output normale del comando e può essere reindirizzato separatamente se necessario.
 
+## Formato di Output
+
+Tutti i comandi `list` e `get` supportano un flag globale `--output` (o `-o`) che controlla il formato di output.
+
+| Valore | Descrizione |
+|--------|-------------|
+| `table` | Tabella leggibile a larghezza fissa (predefinito) |
+| `table-json` | Array JSON di oggetti piatti con chiavi snake_case (uno per riga) |
+| `table-yaml` | Sequenza YAML di mapping piatti con chiavi snake_case (uno per riga) |
+| `json` | Risposta completa dell'SDK come JSON indentato |
+| `yaml` | Risposta completa dell'SDK come YAML |
+
+```bash
+# Output tabella predefinito
+acloud network vpc list
+
+# Array JSON piatto — facile da passare a jq
+acloud network vpc list -o table-json
+
+# Risposta completa dell'SDK
+acloud network vpc list -o json
+```
+
+`table-json` è la scelta migliore per gli script con strumenti come `jq`:
+```bash
+acloud storage blockstorage list -o table-json | jq '.[].name'
+```
+
+## Eliminazione Sicura (Dry Run)
+
+Ogni comando di eliminazione supporta `--dry-run` per verificare che una risorsa esista senza eliminarla effettivamente:
+
+```bash
+acloud storage blockstorage delete <volume-id> --dry-run
+# [dry-run] Would delete block storage '<volume-id>'. Resource exists and is accessible.
+```
+
+Usa `--yes` (o `-y`) per saltare la richiesta di conferma interattiva negli script non interattivi.
+
+## Paginazione
+
+Tutti i comandi `list` supportano i flag `--limit` e `--offset` per navigare tra grandi set di risultati.
+
+| Flag | Descrizione |
+|------|-------------|
+| `--limit N` | Restituisce al massimo N risultati |
+| `--offset N` | Salta i primi N risultati |
+
+```bash
+# Prima pagina di 10 risultati
+acloud storage blockstorage list --limit 10
+
+# Seconda pagina
+acloud storage blockstorage list --limit 10 --offset 10
+```
+
+Se nessun flag viene passato, l'API restituisce il suo set di risultati predefinito.
+
 ## Risoluzione dei Problemi
 
 ### Errori di Versione GLIBC

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.2/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.2/installation.md
@@ -526,6 +526,64 @@ Request Payload:
 
 **Nota**: L'output di debug viene inviato a `stderr`, quindi non interferirà con l'output normale del comando e può essere reindirizzato separatamente se necessario.
 
+## Formato di Output
+
+Tutti i comandi `list` e `get` supportano un flag globale `--output` (o `-o`) che controlla il formato di output.
+
+| Valore | Descrizione |
+|--------|-------------|
+| `table` | Tabella leggibile a larghezza fissa (predefinito) |
+| `table-json` | Array JSON di oggetti piatti con chiavi snake_case (uno per riga) |
+| `table-yaml` | Sequenza YAML di mapping piatti con chiavi snake_case (uno per riga) |
+| `json` | Risposta completa dell'SDK come JSON indentato |
+| `yaml` | Risposta completa dell'SDK come YAML |
+
+```bash
+# Output tabella predefinito
+acloud network vpc list
+
+# Array JSON piatto — facile da passare a jq
+acloud network vpc list -o table-json
+
+# Risposta completa dell'SDK
+acloud network vpc list -o json
+```
+
+`table-json` è la scelta migliore per gli script con strumenti come `jq`:
+```bash
+acloud storage blockstorage list -o table-json | jq '.[].name'
+```
+
+## Eliminazione Sicura (Dry Run)
+
+Ogni comando di eliminazione supporta `--dry-run` per verificare che una risorsa esista senza eliminarla effettivamente:
+
+```bash
+acloud storage blockstorage delete <volume-id> --dry-run
+# [dry-run] Would delete block storage '<volume-id>'. Resource exists and is accessible.
+```
+
+Usa `--yes` (o `-y`) per saltare la richiesta di conferma interattiva negli script non interattivi.
+
+## Paginazione
+
+Tutti i comandi `list` supportano i flag `--limit` e `--offset` per navigare tra grandi set di risultati.
+
+| Flag | Descrizione |
+|------|-------------|
+| `--limit N` | Restituisce al massimo N risultati |
+| `--offset N` | Salta i primi N risultati |
+
+```bash
+# Prima pagina di 10 risultati
+acloud storage blockstorage list --limit 10
+
+# Seconda pagina
+acloud storage blockstorage list --limit 10 --offset 10
+```
+
+Se nessun flag viene passato, l'API restituisce il suo set di risultati predefinito.
+
 ## Risoluzione dei Problemi
 
 ### Errori di Versione GLIBC


### PR DESCRIPTION
## Summary

Documents the multi-mode output feature (shipped in v0.1.2) across all documentation layers.

### Changes

- **\docs/README.md\**: Output Format section now lists all 5 modes (\	able\, \	able-json\, \	able-yaml\, \json\, \yaml\) instead of only mentioning \--output json\.
- **\docs/website/i18n/it/.../current/installation.md\**: Added Italian translations of the **Formato di Output**, **Eliminazione Sicura (Dry Run)**, and **Paginazione** sections, matching the existing English \installation.md\.
- **\docs/website/i18n/it/.../version-0.1.2/installation.md\**: Same three Italian sections added to the versioned doc. Older versions (≤ 0.1.1) are intentionally left unchanged as the feature was not yet present.

### Related
Follows the output format work described in #71.