### PR TITLE
fix(compute): remove spurious --image flag from cloudserver create

### DIFF
--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -36,7 +36,6 @@ func init() {
 	cloudserverCreateCmd.Flags().String("region", "", "Region code (required)")
 	cloudserverCreateCmd.Flags().String("zone", "", "Zone code (required, e.g., itbg1-a)")
 	cloudserverCreateCmd.Flags().String("flavor", "", "Flavor name (required)")
-	cloudserverCreateCmd.Flags().String("image", "", "Image ID or name (required)")
 	cloudserverCreateCmd.Flags().String("keypair-uri", "", "Keypair URI (e.g., /projects/{project-id}/providers/Aruba.Compute/keyPairs/{keypair-name})")
 	cloudserverCreateCmd.Flags().StringSlice("tags", []string{}, "Tags (comma-separated)")
 	cloudserverCreateCmd.Flags().String("user-data-file", "", "Path to cloud-init YAML file (will be base64 encoded)")
@@ -48,7 +47,6 @@ func init() {
 	cloudserverCreateCmd.MarkFlagRequired("name")
 	cloudserverCreateCmd.MarkFlagRequired("region")
 	cloudserverCreateCmd.MarkFlagRequired("flavor")
-	cloudserverCreateCmd.MarkFlagRequired("image")
 	cloudserverCreateCmd.MarkFlagRequired("zone")
 
 	cloudserverGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -202,7 +202,6 @@ func TestCloudServerCreateCmd(t *testing.T) {
 		"--region", "IT-BG",
 		"--zone", "itbg1-a",
 		"--flavor", "m1.small",
-		"--image", "img-001",
 		"--boot-disk-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001",
 		"--vpc-uri", "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001",
 		"--subnet-uri", "/projects/proj-123/providers/Aruba.Network/subnets/sub-001",

--- a/docs/website/docs/examples/cloudserver.md
+++ b/docs/website/docs/examples/cloudserver.md
@@ -304,7 +304,6 @@ acloud compute cloudserver create \
   --zone "ITBG-1" \
   --flavor "CSO4A8" \
   --boot-disk-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Storage/blockStorages/697b3a0dce7dfeef9153256a" \
-  --image "ubuntu-22.04" \
   --vpc-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec" \
   --subnet-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a" \
   --security-group-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b75f9" \
@@ -432,4 +431,4 @@ You will be prompted for confirmation:
 Are you sure you want to delete cloud server '697c62605b79733376b3386a'? (yes/no): yes
 Cloud server '697c62605b79733376b3386a' deleted successfully.
 ```
----
+---

--- a/docs/website/docs/resources/compute/cloudserver.md
+++ b/docs/website/docs/resources/compute/cloudserver.md
@@ -24,7 +24,7 @@ acloud compute cloudserver create [flags]
 - `--name <string>` - Name for the cloud server
 - `--region <string>` - Region code (e.g., `ITBG-Bergamo`)
 - `--flavor <string>` - Flavor name (e.g., `small`, `medium`, `large`)
-- `--image <string>` - Image ID or name
+- `--boot-disk-uri <string>` - Bootable block storage URI (e.g., `/projects/{project-id}/providers/Aruba.Storage/blockStorages/{volume-id}`)
 - `--vpc-uri <string>` - VPC URI (e.g., `/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}`)
 - `--subnet-uri <stringSlice>` - Subnet URI(s) (comma-separated)
 - `--security-group-uri <stringSlice>` - Security Group URI(s) (comma-separated)
@@ -43,8 +43,11 @@ acloud compute cloudserver create \
   --name "web-server" \
   --region "ITBG-Bergamo" \
   --flavor "small" \
-  --image "ubuntu-22.04" \
-  --keypair "my-keypair" \
+  --boot-disk-uri "/projects/{project-id}/providers/Aruba.Storage/blockStorages/{volume-id}" \
+  --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
+  --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
+  --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
+  --keypair-uri "/projects/{project-id}/providers/Aruba.Compute/keyPairs/{keypair-name}" \
   --tags "production,web" \
   --user-data-file "/path/to/cloud-init.yaml"
 ```
@@ -320,8 +323,11 @@ acloud compute cloudserver connect <TAB>
      --name "app-server" \
      --region "ITBG-Bergamo" \
      --flavor "medium" \
-     --image "your-image-id" \
-     --keypair "my-keypair" \
+     --boot-disk-uri "/projects/{project-id}/providers/Aruba.Storage/blockStorages/{volume-id}" \
+     --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
+     --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
+     --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
+     --keypair-uri "/projects/{project-id}/providers/Aruba.Compute/keyPairs/{keypair-name}" \
      --user-data-file "/path/to/cloud-init.yaml"
    ```
 


### PR DESCRIPTION
## Summary

- `CloudServerPropertiesRequest` uses `BootVolume` as a `ReferenceResource` URI — there is no `image` field. The `--image` flag was declared and marked required but never read or used in the handler.
- Removes the `--image` flag and its `MarkFlagRequired` call from `cloudserver create`
- Removes `--image` from the test's `baseArgs`
- Updates the examples doc (Step 10) and the resource reference doc to drop `--image` and show the correct required flags

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./cmd/ -run TestCloudServerCreate` — all 5 sub-tests pass
- [x] Docs examples and required-flags table now match the SDK's `CloudServerPropertiesRequest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)