### PR TITLE
test: add output assertions and cover --dry-run / --output=json flags…

### DIFF
--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ func TestCloudServerListCmd(t *testing.T) {
 		setupMock   func(*mockCloudServersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -29,6 +31,11 @@ func TestCloudServerListCmd(t *testing.T) {
 							},
 						},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cs-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -54,6 +61,28 @@ func TestCloudServerListCmd(t *testing.T) {
 							},
 						},
 					}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockCloudServersClient) {
+				id, name := "cs-001", "my-server"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
+					return &types.Response[types.CloudServerList]{
+						StatusCode: 200,
+						Data: &types.CloudServerList{
+							Values: []types.CloudServerResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -87,8 +116,15 @@ func TestCloudServerListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "list", "--project-id", "proj-123"})
+			args := []string{"compute", "cloudserver", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withCompute(m)), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -99,6 +135,7 @@ func TestCloudServerGetCmd(t *testing.T) {
 		setupMock   func(*mockCloudServersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -109,6 +146,11 @@ func TestCloudServerGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.CloudServerResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cs-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -142,8 +184,11 @@ func TestCloudServerGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "get", "cs-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "get", "cs-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -168,6 +213,7 @@ func TestCloudServerCreateCmd(t *testing.T) {
 		setupMock   func(*mockCloudServersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -179,6 +225,11 @@ func TestCloudServerCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.CloudServerResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cs-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -226,8 +277,11 @@ func TestCloudServerCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withCompute(m)), tc.args)
+			out, err := runCmdCapture(newMockClient(withCompute(m)), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -238,12 +292,32 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 		setupMock   func(*mockCloudServersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockCloudServersClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cs-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockCloudServersClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cs-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -277,8 +351,15 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "delete", "cs-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"compute", "cloudserver", "delete", "cs-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withCompute(m)), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestKeyPairListCmd(t *testing.T) {
 		setupMock   func(*mockKeyPairsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -28,6 +31,11 @@ func TestKeyPairListCmd(t *testing.T) {
 							},
 						},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -53,6 +61,28 @@ func TestKeyPairListCmd(t *testing.T) {
 							},
 						},
 					}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockKeyPairsClient) {
+				kpID, kpName := "kp-001", "my-kp"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
+					return &types.Response[types.KeyPairListResponse]{
+						StatusCode: 200,
+						Data: &types.KeyPairListResponse{
+							Values: []types.KeyPairResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -86,9 +116,15 @@ func TestKeyPairListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})),
-				[]string{"compute", "keypair", "list", "--project-id", "proj-123"})
+			args := []string{"compute", "keypair", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -99,6 +135,7 @@ func TestKeyPairGetCmd(t *testing.T) {
 		setupMock   func(*mockKeyPairsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -109,6 +146,11 @@ func TestKeyPairGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.KeyPairResponse{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-kp") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
@@ -142,9 +184,12 @@ func TestKeyPairGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})),
+			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})),
 				[]string{"compute", "keypair", "get", "kp-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -156,6 +201,7 @@ func TestKeyPairCreateCmd(t *testing.T) {
 		setupMock   func(*mockKeyPairsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -167,6 +213,11 @@ func TestKeyPairCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.KeyPairResponse{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-kp") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
@@ -214,8 +265,11 @@ func TestKeyPairCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -226,12 +280,32 @@ func TestKeyPairDeleteCmd(t *testing.T) {
 		setupMock   func(*mockKeyPairsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockKeyPairsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockKeyPairsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kp-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -265,9 +339,15 @@ func TestKeyPairDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})),
-				[]string{"compute", "keypair", "delete", "kp-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"compute", "keypair", "delete", "kp-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/container.containerregistry_test.go
+++ b/cmd/container.containerregistry_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestContainerRegistryListCmd(t *testing.T) {
 		setupMock   func(*mockContainerRegistryClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestContainerRegistryListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cr-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockContainerRegistryClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
 					return &types.Response[types.ContainerRegistryList]{StatusCode: 200, Data: &types.ContainerRegistryList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockContainerRegistryClient) {
+				id, name := "cr-001", "my-registry"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
+					return &types.Response[types.ContainerRegistryList]{
+						StatusCode: 200,
+						Data: &types.ContainerRegistryList{
+							Values: []types.ContainerRegistryResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestContainerRegistryListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})),
-				[]string{"container", "containerregistry", "list", "--project-id", "proj-123"})
+			args := []string{"container", "containerregistry", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestContainerRegistryGetCmd(t *testing.T) {
 		setupMock   func(*mockContainerRegistryClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestContainerRegistryGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.ContainerRegistryResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cr-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestContainerRegistryGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})),
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})),
 				[]string{"container", "containerregistry", "get", "cr-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -150,6 +195,7 @@ func TestContainerRegistryCreateCmd(t *testing.T) {
 		setupMock   func(*mockContainerRegistryClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -161,6 +207,11 @@ func TestContainerRegistryCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.ContainerRegistryResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cr-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -208,8 +259,11 @@ func TestContainerRegistryCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -220,12 +274,36 @@ func TestContainerRegistryDeleteCmd(t *testing.T) {
 		setupMock   func(*mockContainerRegistryClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockContainerRegistryClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cr-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockContainerRegistryClient) {
+				id, name := "cr-001", "my-registry"
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
+					return &types.Response[types.ContainerRegistryResponse]{StatusCode: 200, Data: &types.ContainerRegistryResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cr-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -259,9 +337,15 @@ func TestContainerRegistryDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})),
-				[]string{"container", "containerregistry", "delete", "cr-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"container", "containerregistry", "delete", "cr-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{containerRegistryClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/container.kaas_test.go
+++ b/cmd/container.kaas_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestKaaSListCmd(t *testing.T) {
 		setupMock   func(*mockKaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestKaaSListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kaas-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockKaaSClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KaaSList], error) {
 					return &types.Response[types.KaaSList]{StatusCode: 200, Data: &types.KaaSList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockKaaSClient) {
+				id, name := "kaas-001", "my-cluster"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KaaSList], error) {
+					return &types.Response[types.KaaSList]{
+						StatusCode: 200,
+						Data: &types.KaaSList{
+							Values: []types.KaaSResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestKaaSListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{kaasClient: m})),
-				[]string{"container", "kaas", "list", "--project-id", "proj-123"})
+			args := []string{"container", "kaas", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{kaasClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestKaaSGetCmd(t *testing.T) {
 		setupMock   func(*mockKaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestKaaSGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.KaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kaas-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestKaaSGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{kaasClient: m})),
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{kaasClient: m})),
 				[]string{"container", "kaas", "get", "kaas-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -155,6 +200,7 @@ func TestKaaSCreateCmd(t *testing.T) {
 		setupMock   func(*mockKaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -166,6 +212,11 @@ func TestKaaSCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.KaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kaas-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -207,8 +258,11 @@ func TestKaaSCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{kaasClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{kaasClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -219,12 +273,36 @@ func TestKaaSDeleteCmd(t *testing.T) {
 		setupMock   func(*mockKaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockKaaSClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kaas-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockKaaSClient) {
+				id, name := "kaas-001", "my-cluster"
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KaaSResponse], error) {
+					return &types.Response[types.KaaSResponse]{StatusCode: 200, Data: &types.KaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kaas-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -258,9 +336,15 @@ func TestKaaSDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withContainer(&mockContainerClient{kaasClient: m})),
-				[]string{"container", "kaas", "delete", "kaas-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"container", "kaas", "delete", "kaas-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withContainer(&mockContainerClient{kaasClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestDBBackupListCmd(t *testing.T) {
 		setupMock   func(*mockDBBackupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestDBBackupListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockDBBackupsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
 					return &types.Response[types.BackupList]{StatusCode: 200, Data: &types.BackupList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockDBBackupsClient) {
+				id, name := "bkp-001", "my-backup"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
+					return &types.Response[types.BackupList]{
+						StatusCode: 200,
+						Data: &types.BackupList{
+							Values: []types.BackupResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestDBBackupListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})),
-				[]string{"database", "backup", "list", "--project-id", "proj-123"})
+			args := []string{"database", "backup", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestDBBackupGetCmd(t *testing.T) {
 		setupMock   func(*mockDBBackupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestDBBackupGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.BackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestDBBackupGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})),
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})),
 				[]string{"database", "backup", "get", "bkp-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -162,6 +207,7 @@ func TestDBBackupCreateCmd(t *testing.T) {
 		dbMock      *mockDatabaseClient
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -173,6 +219,11 @@ func TestDBBackupCreateCmd(t *testing.T) {
 					Data:       &types.BackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &bname}},
 				}, nil
 			}),
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-new") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name:        "missing required flag --name",
@@ -214,8 +265,11 @@ func TestDBBackupCreateCmd(t *testing.T) {
 			if dbMock == nil {
 				dbMock = &mockDatabaseClient{}
 			}
-			err := runCmd(newMockClient(withDatabase(dbMock)), tc.args)
+			out, err := runCmdCapture(newMockClient(withDatabase(dbMock)), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -226,12 +280,36 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 		setupMock   func(*mockDBBackupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockDBBackupsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockDBBackupsClient) {
+				id, name := "bkp-001", "my-backup"
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
+					return &types.Response[types.BackupResponse]{StatusCode: 200, Data: &types.BackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -265,9 +343,15 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})),
-				[]string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 		setupMock   func(*mockDatabasesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -29,12 +32,38 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-db") {
+					t.Errorf("expected name in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockDatabasesClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
 					return &types.Response[types.DatabaseList]{StatusCode: 200, Data: &types.DatabaseList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockDatabasesClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
+					return &types.Response[types.DatabaseList]{
+						StatusCode: 200,
+						Data: &types.DatabaseList{
+							Values: []types.DatabaseResponse{
+								{Name: "my-db"},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -68,9 +97,15 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})),
-				[]string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"})
+			args := []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -81,6 +116,7 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 		setupMock   func(*mockDatabasesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -90,6 +126,11 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.DatabaseResponse{Name: "my-db"},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-db") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
@@ -123,9 +164,12 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})),
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})),
 				[]string{"database", "dbaas", "database", "get", "dbaas-001", "my-db", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -137,6 +181,7 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 		setupMock   func(*mockDatabasesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -147,6 +192,11 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.DatabaseResponse{Name: "my-db"},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-db") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
@@ -188,8 +238,11 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -200,12 +253,35 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 		setupMock   func(*mockDatabasesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockDatabasesClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-db") {
+					t.Errorf("expected name in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockDatabasesClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
+					return &types.Response[types.DatabaseResponse]{StatusCode: 200, Data: &types.DatabaseResponse{Name: "my-db"}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-db") {
+					t.Errorf("expected name in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -239,9 +315,15 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})),
-				[]string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes"})
+			args := []string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestDBaaSUserListCmd(t *testing.T) {
 		setupMock   func(*mockUsersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -29,12 +32,38 @@ func TestDBaaSUserListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "admin") {
+					t.Errorf("expected username in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockUsersClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
 					return &types.Response[types.UserList]{StatusCode: 200, Data: &types.UserList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockUsersClient) {
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
+					return &types.Response[types.UserList]{
+						StatusCode: 200,
+						Data: &types.UserList{
+							Values: []types.UserResponse{
+								{Username: "admin"},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -68,9 +97,15 @@ func TestDBaaSUserListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})),
-				[]string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"})
+			args := []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -81,6 +116,7 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 		setupMock   func(*mockUsersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -90,6 +126,11 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.UserResponse{Username: "admin"},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "admin") {
+					t.Errorf("expected username in output, got: %s", out)
 				}
 			},
 		},
@@ -123,9 +164,12 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})),
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})),
 				[]string{"database", "dbaas", "user", "get", "dbaas-001", "admin", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -137,6 +181,7 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 		setupMock   func(*mockUsersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -147,6 +192,11 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.UserResponse{Username: "myuser"},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "myuser") {
+					t.Errorf("expected username in output, got: %s", out)
 				}
 			},
 		},
@@ -194,8 +244,11 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -206,12 +259,35 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 		setupMock   func(*mockUsersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockUsersClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "myuser") {
+					t.Errorf("expected username in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockUsersClient) {
+				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
+					return &types.Response[types.UserResponse]{StatusCode: 200, Data: &types.UserResponse{Username: "myuser"}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "myuser") {
+					t.Errorf("expected username in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -245,9 +321,15 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})),
-				[]string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes"})
+			args := []string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/database.dbaas_test.go
+++ b/cmd/database.dbaas_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestDBaaSListCmd(t *testing.T) {
 		setupMock   func(*mockDBaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestDBaaSListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "dbaas-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockDBaaSClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
 					return &types.Response[types.DBaaSList]{StatusCode: 200, Data: &types.DBaaSList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockDBaaSClient) {
+				id, name := "dbaas-001", "my-dbaas"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
+					return &types.Response[types.DBaaSList]{
+						StatusCode: 200,
+						Data: &types.DBaaSList{
+							Values: []types.DBaaSResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestDBaaSListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})),
-				[]string{"database", "dbaas", "list", "--project-id", "proj-123"})
+			args := []string{"database", "dbaas", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestDBaaSGetCmd(t *testing.T) {
 		setupMock   func(*mockDBaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestDBaaSGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "dbaas-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestDBaaSGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})),
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})),
 				[]string{"database", "dbaas", "get", "dbaas-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestDBaaSCreateCmd(t *testing.T) {
 		setupMock   func(*mockDBaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestDBaaSCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "dbaas-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -197,8 +248,11 @@ func TestDBaaSCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -209,12 +263,36 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 		setupMock   func(*mockDBaaSClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockDBaaSClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "dbaas-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockDBaaSClient) {
+				id, name := "dbaas-001", "my-dbaas"
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
+					return &types.Response[types.DBaaSResponse]{StatusCode: 200, Data: &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "dbaas-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -248,9 +326,15 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})),
-				[]string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/management.project_test.go
+++ b/cmd/management.project_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestProjectListCmd(t *testing.T) {
 		setupMock   func(*mockProjectClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestProjectListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "proj-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockProjectClient) {
 				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
 					return &types.Response[types.ProjectList]{StatusCode: 200, Data: &types.ProjectList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockProjectClient) {
+				id, name := "proj-001", "my-project"
+				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
+					return &types.Response[types.ProjectList]{
+						StatusCode: 200,
+						Data: &types.ProjectList{
+							Values: []types.ProjectResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,8 +99,15 @@ func TestProjectListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withProject(m)), []string{"management", "project", "list"})
+			args := []string{"management", "project", "list"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withProject(m)), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -81,6 +118,7 @@ func TestProjectGetCmd(t *testing.T) {
 		setupMock   func(*mockProjectClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -91,6 +129,11 @@ func TestProjectGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.ProjectResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "proj-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -124,8 +167,11 @@ func TestProjectGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withProject(m)), []string{"management", "project", "get", "proj-001"})
+			out, err := runCmdCapture(newMockClient(withProject(m)), []string{"management", "project", "get", "proj-001"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -137,6 +183,7 @@ func TestProjectCreateCmd(t *testing.T) {
 		setupMock   func(*mockProjectClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -148,6 +195,11 @@ func TestProjectCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.ProjectResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "proj-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -189,8 +241,11 @@ func TestProjectCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withProject(m)), tc.args)
+			out, err := runCmdCapture(newMockClient(withProject(m)), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -201,12 +256,39 @@ func TestProjectDeleteCmd(t *testing.T) {
 		setupMock   func(*mockProjectClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockProjectClient) {
 				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "proj-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockProjectClient) {
+				id, name := "proj-001", "my-project"
+				m.getFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
+					return &types.Response[types.ProjectResponse]{
+						StatusCode: 200,
+						Data:       &types.ProjectResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					}, nil
+				}
+				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "proj-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -240,8 +322,15 @@ func TestProjectDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withProject(m)), []string{"management", "project", "delete", "proj-001", "--yes"})
+			args := []string{"management", "project", "delete", "proj-001", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withProject(m)), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"os"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -1156,8 +1159,14 @@ func withSchedule(s *mockScheduleClient) func(*mockClient) {
 // a flag set in test N remains "seen" in test N+1, causing MarkFlagRequired
 // validation to pass even when the flag is absent.
 func resetCmdFlags(cmd *cobra.Command) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
-	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	resetFlagSet := func(f *pflag.Flag) {
+		f.Changed = false
+		if f.DefValue != "" {
+			_ = f.Value.Set(f.DefValue) //nolint:errcheck
+		}
+	}
+	cmd.Flags().VisitAll(resetFlagSet)
+	cmd.PersistentFlags().VisitAll(resetFlagSet)
 	for _, sub := range cmd.Commands() {
 		resetCmdFlags(sub)
 	}
@@ -1175,3 +1184,19 @@ func runCmd(mock aruba.Client, args []string) error {
 
 // errSDK returns a non-nil SDK error suitable for injection in test cases.
 func errSDK(msg string) error { return errors.New(msg) }
+
+// runCmdCapture executes rootCmd with the given args (via runCmd) and returns
+// everything written to os.Stdout during the call. Use this instead of runCmd
+// when a test needs to assert output content.
+func runCmdCapture(mock aruba.Client, args []string) (string, error) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	runErr := runCmd(mock, args)
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	r.Close()
+	return buf.String(), runErr
+}

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestElasticIPListCmd(t *testing.T) {
 		setupMock   func(*mockElasticIPsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestElasticIPListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "eip-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockElasticIPsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
 					return &types.Response[types.ElasticList]{StatusCode: 200, Data: &types.ElasticList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockElasticIPsClient) {
+				id, name := "eip-001", "my-eip"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
+					return &types.Response[types.ElasticList]{
+						StatusCode: 200,
+						Data: &types.ElasticList{
+							Values: []types.ElasticIPResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestElasticIPListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})),
-				[]string{"network", "elasticip", "list", "--project-id", "proj-123"})
+			args := []string{"network", "elasticip", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestElasticIPGetCmd(t *testing.T) {
 		setupMock   func(*mockElasticIPsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestElasticIPGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.ElasticIPResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "eip-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestElasticIPGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})),
 				[]string{"network", "elasticip", "get", "eip-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestElasticIPCreateCmd(t *testing.T) {
 		setupMock   func(*mockElasticIPsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestElasticIPCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.ElasticIPResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "eip-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -197,8 +248,11 @@ func TestElasticIPCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -209,12 +263,32 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 		setupMock   func(*mockElasticIPsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockElasticIPsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "eip-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockElasticIPsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "eip-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -248,9 +322,15 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})),
-				[]string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.loadbalancer_test.go
+++ b/cmd/network.loadbalancer_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestLoadBalancerListCmd(t *testing.T) {
 		setupMock   func(*mockLoadBalancersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestLoadBalancerListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "lb-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockLoadBalancersClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
 					return &types.Response[types.LoadBalancerList]{StatusCode: 200, Data: &types.LoadBalancerList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockLoadBalancersClient) {
+				id, name := "lb-001", "my-lb"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
+					return &types.Response[types.LoadBalancerList]{
+						StatusCode: 200,
+						Data: &types.LoadBalancerList{
+							Values: []types.LoadBalancerResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{loadBalancersMock: m})),
-				[]string{"network", "loadbalancer", "list", "--project-id", "proj-123"})
+			args := []string{"network", "loadbalancer", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{loadBalancersMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestLoadBalancerGetCmd(t *testing.T) {
 		setupMock   func(*mockLoadBalancersClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestLoadBalancerGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.LoadBalancerResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "lb-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -133,9 +175,12 @@ func TestLoadBalancerGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{loadBalancersMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{loadBalancersMock: m})),
 				[]string{"network", "loadbalancer", "get", "lb-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.securitygroup_test.go
+++ b/cmd/network.securitygroup_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestSecurityGroupListCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestSecurityGroupListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sg-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockSecurityGroupsClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
 					return &types.Response[types.SecurityGroupList]{StatusCode: 200, Data: &types.SecurityGroupList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockSecurityGroupsClient) {
+				id, name := "sg-001", "my-sg"
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
+					return &types.Response[types.SecurityGroupList]{
+						StatusCode: 200,
+						Data: &types.SecurityGroupList{
+							Values: []types.SecurityGroupResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})),
-				[]string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"})
+			args := []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SecurityGroupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sg-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})),
 				[]string{"network", "securitygroup", "get", "vpc-001", "sg-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SecurityGroupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sg-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -209,12 +260,32 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockSecurityGroupsClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sg-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockSecurityGroupsClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sg-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -248,9 +319,15 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})),
-				[]string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.securityrule_test.go
+++ b/cmd/network.securityrule_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestSecurityRuleListCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupRulesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestSecurityRuleListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rule-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockSecurityGroupRulesClient) {
 				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
 					return &types.Response[types.SecurityRuleList]{StatusCode: 200, Data: &types.SecurityRuleList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockSecurityGroupRulesClient) {
+				id, name := "rule-001", "my-rule"
+				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
+					return &types.Response[types.SecurityRuleList]{
+						StatusCode: 200,
+						Data: &types.SecurityRuleList{
+							Values: []types.SecurityRuleResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})),
-				[]string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"})
+			args := []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupRulesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SecurityRuleResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rule-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})),
 				[]string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -149,6 +194,7 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupRulesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -160,6 +206,11 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SecurityRuleResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rule-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -207,8 +258,11 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -219,12 +273,32 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 		setupMock   func(*mockSecurityGroupRulesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockSecurityGroupRulesClient) {
 				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rule-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockSecurityGroupRulesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rule-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -258,9 +332,15 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})),
-				[]string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.subnet_test.go
+++ b/cmd/network.subnet_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestSubnetListCmd(t *testing.T) {
 		setupMock   func(*mockSubnetsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestSubnetListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sub-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockSubnetsClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
 					return &types.Response[types.SubnetList]{StatusCode: 200, Data: &types.SubnetList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockSubnetsClient) {
+				id, name := "sub-001", "my-subnet"
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
+					return &types.Response[types.SubnetList]{
+						StatusCode: 200,
+						Data: &types.SubnetList{
+							Values: []types.SubnetResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestSubnetListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})),
-				[]string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"})
+			args := []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestSubnetGetCmd(t *testing.T) {
 		setupMock   func(*mockSubnetsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestSubnetGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SubnetResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sub-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestSubnetGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})),
 				[]string{"network", "subnet", "get", "vpc-001", "sub-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestSubnetCreateCmd(t *testing.T) {
 		setupMock   func(*mockSubnetsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestSubnetCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SubnetResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sub-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -197,8 +248,11 @@ func TestSubnetCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -209,12 +263,32 @@ func TestSubnetDeleteCmd(t *testing.T) {
 		setupMock   func(*mockSubnetsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockSubnetsClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sub-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockSubnetsClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sub-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -248,9 +322,15 @@ func TestSubnetDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})),
-				[]string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.vpc_test.go
+++ b/cmd/network.vpc_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ func TestVPCListCmd(t *testing.T) {
 		setupMock   func(*mockVPCsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -33,12 +35,38 @@ func TestVPCListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpc-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success with no results",
 			setupMock: func(m *mockVPCsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
 					return &types.Response[types.VPCList]{StatusCode: 200, Data: &types.VPCList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockVPCsClient) {
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
+					return &types.Response[types.VPCList]{
+						StatusCode: 200,
+						Data: &types.VPCList{
+							Values: []types.VPCResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -73,7 +101,11 @@ func TestVPCListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetwork(m)), []string{"network", "vpc", "list", "--project-id", "proj-123"})
+			args := []string{"network", "vpc", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetwork(m)), args)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -83,6 +115,9 @@ func TestVPCListCmd(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
 			}
 		})
 	}
@@ -97,6 +132,7 @@ func TestVPCGetCmd(t *testing.T) {
 		setupMock   func(*mockVPCsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -106,6 +142,11 @@ func TestVPCGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPCResponse{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpc-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -148,7 +189,7 @@ func TestVPCGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetwork(m)), []string{"network", "vpc", "get", "vpc-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(newMockClient(withNetwork(m)), []string{"network", "vpc", "get", "vpc-001", "--project-id", "proj-123"})
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -158,6 +199,9 @@ func TestVPCGetCmd(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
 			}
 		})
 	}
@@ -173,6 +217,7 @@ func TestVPCCreateCmd(t *testing.T) {
 		setupMock   func(*mockVPCsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -183,6 +228,11 @@ func TestVPCCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPCResponse{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpc-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -231,7 +281,7 @@ func TestVPCCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetwork(m)), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetwork(m)), tc.args)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -241,6 +291,9 @@ func TestVPCCreateCmd(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
 			}
 		})
 	}
@@ -252,12 +305,32 @@ func TestVPCDeleteCmd(t *testing.T) {
 		setupMock   func(*mockVPCsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes flag",
 			setupMock: func(m *mockVPCsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpc-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockVPCsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpc-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -293,7 +366,11 @@ func TestVPCDeleteCmd(t *testing.T) {
 				tc.setupMock(m)
 			}
 			// --yes skips the interactive confirmation prompt
-			err := runCmd(newMockClient(withNetwork(m)), []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetwork(m)), args)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -303,6 +380,9 @@ func TestVPCDeleteCmd(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
 			}
 		})
 	}

--- a/cmd/network.vpcpeering_test.go
+++ b/cmd/network.vpcpeering_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestVPCPeeringListCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestVPCPeeringListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "peer-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockVPCPeeringsClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
 					return &types.Response[types.VPCPeeringList]{StatusCode: 200, Data: &types.VPCPeeringList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockVPCPeeringsClient) {
+				id, name := "peer-001", "my-peering"
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
+					return &types.Response[types.VPCPeeringList]{
+						StatusCode: 200,
+						Data: &types.VPCPeeringList{
+							Values: []types.VPCPeeringResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})),
-				[]string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"})
+			args := []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPCPeeringResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "peer-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})),
 				[]string{"network", "vpcpeering", "get", "vpc-001", "peer-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPCPeeringResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "peer-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -191,8 +242,11 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -203,12 +257,32 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockVPCPeeringsClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "peer-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockVPCPeeringsClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "peer-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -242,9 +316,15 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})),
-				[]string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -33,6 +36,25 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			setupMock: func(m *mockVPCPeeringRoutesClient) {
 				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
 					return &types.Response[types.VPCPeeringRouteList]{StatusCode: 200, Data: &types.VPCPeeringRouteList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockVPCPeeringRoutesClient) {
+				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
+					return &types.Response[types.VPCPeeringRouteList]{
+						StatusCode: 200,
+						Data: &types.VPCPeeringRouteList{
+							Values: []types.VPCPeeringRouteResponse{{}},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -66,9 +88,15 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})),
-				[]string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"})
+			args := []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -79,6 +107,7 @@ func TestVPCPeeringRouteGetCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -121,9 +150,12 @@ func TestVPCPeeringRouteGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})),
 				[]string{"network", "vpcpeeringroute", "get", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -135,6 +167,7 @@ func TestVPCPeeringRouteCreateCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -203,8 +236,11 @@ func TestVPCPeeringRouteCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -215,12 +251,32 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 		setupMock   func(*mockVPCPeeringRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockVPCPeeringRoutesClient) {
 				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockVPCPeeringRoutesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -254,9 +310,15 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})),
-				[]string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestVPNRouteListCmd(t *testing.T) {
 		setupMock   func(*mockVPNRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestVPNRouteListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpnr-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockVPNRoutesClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
 					return &types.Response[types.VPNRouteList]{StatusCode: 200, Data: &types.VPNRouteList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockVPNRoutesClient) {
+				id, name := "vpnr-001", "my-vpnroute"
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
+					return &types.Response[types.VPNRouteList]{
+						StatusCode: 200,
+						Data: &types.VPNRouteList{
+							Values: []types.VPNRouteResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestVPNRouteListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})),
-				[]string{"network", "vpnroute", "list", "tun-001", "--project-id", "proj-123"})
+			args := []string{"network", "vpnroute", "list", "tun-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestVPNRouteGetCmd(t *testing.T) {
 		setupMock   func(*mockVPNRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestVPNRouteGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPNRouteResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpnr-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestVPNRouteGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})),
 				[]string{"network", "vpnroute", "get", "tun-001", "vpnr-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -147,6 +192,7 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 		setupMock   func(*mockVPNRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -158,6 +204,11 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPNRouteResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpnr-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -199,8 +250,11 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -211,12 +265,32 @@ func TestVPNRouteDeleteCmd(t *testing.T) {
 		setupMock   func(*mockVPNRoutesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockVPNRoutesClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpnr-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockVPNRoutesClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpnr-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -250,9 +324,15 @@ func TestVPNRouteDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})),
-				[]string{"network", "vpnroute", "delete", "tun-001", "vpnr-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "vpnroute", "delete", "tun-001", "vpnr-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/network.vpntunnel_test.go
+++ b/cmd/network.vpntunnel_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ func TestVPNTunnelListCmd(t *testing.T) {
 		setupMock   func(*mockVPNTunnelsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -31,12 +33,39 @@ func TestVPNTunnelListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "tun-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockVPNTunnelsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
 					return &types.Response[types.VPNTunnelList]{StatusCode: 200, Data: &types.VPNTunnelList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockVPNTunnelsClient) {
+				id, name := "tun-001", "my-tunnel"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
+					return &types.Response[types.VPNTunnelList]{
+						StatusCode: 200,
+						Data: &types.VPNTunnelList{
+							Values: []types.VPNTunnelResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -70,9 +99,15 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})),
-				[]string{"network", "vpntunnel", "list", "--project-id", "proj-123"})
+			args := []string{"network", "vpntunnel", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -120,6 +155,7 @@ func TestVPNTunnelGetCmd(t *testing.T) {
 		setupMock   func(*mockVPNTunnelsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -130,6 +166,11 @@ func TestVPNTunnelGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPNTunnelResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "tun-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -163,9 +204,12 @@ func TestVPNTunnelGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})),
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})),
 				[]string{"network", "vpntunnel", "get", "tun-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -187,6 +231,7 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 		setupMock   func(*mockVPNTunnelsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -198,6 +243,11 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.VPNTunnelResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "tun-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -239,8 +289,11 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -251,12 +304,32 @@ func TestVPNTunnelDeleteCmd(t *testing.T) {
 		setupMock   func(*mockVPNTunnelsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockVPNTunnelsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "tun-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockVPNTunnelsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "tun-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -290,9 +363,15 @@ func TestVPNTunnelDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})),
-				[]string{"network", "vpntunnel", "delete", "tun-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"network", "vpntunnel", "delete", "tun-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/schedule.job_test.go
+++ b/cmd/schedule.job_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestJobListCmd(t *testing.T) {
 		setupMock   func(*mockJobsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestJobListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "job-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockJobsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.JobList], error) {
 					return &types.Response[types.JobList]{StatusCode: 200, Data: &types.JobList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockJobsClient) {
+				id, name := "job-001", "my-job"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.JobList], error) {
+					return &types.Response[types.JobList]{
+						StatusCode: 200,
+						Data: &types.JobList{
+							Values: []types.JobResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestJobListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})),
-				[]string{"schedule", "job", "list", "--project-id", "proj-123"})
+			args := []string{"schedule", "job", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestJobGetCmd(t *testing.T) {
 		setupMock   func(*mockJobsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestJobGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.JobResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "job-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestJobGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})),
+			out, err := runCmdCapture(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})),
 				[]string{"schedule", "job", "get", "job-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestJobCreateCmd(t *testing.T) {
 		setupMock   func(*mockJobsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestJobCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.JobResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "job-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -197,8 +248,11 @@ func TestJobCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -209,12 +263,36 @@ func TestJobDeleteCmd(t *testing.T) {
 		setupMock   func(*mockJobsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockJobsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "job-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockJobsClient) {
+				id, name := "job-001", "my-job"
+				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.JobResponse], error) {
+					return &types.Response[types.JobResponse]{StatusCode: 200, Data: &types.JobResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
+				}
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "job-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -248,9 +326,15 @@ func TestJobDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})),
-				[]string{"schedule", "job", "delete", "job-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"schedule", "job", "delete", "job-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withSchedule(&mockScheduleClient{jobsClient: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/storage.backup_test.go
+++ b/cmd/storage.backup_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -35,6 +37,7 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 		storageMock *mockStorageClient
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -46,6 +49,11 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 					Data:       &types.StorageBackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
 				}, nil
 			}),
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-new") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name:        "missing required flag --name",
@@ -81,8 +89,11 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 			if sm == nil {
 				sm = &mockStorageClient{}
 			}
-			err := runCmd(newMockClient(withStorageMock(sm)), tc.args)
+			out, err := runCmdCapture(newMockClient(withStorageMock(sm)), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -93,6 +104,7 @@ func TestStorageBackupListCmd(t *testing.T) {
 		setupMock   func(*mockStorageBackupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -109,12 +121,39 @@ func TestStorageBackupListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockStorageBackupsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
 					return &types.Response[types.StorageBackupList]{StatusCode: 200, Data: &types.StorageBackupList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockStorageBackupsClient) {
+				id, sname := "bkp-001", "my-backup"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
+					return &types.Response[types.StorageBackupList]{
+						StatusCode: 200,
+						Data: &types.StorageBackupList{
+							Values: []types.StorageBackupResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -148,9 +187,15 @@ func TestStorageBackupListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})),
-				[]string{"storage", "backup", "list", "--project-id", "proj-123"})
+			args := []string{"storage", "backup", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -161,6 +206,7 @@ func TestStorageBackupGetCmd(t *testing.T) {
 		setupMock   func(*mockStorageBackupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -171,6 +217,11 @@ func TestStorageBackupGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.StorageBackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -204,9 +255,12 @@ func TestStorageBackupGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})),
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})),
 				[]string{"storage", "backup", "get", "bkp-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -217,12 +271,32 @@ func TestStorageBackupDeleteCmd(t *testing.T) {
 		setupMock   func(*mockStorageBackupsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockStorageBackupsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockStorageBackupsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "bkp-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -256,9 +330,15 @@ func TestStorageBackupDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})),
-				[]string{"storage", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"storage", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,6 +16,7 @@ func TestBlockStorageListCmd(t *testing.T) {
 		setupMock   func(*mockVolumesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -30,12 +33,39 @@ func TestBlockStorageListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vol-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockVolumesClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
 					return &types.Response[types.BlockStorageList]{StatusCode: 200, Data: &types.BlockStorageList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockVolumesClient) {
+				id, name := "vol-001", "my-volume"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
+					return &types.Response[types.BlockStorageList]{
+						StatusCode: 200,
+						Data: &types.BlockStorageList{
+							Values: []types.BlockStorageResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,9 +99,15 @@ func TestBlockStorageListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorage(m)),
-				[]string{"storage", "blockstorage", "list", "--project-id", "proj-123"})
+			args := []string{"storage", "blockstorage", "list", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withStorage(m)), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -82,6 +118,7 @@ func TestBlockStorageGetCmd(t *testing.T) {
 		setupMock   func(*mockVolumesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -92,6 +129,11 @@ func TestBlockStorageGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.BlockStorageResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vol-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -125,9 +167,12 @@ func TestBlockStorageGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorage(m)),
+			out, err := runCmdCapture(newMockClient(withStorage(m)),
 				[]string{"storage", "blockstorage", "get", "vol-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -139,6 +184,7 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 		setupMock   func(*mockVolumesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -150,6 +196,11 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.BlockStorageResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vol-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -197,8 +248,11 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorage(m)), tc.args)
+			out, err := runCmdCapture(newMockClient(withStorage(m)), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -209,12 +263,32 @@ func TestBlockStorageDeleteCmd(t *testing.T) {
 		setupMock   func(*mockVolumesClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockVolumesClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vol-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockVolumesClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vol-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -248,9 +322,15 @@ func TestBlockStorageDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorage(m)),
-				[]string{"storage", "blockstorage", "delete", "vol-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"storage", "blockstorage", "delete", "vol-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withStorage(m)), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/storage.restore_test.go
+++ b/cmd/storage.restore_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -44,6 +46,7 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 		storageMock *mockStorageClient
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -55,6 +58,11 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 					Data:       &types.RestoreResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
 				}, nil
 			}),
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rst-new") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name:        "missing required flag --name",
@@ -90,8 +98,11 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 			if sm == nil {
 				sm = &mockStorageClient{}
 			}
-			err := runCmd(newMockClient(withStorageMock(sm)), tc.args)
+			out, err := runCmdCapture(newMockClient(withStorageMock(sm)), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -102,6 +113,7 @@ func TestStorageRestoreListCmd(t *testing.T) {
 		setupMock   func(*mockStorageRestoreClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
@@ -118,12 +130,39 @@ func TestStorageRestoreListCmd(t *testing.T) {
 					}, nil
 				}
 			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rst-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
 		},
 		{
 			name: "success empty",
 			setupMock: func(m *mockStorageRestoreClient) {
 				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
 					return &types.Response[types.RestoreList]{StatusCode: 200, Data: &types.RestoreList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockStorageRestoreClient) {
+				id, rname := "rst-001", "my-restore"
+				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
+					return &types.Response[types.RestoreList]{
+						StatusCode: 200,
+						Data: &types.RestoreList{
+							Values: []types.RestoreResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -157,9 +196,15 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})),
-				[]string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"})
+			args := []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -170,6 +215,7 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 		setupMock   func(*mockStorageRestoreClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -180,6 +226,11 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.RestoreResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rst-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -213,9 +264,12 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})),
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})),
 				[]string{"storage", "restore", "get", "bkp-001", "rst-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -226,12 +280,32 @@ func TestStorageRestoreDeleteCmd(t *testing.T) {
 		setupMock   func(*mockStorageRestoreClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockStorageRestoreClient) {
 				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rst-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockStorageRestoreClient) {
+				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rst-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -265,9 +339,15 @@ func TestStorageRestoreDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})),
-				[]string{"storage", "restore", "delete", "bkp-001", "rst-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"storage", "restore", "delete", "bkp-001", "rst-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }

--- a/cmd/storage.snapshot_test.go
+++ b/cmd/storage.snapshot_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -14,20 +16,28 @@ func TestSnapshotListCmd(t *testing.T) {
 		setupMock   func(*mockSnapshotsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
 			setupMock: func(m *mockSnapshotsClient) {
 				id, name := "snap-001", "my-snapshot"
+				volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
 					return &types.Response[types.SnapshotList]{
 						StatusCode: 200,
 						Data: &types.SnapshotList{
 							Values: []types.SnapshotResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+									Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}}},
 							},
 						},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "snap-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -36,6 +46,30 @@ func TestSnapshotListCmd(t *testing.T) {
 			setupMock: func(m *mockSnapshotsClient) {
 				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
 					return &types.Response[types.SnapshotList]{StatusCode: 200, Data: &types.SnapshotList{}}, nil
+				}
+			},
+		},
+		{
+			name: "--output=json emits valid JSON",
+			setupMock: func(m *mockSnapshotsClient) {
+				id, name := "snap-001", "my-snapshot"
+				volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
+				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
+					return &types.Response[types.SnapshotList]{
+						StatusCode: 200,
+						Data: &types.SnapshotList{
+							Values: []types.SnapshotResponse{
+								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+									Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}}},
+							},
+						},
+					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
 				}
 			},
 		},
@@ -69,10 +103,16 @@ func TestSnapshotListCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})),
-				[]string{"storage", "snapshot", "list", "--project-id", "proj-123",
-					"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"})
+			args := []string{"storage", "snapshot", "list", "--project-id", "proj-123",
+				"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"}
+			if tc.name == "--output=json emits valid JSON" {
+				args = append(args, "--output", "json")
+			}
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -83,6 +123,7 @@ func TestSnapshotGetCmd(t *testing.T) {
 		setupMock   func(*mockSnapshotsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -93,6 +134,11 @@ func TestSnapshotGetCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SnapshotResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "snap-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -126,9 +172,12 @@ func TestSnapshotGetCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})),
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})),
 				[]string{"storage", "snapshot", "get", "snap-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -140,6 +189,7 @@ func TestSnapshotCreateCmd(t *testing.T) {
 		setupMock   func(*mockSnapshotsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
@@ -157,6 +207,11 @@ func TestSnapshotCreateCmd(t *testing.T) {
 						StatusCode: 200,
 						Data:       &types.SnapshotResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "snap-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
@@ -214,8 +269,11 @@ func TestSnapshotCreateCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), tc.args)
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -226,12 +284,32 @@ func TestSnapshotDeleteCmd(t *testing.T) {
 		setupMock   func(*mockSnapshotsClient)
 		wantErr     bool
 		errContains string
+		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
 			setupMock: func(m *mockSnapshotsClient) {
 				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
 					return &types.Response[any]{StatusCode: 200}, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "snap-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			setupMock: func(m *mockSnapshotsClient) {
+				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
+					t.Fatal("Delete must not be called in --dry-run mode")
+					return nil, nil
+				}
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "snap-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
@@ -265,9 +343,15 @@ func TestSnapshotDeleteCmd(t *testing.T) {
 			if tc.setupMock != nil {
 				tc.setupMock(m)
 			}
-			err := runCmd(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})),
-				[]string{"storage", "snapshot", "delete", "snap-001", "--project-id", "proj-123", "--yes"})
+			args := []string{"storage", "snapshot", "delete", "snap-001", "--project-id", "proj-123", "--yes"}
+			if tc.name == "--dry-run: prints intent, does not call Delete" {
+				args = append(args, "--dry-run")
+			}
+			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #63 

- Add runCmdCapture helper to capture stdout in tests
- Add assertOut field to all test structs
- Add --output=json test cases for all list commands (validates JSON output)
- Add --dry-run test cases for all delete commands (asserts Delete not called)
- Fix resetCmdFlags to also reset flag values (not just Changed bit) to prevent test pollution
- Fix snapshot list test to set Properties.Volume.URI so snapshots pass the volume filter