### PR TITLE
feat(sdk): foundations & shared helpers for v0.2.0 (#100)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -41,10 +41,10 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 ---
 
-### TD-022 · Pre-release SDK version (v0.1.x)
-`go.mod` depends on `github.com/Arubacloud/sdk-go v0.1.28`. The `0.x` major version provides no semantic versioning stability guarantee — a minor-version bump may introduce breaking changes.
+### TD-022 · Pre-release SDK version (v0.1.x → v0.2.0 migration in progress)
+`go.mod` now depends on `github.com/Arubacloud/sdk-go v0.2.0`. The bump was the first step of the multi-PR migration tracked in #99; foundations (shared helpers in `cmd/root.go`, `StateActive` constant) landed via #100. Per-family migrations (#101-#110) and behavioural fixups (#111) are still open — `go build ./cmd` will remain red until those merge.
 
-**Fix:** Track the SDK release roadmap. When a `v1.0.0` is released, migrate and pin to it. Until then, pin to a specific minor version and treat any upgrade as potentially breaking.
+**Fix:** Close out #99's exit criteria, then mark TD-022 resolved.
 
 ---
 

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -2,6 +2,7 @@ package cmd
 
 // Resource state values returned by the API.
 const (
+	StateActive     = "Active"
 	StateInCreation = "InCreation"
 	StateUsed       = "Used"
 	StateNotUsed    = "NotUsed"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
-	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
@@ -86,6 +86,21 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging (WARNING: may expose credentials and tokens in HTTP headers)")
 	// Add global output format flag (TD-016)
 	rootCmd.PersistentFlags().StringP("output", "o", OutputFormatTable, "Output format: table|std|standard, table-json|std-json, table-yaml|std-yaml, json, yaml")
+}
+
+// projectRef returns an opaque aruba.Ref for /projects/<projectID>. (TD-022)
+func projectRef(projectID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID)
+}
+
+// projectWrapper fetches the *aruba.Project for projectID so callers can chain
+// IntoProject(proj) on project-scoped resources. (TD-022)
+func projectWrapper(ctx context.Context, client aruba.Client, projectID string) (*aruba.Project, error) {
+	proj, err := client.FromProject().Get(ctx, projectRef(projectID))
+	if err != nil {
+		return nil, apiErrFromV2(err)
+	}
+	return proj, nil
 }
 
 // GetArubaClient creates and returns an Aruba Cloud SDK client using stored credentials
@@ -215,16 +230,23 @@ func fmtAPIError(statusCode int, title, detail *string) error {
 	return fmt.Errorf("%s", msg)
 }
 
-// apiErrFromResp returns an error for 4xx/5xx status codes, safely handling
-// the case where the SDK did not populate an error body. Returns nil for any status < 400.
-func apiErrFromResp(statusCode int, errResp *types.ErrorResponse) error {
-	if statusCode < 400 {
+// apiErrFromV2 extracts an *aruba.HTTPError from err and formats it via fmtAPIError.
+// Returns the original error if it isn't an HTTPError. Nil-safe on ErrResp/Title/Detail.
+// (TD-022)
+func apiErrFromV2(err error) error {
+	if err == nil {
 		return nil
 	}
-	if errResp != nil {
-		return fmtAPIError(statusCode, errResp.Title, errResp.Detail)
+	var httpErr *aruba.HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
 	}
-	return fmtAPIError(statusCode, nil, nil)
+	var title, detail *string
+	if httpErr.ErrResp != nil {
+		title = httpErr.ErrResp.Title
+		detail = httpErr.ErrResp.Detail
+	}
+	return fmtAPIError(httpErr.StatusCode, title, detail)
 }
 
 // confirmDelete prompts the user for confirmation before a destructive operation.
@@ -295,22 +317,22 @@ func msgDryRun(kind, id string) string {
 	return fmt.Sprintf("[dry-run] Would delete %s '%s'. Resource exists and is accessible.", kind, id)
 }
 
-// listParams builds pagination RequestParameters from --limit and --offset flags (TD-017).
+// listOpts builds v0.2.0 CallOptions from --limit and --offset flags (TD-017, TD-022).
 // Returns nil when neither flag is set, preserving the existing nil-means-no-options contract.
-func listParams(cmd *cobra.Command) *types.RequestParameters {
+func listOpts(cmd *cobra.Command) []aruba.CallOption {
 	limit, _ := cmd.Flags().GetInt32("limit")
 	offset, _ := cmd.Flags().GetInt32("offset")
 	if limit == 0 && offset == 0 {
 		return nil
 	}
-	params := &types.RequestParameters{}
+	var opts []aruba.CallOption
 	if limit > 0 {
-		params.Limit = &limit
+		opts = append(opts, aruba.WithLimit(int(limit)))
 	}
 	if offset > 0 {
-		params.Offset = &offset
+		opts = append(opts, aruba.WithOffset(int(offset)))
 	}
-	return params
+	return opts
 }
 
 // TableColumn represents a column definition for the table printer

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module acloud
 go 1.25.0
 
 require (
-	github.com/Arubacloud/sdk-go v0.1.28
+	github.com/Arubacloud/sdk-go v0.2.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/Arubacloud/sdk-go v0.1.27 h1:/S10UjYq7ppm8mL4BwuKmbJWzXUuU0BPJQxsDysrV/Q=
-github.com/Arubacloud/sdk-go v0.1.27/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
-github.com/Arubacloud/sdk-go v0.1.28-0.20260428150839-29dadc76c9fb h1:S7wCrRugJkdsv5RV7/g9MhOBnbf3SdIh9xRsESiBv38=
-github.com/Arubacloud/sdk-go v0.1.28-0.20260428150839-29dadc76c9fb/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
-github.com/Arubacloud/sdk-go v0.1.28 h1:F8Qf5UTwP5H1RZKz14YQdeRyahGZGOJ9qrq6kHlqZ3c=
-github.com/Arubacloud/sdk-go v0.1.28/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
+github.com/Arubacloud/sdk-go v0.2.0 h1:Ink9Euv6+ZvJu/78InPWioAufOr6Wnz0zoo07fvuWFo=
+github.com/Arubacloud/sdk-go v0.2.0/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
Closes #100. Part of #99.

## Summary
- Bumps `github.com/Arubacloud/sdk-go` from `v0.1.28` to `v0.2.0`.
- Adds the four shared helpers later sub-issues depend on: `apiErrFromV2`, `projectRef`, `projectWrapper`, `listOpts`.
- Adds `StateActive = "Active"` to `cmd/constants.go`.
- Removes `apiErrFromResp` and `listParams` (replaced by the v2 equivalents); drops the now-unused `sdk-go/pkg/types` import from `root.go`.
- Updates TD-022 in `ai/TECH_DEBT.md` to record progress.

## Notes on parent issue framing
- `go.mod` was actually pinned to `v0.1.28`, not `v0.1.26` as #100's description states. Bump target adjusted accordingly.
- `aruba.KMSClient` is confirmed to be an **interface** in v0.2.0 (`pkg/aruba/security.go:23-30`) — the `security.kms` sub-issue can build a real mock for it.
- `aruba.WithOffset(n int) CallOption` is confirmed present at `pkg/aruba/call_options.go:40-44`. No fallback needed.

## Build status
`go build ./cmd` is **expected to fail** on this branch — the 25 helper-consuming resource files have not migrated yet, by design (see #100 acceptance criteria). Targeted checks on the two changed files pass:

- `gofmt -l cmd/root.go cmd/constants.go` — clean (no output)
- `go mod verify` — all modules verified
- `go mod tidy` — no further diff

Full `make build`/`test`/`lint` will go green once sub-issues #101-#110 land.

## Test plan
- [ ] CI: confirm `go mod verify` passes
- [ ] Local: re-run `gofmt -l` against the two changed files
- [ ] Spot-check helper signatures match #100 acceptance