### PR TITLE
fix(release): add --repo flag to gh release download in publish-apt job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           echo "FCE74C4292A6302089B4C98442A7DE3F298D6FB8:6:" | gpg --import-ownertrust
 
       - name: Download .deb packages
-        run: gh release download ${{ github.ref_name }} --pattern "*.deb" --dir debs/
+        run: gh release download ${{ github.ref_name }} --repo ${{ github.repository }} --pattern "*.deb" --dir debs/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `publish-apt` job downloads `.deb` files with `gh release download` but had no `--repo` flag
- Without `--repo`, `gh` tries to infer the repo from a local `.git` directory, which doesn't exist in that job (only `Arubacloud/apt` is checked out)
- This caused `fatal: not a git repository` on every release since the apt job was added
- Fix: add `--repo ${{ github.repository }}` so `gh` targets `Arubacloud/acloud-cli` directly

## Test plan

- [ ] Merge and re-run the release workflow (or re-publish by re-triggering a tag) to verify the `.deb` download succeeds and the apt repo is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)