### PR TITLE
test(sdk): rebuild test mock infrastructure for v0.2.0 (#101)

### DIFF
--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -278,10 +278,33 @@ fmt.Println(msgDeleted("<resource type>", id))
 
 - Tests live in `package cmd` (same package as the code).
 - Use `t.TempDir()` for isolated file paths; override `HOME` (or `USERPROFILE` on Windows) to redirect config/context files.
-- Clear the client cache after each test:
-  ```go
-  resetClientState()  // helper in cmd/root.go (TD-018)
-  ```
 - Use `defer cleanup()` to restore environment variables.
 - Skip live-API tests with `ACLOUD_TEST_SKIP_CLIENT=true`.
 - Table-driven tests are preferred for multiple input/output cases.
+
+### Test client — httptest harness (v0.2.0+)
+
+Since SDK v0.2.0, wrapper types (`aruba.CloudServer`, `aruba.VPC`, …) carry unexported internal state that can only be populated by the SDK's own adapters. Hand-built fake structs cannot produce a hydrated wrapper with real `.ID()`/`.State()`/`List[T]` values.
+
+Use the `arubaTestServer` harness in `cmd/mock_test.go` instead:
+
+```go
+func TestMyCommand(t *testing.T) {
+    srv := newArubaTestServer(t)          // real aruba.Client pointed at httptest.Server
+    srv.OnGet("/projects/p1/cloudServers", jsonResponse(200, types.CloudServerList{
+        // ... fixture fields ...
+    }))
+
+    err := runCmd(srv.Client(), []string{"cloud-server", "list", "--project-id", "p1"})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+}
+```
+
+- Register routes with `OnGet`/`OnPost`/`OnPut`/`OnDelete`/`OnPatch` before calling `runCmd`.
+- `jsonResponse(status, body)` marshals `body` (a `types.*Response` or `types.*List`) to JSON.
+- `errorResponse(status, title, detail)` emits a `types.ErrorResponse` body so the SDK surfaces an `*aruba.HTTPError`.
+- Unregistered routes cause `t.Errorf` (not a silent 404) — mis-keyed paths fail loudly.
+- `runCmd`/`runCmdCapture`/`resetCmdFlags`/`strPtr` helpers are unchanged; pass `srv.Client()` where the old code passed a `newMockClient(...)`.
+- Clear the client cache after each test (handled automatically by `runCmd` via `defer resetClientState()`).

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"bytes"
-	"context"
-	"errors"
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -13,1145 +15,120 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// ─── top-level client mock ────────────────────────────────────────────────────
+// ─── httptest harness ─────────────────────────────────────────────────────────
 
-type mockClient struct {
-	computeClient   aruba.ComputeClient
-	networkClient   aruba.NetworkClient
-	storageClient   aruba.StorageClient
-	databaseClient  aruba.DatabaseClient
-	projectClient   aruba.ProjectClient
-	scheduleClient  aruba.ScheduleClient
-	containerClient aruba.ContainerClient
-	securityClient  aruba.SecurityClient
-	auditClient     aruba.AuditClient
-	metricClient    aruba.MetricClient
+// arubaTestServer is an httptest-backed fake Aruba API. Tests register routes
+// with On*/jsonResponse, then call Client() to get a real aruba.Client whose
+// adapters hydrate real wrapper types from the registered responses. (TD-022)
+type arubaTestServer struct {
+	t      *testing.T
+	routes map[string]http.HandlerFunc // keyed by "METHOD /path"
+	srv    *httptest.Server
+	client aruba.Client
 }
 
-func (m *mockClient) FromCompute() aruba.ComputeClient   { return m.computeClient }
-func (m *mockClient) FromNetwork() aruba.NetworkClient   { return m.networkClient }
-func (m *mockClient) FromStorage() aruba.StorageClient   { return m.storageClient }
-func (m *mockClient) FromDatabase() aruba.DatabaseClient { return m.databaseClient }
-func (m *mockClient) FromProject() aruba.ProjectClient   { return m.projectClient }
-func (m *mockClient) FromSchedule() aruba.ScheduleClient { return m.scheduleClient }
-func (m *mockClient) FromContainer() aruba.ContainerClient {
-	return m.containerClient
-}
-func (m *mockClient) FromSecurity() aruba.SecurityClient { return m.securityClient }
-func (m *mockClient) FromAudit() aruba.AuditClient       { return m.auditClient }
-func (m *mockClient) FromMetric() aruba.MetricClient     { return m.metricClient }
-
-// ─── compute ─────────────────────────────────────────────────────────────────
-
-type mockComputeClient struct {
-	cloudServersClient aruba.CloudServersClient
-	keyPairsClient     aruba.KeyPairsClient
-}
-
-func (m *mockComputeClient) CloudServers() aruba.CloudServersClient { return m.cloudServersClient }
-func (m *mockComputeClient) KeyPairs() aruba.KeyPairsClient         { return m.keyPairsClient }
-
-type mockCloudServersClient struct {
-	listFn        func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerList], error)
-	getFn         func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
-	createFn      func(ctx context.Context, projectID string, body types.CloudServerRequest, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
-	updateFn      func(ctx context.Context, projectID string, id string, body types.CloudServerRequest, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
-	deleteFn      func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[any], error)
-	powerOnFn     func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
-	powerOffFn    func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
-	setPasswordFn func(ctx context.Context, projectID string, id string, body types.CloudServerPasswordRequest, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockCloudServersClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.CloudServerList]{StatusCode: 200, Data: &types.CloudServerList{}}, nil
-}
-func (m *mockCloudServersClient) Get(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-}
-func (m *mockCloudServersClient) Create(ctx context.Context, projectID string, body types.CloudServerRequest, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-}
-func (m *mockCloudServersClient) Update(ctx context.Context, projectID, id string, body types.CloudServerRequest, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, id, body, params)
-	}
-	return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-}
-func (m *mockCloudServersClient) Delete(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, id, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-func (m *mockCloudServersClient) PowerOn(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-	if m.powerOnFn != nil {
-		return m.powerOnFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-}
-func (m *mockCloudServersClient) PowerOff(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-	if m.powerOffFn != nil {
-		return m.powerOffFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-}
-func (m *mockCloudServersClient) SetPassword(ctx context.Context, projectID, id string, body types.CloudServerPasswordRequest, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.setPasswordFn != nil {
-		return m.setPasswordFn(ctx, projectID, id, body, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockKeyPairsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error)
-	getFn    func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.KeyPairResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.KeyPairRequest, params *types.RequestParameters) (*types.Response[types.KeyPairResponse], error)
-	deleteFn func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockKeyPairsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.KeyPairListResponse]{StatusCode: 200, Data: &types.KeyPairListResponse{}}, nil
-}
-func (m *mockKeyPairsClient) Get(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.KeyPairResponse]{StatusCode: 200, Data: &types.KeyPairResponse{}}, nil
-}
-func (m *mockKeyPairsClient) Create(ctx context.Context, projectID string, body types.KeyPairRequest, params *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.KeyPairResponse]{StatusCode: 200, Data: &types.KeyPairResponse{}}, nil
-}
-func (m *mockKeyPairsClient) Delete(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, id, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── network ─────────────────────────────────────────────────────────────────
-
-type mockNetworkClient struct {
-	vpcsMock             *mockVPCsClient
-	elasticIPsMock       *mockElasticIPsClient
-	loadBalancersMock    aruba.LoadBalancersClient
-	securityGroupsMock   aruba.SecurityGroupsClient
-	securityGroupRules   aruba.SecurityGroupRulesClient
-	subnetsMock          aruba.SubnetsClient
-	vpcPeeringsMock      aruba.VPCPeeringsClient
-	vpcPeeringRoutesMock aruba.VPCPeeringRoutesClient
-	vpnTunnelsMock       aruba.VPNTunnelsClient
-	vpnRoutesMock        aruba.VPNRoutesClient
-}
-
-func (m *mockNetworkClient) VPCs() aruba.VPCsClient { return m.vpcsMock }
-func (m *mockNetworkClient) ElasticIPs() aruba.ElasticIPsClient {
-	return m.elasticIPsMock
-}
-func (m *mockNetworkClient) LoadBalancers() aruba.LoadBalancersClient {
-	return m.loadBalancersMock
-}
-func (m *mockNetworkClient) SecurityGroups() aruba.SecurityGroupsClient {
-	return m.securityGroupsMock
-}
-func (m *mockNetworkClient) SecurityGroupRules() aruba.SecurityGroupRulesClient {
-	return m.securityGroupRules
-}
-func (m *mockNetworkClient) Subnets() aruba.SubnetsClient         { return m.subnetsMock }
-func (m *mockNetworkClient) VPCPeerings() aruba.VPCPeeringsClient { return m.vpcPeeringsMock }
-func (m *mockNetworkClient) VPCPeeringRoutes() aruba.VPCPeeringRoutesClient {
-	return m.vpcPeeringRoutesMock
-}
-func (m *mockNetworkClient) VPNTunnels() aruba.VPNTunnelsClient { return m.vpnTunnelsMock }
-func (m *mockNetworkClient) VPNRoutes() aruba.VPNRoutesClient   { return m.vpnRoutesMock }
-
-type mockVPCsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPCList], error)
-	getFn    func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.VPCResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.VPCRequest, params *types.RequestParameters) (*types.Response[types.VPCResponse], error)
-	updateFn func(ctx context.Context, projectID string, id string, body types.VPCRequest, params *types.RequestParameters) (*types.Response[types.VPCResponse], error)
-	deleteFn func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockVPCsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPCList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.VPCList]{StatusCode: 200, Data: &types.VPCList{}}, nil
-}
-func (m *mockVPCsClient) Get(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.VPCResponse]{StatusCode: 200, Data: &types.VPCResponse{}}, nil
-}
-func (m *mockVPCsClient) Create(ctx context.Context, projectID string, body types.VPCRequest, params *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.VPCResponse]{StatusCode: 200, Data: &types.VPCResponse{}}, nil
-}
-func (m *mockVPCsClient) Update(ctx context.Context, projectID, id string, body types.VPCRequest, params *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, id, body, params)
-	}
-	return &types.Response[types.VPCResponse]{StatusCode: 200, Data: &types.VPCResponse{}}, nil
-}
-func (m *mockVPCsClient) Delete(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, id, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockElasticIPsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ElasticList], error)
-	getFn    func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.ElasticIPRequest, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error)
-	updateFn func(ctx context.Context, projectID string, id string, body types.ElasticIPRequest, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error)
-	deleteFn func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockElasticIPsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ElasticList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.ElasticList]{StatusCode: 200, Data: &types.ElasticList{}}, nil
-}
-func (m *mockElasticIPsClient) Get(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.ElasticIPResponse]{StatusCode: 200, Data: &types.ElasticIPResponse{}}, nil
-}
-func (m *mockElasticIPsClient) Create(ctx context.Context, projectID string, body types.ElasticIPRequest, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.ElasticIPResponse]{StatusCode: 200, Data: &types.ElasticIPResponse{}}, nil
-}
-func (m *mockElasticIPsClient) Update(ctx context.Context, projectID, id string, body types.ElasticIPRequest, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, id, body, params)
-	}
-	return &types.Response[types.ElasticIPResponse]{StatusCode: 200, Data: &types.ElasticIPResponse{}}, nil
-}
-func (m *mockElasticIPsClient) Delete(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, id, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── storage ──────────────────────────────────────────────────────────────────
-
-type mockStorageClient struct {
-	volumesMock   *mockVolumesClient
-	snapshotsMock aruba.SnapshotsClient
-	backupsMock   aruba.StorageBackupsClient
-	restoresMock  aruba.StorageRestoreClient
-}
-
-func (m *mockStorageClient) Volumes() aruba.VolumesClient         { return m.volumesMock }
-func (m *mockStorageClient) Snapshots() aruba.SnapshotsClient     { return m.snapshotsMock }
-func (m *mockStorageClient) Backups() aruba.StorageBackupsClient  { return m.backupsMock }
-func (m *mockStorageClient) Restores() aruba.StorageRestoreClient { return m.restoresMock }
-
-type mockVolumesClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BlockStorageList], error)
-	getFn    func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.BlockStorageRequest, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error)
-	updateFn func(ctx context.Context, projectID string, id string, body types.BlockStorageRequest, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error)
-	deleteFn func(ctx context.Context, projectID string, id string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockVolumesClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.BlockStorageList]{StatusCode: 200, Data: &types.BlockStorageList{}}, nil
-}
-func (m *mockVolumesClient) Get(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, id, params)
-	}
-	return &types.Response[types.BlockStorageResponse]{StatusCode: 200, Data: &types.BlockStorageResponse{}}, nil
-}
-func (m *mockVolumesClient) Create(ctx context.Context, projectID string, body types.BlockStorageRequest, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.BlockStorageResponse]{StatusCode: 200, Data: &types.BlockStorageResponse{}}, nil
-}
-func (m *mockVolumesClient) Update(ctx context.Context, projectID, id string, body types.BlockStorageRequest, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, id, body, params)
-	}
-	return &types.Response[types.BlockStorageResponse]{StatusCode: 200, Data: &types.BlockStorageResponse{}}, nil
-}
-func (m *mockVolumesClient) Delete(ctx context.Context, projectID, id string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, id, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── project ──────────────────────────────────────────────────────────────────
-
-type mockProjectClient struct {
-	listFn   func(ctx context.Context, params *types.RequestParameters) (*types.Response[types.ProjectList], error)
-	getFn    func(ctx context.Context, id string, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error)
-	createFn func(ctx context.Context, body types.ProjectRequest, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error)
-	updateFn func(ctx context.Context, id string, body types.ProjectRequest, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error)
-	deleteFn func(ctx context.Context, id string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockProjectClient) List(ctx context.Context, params *types.RequestParameters) (*types.Response[types.ProjectList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, params)
-	}
-	return &types.Response[types.ProjectList]{StatusCode: 200, Data: &types.ProjectList{}}, nil
-}
-func (m *mockProjectClient) Get(ctx context.Context, id string, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, id, params)
-	}
-	return &types.Response[types.ProjectResponse]{StatusCode: 200, Data: &types.ProjectResponse{}}, nil
-}
-func (m *mockProjectClient) Create(ctx context.Context, body types.ProjectRequest, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, body, params)
-	}
-	return &types.Response[types.ProjectResponse]{StatusCode: 200, Data: &types.ProjectResponse{}}, nil
-}
-func (m *mockProjectClient) Update(ctx context.Context, id string, body types.ProjectRequest, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, id, body, params)
-	}
-	return &types.Response[types.ProjectResponse]{StatusCode: 200, Data: &types.ProjectResponse{}}, nil
-}
-func (m *mockProjectClient) Delete(ctx context.Context, id string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, id, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── network: remaining sub-clients ──────────────────────────────────────────
-
-type mockLoadBalancersClient struct {
-	listFn func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerList], error)
-	getFn  func(ctx context.Context, projectID string, lbID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error)
-}
-
-func (m *mockLoadBalancersClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.LoadBalancerList]{StatusCode: 200, Data: &types.LoadBalancerList{}}, nil
-}
-func (m *mockLoadBalancersClient) Get(ctx context.Context, projectID, lbID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, lbID, params)
-	}
-	return &types.Response[types.LoadBalancerResponse]{StatusCode: 200, Data: &types.LoadBalancerResponse{}}, nil
-}
-
-type mockSecurityGroupsClient struct {
-	listFn   func(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupList], error)
-	getFn    func(ctx context.Context, projectID string, vpcID string, sgID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error)
-	createFn func(ctx context.Context, projectID string, vpcID string, body types.SecurityGroupRequest, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error)
-	updateFn func(ctx context.Context, projectID string, vpcID string, sgID string, body types.SecurityGroupRequest, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error)
-	deleteFn func(ctx context.Context, projectID string, vpcID string, sgID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockSecurityGroupsClient) List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, vpcID, params)
-	}
-	return &types.Response[types.SecurityGroupList]{StatusCode: 200, Data: &types.SecurityGroupList{}}, nil
-}
-func (m *mockSecurityGroupsClient) Get(ctx context.Context, projectID, vpcID, sgID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, vpcID, sgID, params)
-	}
-	return &types.Response[types.SecurityGroupResponse]{StatusCode: 200, Data: &types.SecurityGroupResponse{}}, nil
-}
-func (m *mockSecurityGroupsClient) Create(ctx context.Context, projectID, vpcID string, body types.SecurityGroupRequest, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, vpcID, body, params)
-	}
-	return &types.Response[types.SecurityGroupResponse]{StatusCode: 200, Data: &types.SecurityGroupResponse{}}, nil
-}
-func (m *mockSecurityGroupsClient) Update(ctx context.Context, projectID, vpcID, sgID string, body types.SecurityGroupRequest, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, vpcID, sgID, body, params)
-	}
-	return &types.Response[types.SecurityGroupResponse]{StatusCode: 200, Data: &types.SecurityGroupResponse{}}, nil
-}
-func (m *mockSecurityGroupsClient) Delete(ctx context.Context, projectID, vpcID, sgID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, vpcID, sgID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockSecurityGroupRulesClient struct {
-	listFn   func(ctx context.Context, projectID string, vpcID string, sgID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleList], error)
-	getFn    func(ctx context.Context, projectID string, vpcID string, sgID string, ruleID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error)
-	createFn func(ctx context.Context, projectID string, vpcID string, sgID string, body types.SecurityRuleRequest, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error)
-	updateFn func(ctx context.Context, projectID string, vpcID string, sgID string, ruleID string, body types.SecurityRuleRequest, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error)
-	deleteFn func(ctx context.Context, projectID string, vpcID string, sgID string, ruleID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockSecurityGroupRulesClient) List(ctx context.Context, projectID, vpcID, sgID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, vpcID, sgID, params)
-	}
-	return &types.Response[types.SecurityRuleList]{StatusCode: 200, Data: &types.SecurityRuleList{}}, nil
-}
-func (m *mockSecurityGroupRulesClient) Get(ctx context.Context, projectID, vpcID, sgID, ruleID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, vpcID, sgID, ruleID, params)
-	}
-	return &types.Response[types.SecurityRuleResponse]{StatusCode: 200, Data: &types.SecurityRuleResponse{}}, nil
-}
-func (m *mockSecurityGroupRulesClient) Create(ctx context.Context, projectID, vpcID, sgID string, body types.SecurityRuleRequest, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, vpcID, sgID, body, params)
-	}
-	return &types.Response[types.SecurityRuleResponse]{StatusCode: 200, Data: &types.SecurityRuleResponse{}}, nil
-}
-func (m *mockSecurityGroupRulesClient) Update(ctx context.Context, projectID, vpcID, sgID, ruleID string, body types.SecurityRuleRequest, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, vpcID, sgID, ruleID, body, params)
-	}
-	return &types.Response[types.SecurityRuleResponse]{StatusCode: 200, Data: &types.SecurityRuleResponse{}}, nil
-}
-func (m *mockSecurityGroupRulesClient) Delete(ctx context.Context, projectID, vpcID, sgID, ruleID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, vpcID, sgID, ruleID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockSubnetsClient struct {
-	listFn   func(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.SubnetList], error)
-	getFn    func(ctx context.Context, projectID string, vpcID string, subnetID string, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error)
-	createFn func(ctx context.Context, projectID string, vpcID string, body types.SubnetRequest, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error)
-	updateFn func(ctx context.Context, projectID string, vpcID string, subnetID string, body types.SubnetRequest, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error)
-	deleteFn func(ctx context.Context, projectID string, vpcID string, subnetID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockSubnetsClient) List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.SubnetList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, vpcID, params)
-	}
-	return &types.Response[types.SubnetList]{StatusCode: 200, Data: &types.SubnetList{}}, nil
-}
-func (m *mockSubnetsClient) Get(ctx context.Context, projectID, vpcID, subnetID string, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, vpcID, subnetID, params)
-	}
-	return &types.Response[types.SubnetResponse]{StatusCode: 200, Data: &types.SubnetResponse{}}, nil
-}
-func (m *mockSubnetsClient) Create(ctx context.Context, projectID, vpcID string, body types.SubnetRequest, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, vpcID, body, params)
-	}
-	return &types.Response[types.SubnetResponse]{StatusCode: 200, Data: &types.SubnetResponse{}}, nil
-}
-func (m *mockSubnetsClient) Update(ctx context.Context, projectID, vpcID, subnetID string, body types.SubnetRequest, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, vpcID, subnetID, body, params)
-	}
-	return &types.Response[types.SubnetResponse]{StatusCode: 200, Data: &types.SubnetResponse{}}, nil
-}
-func (m *mockSubnetsClient) Delete(ctx context.Context, projectID, vpcID, subnetID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, vpcID, subnetID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockVPCPeeringsClient struct {
-	listFn   func(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringList], error)
-	getFn    func(ctx context.Context, projectID string, vpcID string, peeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error)
-	createFn func(ctx context.Context, projectID string, vpcID string, body types.VPCPeeringRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error)
-	updateFn func(ctx context.Context, projectID string, vpcID string, peeringID string, body types.VPCPeeringRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error)
-	deleteFn func(ctx context.Context, projectID string, vpcID string, peeringID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockVPCPeeringsClient) List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, vpcID, params)
-	}
-	return &types.Response[types.VPCPeeringList]{StatusCode: 200, Data: &types.VPCPeeringList{}}, nil
-}
-func (m *mockVPCPeeringsClient) Get(ctx context.Context, projectID, vpcID, peeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, vpcID, peeringID, params)
-	}
-	return &types.Response[types.VPCPeeringResponse]{StatusCode: 200, Data: &types.VPCPeeringResponse{}}, nil
-}
-func (m *mockVPCPeeringsClient) Create(ctx context.Context, projectID, vpcID string, body types.VPCPeeringRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, vpcID, body, params)
-	}
-	return &types.Response[types.VPCPeeringResponse]{StatusCode: 200, Data: &types.VPCPeeringResponse{}}, nil
-}
-func (m *mockVPCPeeringsClient) Update(ctx context.Context, projectID, vpcID, peeringID string, body types.VPCPeeringRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, vpcID, peeringID, body, params)
-	}
-	return &types.Response[types.VPCPeeringResponse]{StatusCode: 200, Data: &types.VPCPeeringResponse{}}, nil
-}
-func (m *mockVPCPeeringsClient) Delete(ctx context.Context, projectID, vpcID, peeringID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, vpcID, peeringID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockVPCPeeringRoutesClient struct {
-	listFn   func(ctx context.Context, projectID string, vpcID string, peeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error)
-	getFn    func(ctx context.Context, projectID string, vpcID string, peeringID string, routeID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error)
-	createFn func(ctx context.Context, projectID string, vpcID string, peeringID string, body types.VPCPeeringRouteRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error)
-	updateFn func(ctx context.Context, projectID string, vpcID string, peeringID string, routeID string, body types.VPCPeeringRouteRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error)
-	deleteFn func(ctx context.Context, projectID string, vpcID string, peeringID string, routeID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockVPCPeeringRoutesClient) List(ctx context.Context, projectID, vpcID, peeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, vpcID, peeringID, params)
-	}
-	return &types.Response[types.VPCPeeringRouteList]{StatusCode: 200, Data: &types.VPCPeeringRouteList{}}, nil
-}
-func (m *mockVPCPeeringRoutesClient) Get(ctx context.Context, projectID, vpcID, peeringID, routeID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, vpcID, peeringID, routeID, params)
-	}
-	return &types.Response[types.VPCPeeringRouteResponse]{StatusCode: 200, Data: &types.VPCPeeringRouteResponse{}}, nil
-}
-func (m *mockVPCPeeringRoutesClient) Create(ctx context.Context, projectID, vpcID, peeringID string, body types.VPCPeeringRouteRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, vpcID, peeringID, body, params)
-	}
-	return &types.Response[types.VPCPeeringRouteResponse]{StatusCode: 200, Data: &types.VPCPeeringRouteResponse{}}, nil
-}
-func (m *mockVPCPeeringRoutesClient) Update(ctx context.Context, projectID, vpcID, peeringID, routeID string, body types.VPCPeeringRouteRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, vpcID, peeringID, routeID, body, params)
-	}
-	return &types.Response[types.VPCPeeringRouteResponse]{StatusCode: 200, Data: &types.VPCPeeringRouteResponse{}}, nil
-}
-func (m *mockVPCPeeringRoutesClient) Delete(ctx context.Context, projectID, vpcID, peeringID, routeID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, vpcID, peeringID, routeID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockVPNTunnelsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelList], error)
-	getFn    func(ctx context.Context, projectID string, tunnelID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.VPNTunnelRequest, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error)
-	updateFn func(ctx context.Context, projectID string, tunnelID string, body types.VPNTunnelRequest, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error)
-	deleteFn func(ctx context.Context, projectID string, tunnelID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockVPNTunnelsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.VPNTunnelList]{StatusCode: 200, Data: &types.VPNTunnelList{}}, nil
-}
-func (m *mockVPNTunnelsClient) Get(ctx context.Context, projectID, tunnelID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, tunnelID, params)
-	}
-	return &types.Response[types.VPNTunnelResponse]{StatusCode: 200, Data: &types.VPNTunnelResponse{}}, nil
-}
-func (m *mockVPNTunnelsClient) Create(ctx context.Context, projectID string, body types.VPNTunnelRequest, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.VPNTunnelResponse]{StatusCode: 200, Data: &types.VPNTunnelResponse{}}, nil
-}
-func (m *mockVPNTunnelsClient) Update(ctx context.Context, projectID, tunnelID string, body types.VPNTunnelRequest, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, tunnelID, body, params)
-	}
-	return &types.Response[types.VPNTunnelResponse]{StatusCode: 200, Data: &types.VPNTunnelResponse{}}, nil
-}
-func (m *mockVPNTunnelsClient) Delete(ctx context.Context, projectID, tunnelID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, tunnelID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockVPNRoutesClient struct {
-	listFn   func(ctx context.Context, projectID string, tunnelID string, params *types.RequestParameters) (*types.Response[types.VPNRouteList], error)
-	getFn    func(ctx context.Context, projectID string, tunnelID string, routeID string, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error)
-	createFn func(ctx context.Context, projectID string, tunnelID string, body types.VPNRouteRequest, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error)
-	updateFn func(ctx context.Context, projectID string, tunnelID string, routeID string, body types.VPNRouteRequest, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error)
-	deleteFn func(ctx context.Context, projectID string, tunnelID string, routeID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockVPNRoutesClient) List(ctx context.Context, projectID, tunnelID string, params *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, tunnelID, params)
-	}
-	return &types.Response[types.VPNRouteList]{StatusCode: 200, Data: &types.VPNRouteList{}}, nil
-}
-func (m *mockVPNRoutesClient) Get(ctx context.Context, projectID, tunnelID, routeID string, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, tunnelID, routeID, params)
-	}
-	return &types.Response[types.VPNRouteResponse]{StatusCode: 200, Data: &types.VPNRouteResponse{}}, nil
-}
-func (m *mockVPNRoutesClient) Create(ctx context.Context, projectID, tunnelID string, body types.VPNRouteRequest, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, tunnelID, body, params)
-	}
-	return &types.Response[types.VPNRouteResponse]{StatusCode: 200, Data: &types.VPNRouteResponse{}}, nil
-}
-func (m *mockVPNRoutesClient) Update(ctx context.Context, projectID, tunnelID, routeID string, body types.VPNRouteRequest, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, tunnelID, routeID, body, params)
-	}
-	return &types.Response[types.VPNRouteResponse]{StatusCode: 200, Data: &types.VPNRouteResponse{}}, nil
-}
-func (m *mockVPNRoutesClient) Delete(ctx context.Context, projectID, tunnelID, routeID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, tunnelID, routeID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── storage: remaining sub-clients ──────────────────────────────────────────
-
-type mockSnapshotsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotList], error)
-	getFn    func(ctx context.Context, projectID string, snapshotID string, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
-	updateFn func(ctx context.Context, projectID string, snapshotID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
-	deleteFn func(ctx context.Context, projectID string, snapshotID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockSnapshotsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.SnapshotList]{StatusCode: 200, Data: &types.SnapshotList{}}, nil
-}
-func (m *mockSnapshotsClient) Get(ctx context.Context, projectID, snapshotID string, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, snapshotID, params)
-	}
-	return &types.Response[types.SnapshotResponse]{StatusCode: 200, Data: &types.SnapshotResponse{}}, nil
-}
-func (m *mockSnapshotsClient) Create(ctx context.Context, projectID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.SnapshotResponse]{StatusCode: 200, Data: &types.SnapshotResponse{}}, nil
-}
-func (m *mockSnapshotsClient) Update(ctx context.Context, projectID, snapshotID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, snapshotID, body, params)
-	}
-	return &types.Response[types.SnapshotResponse]{StatusCode: 200, Data: &types.SnapshotResponse{}}, nil
-}
-func (m *mockSnapshotsClient) Delete(ctx context.Context, projectID, snapshotID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, snapshotID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockStorageBackupsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupList], error)
-	getFn    func(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
-	updateFn func(ctx context.Context, projectID string, backupID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
-	deleteFn func(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockStorageBackupsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.StorageBackupList]{StatusCode: 200, Data: &types.StorageBackupList{}}, nil
-}
-func (m *mockStorageBackupsClient) Get(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, backupID, params)
-	}
-	return &types.Response[types.StorageBackupResponse]{StatusCode: 200, Data: &types.StorageBackupResponse{}}, nil
-}
-func (m *mockStorageBackupsClient) Create(ctx context.Context, projectID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.StorageBackupResponse]{StatusCode: 200, Data: &types.StorageBackupResponse{}}, nil
-}
-func (m *mockStorageBackupsClient) Update(ctx context.Context, projectID, backupID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, backupID, body, params)
-	}
-	return &types.Response[types.StorageBackupResponse]{StatusCode: 200, Data: &types.StorageBackupResponse{}}, nil
-}
-func (m *mockStorageBackupsClient) Delete(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, backupID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-type mockStorageRestoreClient struct {
-	listFn   func(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[types.RestoreList], error)
-	getFn    func(ctx context.Context, projectID string, backupID string, restoreID string, params *types.RequestParameters) (*types.Response[types.RestoreResponse], error)
-	createFn func(ctx context.Context, projectID string, backupID string, body types.RestoreRequest, params *types.RequestParameters) (*types.Response[types.RestoreResponse], error)
-	updateFn func(ctx context.Context, projectID string, backupID string, restoreID string, body types.RestoreRequest, params *types.RequestParameters) (*types.Response[types.RestoreResponse], error)
-	deleteFn func(ctx context.Context, projectID string, backupID string, restoreID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockStorageRestoreClient) List(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.RestoreList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, backupID, params)
-	}
-	return &types.Response[types.RestoreList]{StatusCode: 200, Data: &types.RestoreList{}}, nil
-}
-func (m *mockStorageRestoreClient) Get(ctx context.Context, projectID, backupID, restoreID string, params *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, backupID, restoreID, params)
-	}
-	return &types.Response[types.RestoreResponse]{StatusCode: 200, Data: &types.RestoreResponse{}}, nil
-}
-func (m *mockStorageRestoreClient) Create(ctx context.Context, projectID, backupID string, body types.RestoreRequest, params *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, backupID, body, params)
-	}
-	return &types.Response[types.RestoreResponse]{StatusCode: 200, Data: &types.RestoreResponse{}}, nil
-}
-func (m *mockStorageRestoreClient) Update(ctx context.Context, projectID, backupID, restoreID string, body types.RestoreRequest, params *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, backupID, restoreID, body, params)
-	}
-	return &types.Response[types.RestoreResponse]{StatusCode: 200, Data: &types.RestoreResponse{}}, nil
-}
-func (m *mockStorageRestoreClient) Delete(ctx context.Context, projectID, backupID, restoreID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, backupID, restoreID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── database ─────────────────────────────────────────────────────────────────
-
-type mockDatabaseClient struct {
-	dbaasClient     aruba.DBaaSClient
-	databasesClient aruba.DatabasesClient
-	backupsClient   aruba.BackupsClient
-	usersClient     aruba.UsersClient
-}
-
-func (m *mockDatabaseClient) DBaaS() aruba.DBaaSClient         { return m.dbaasClient }
-func (m *mockDatabaseClient) Databases() aruba.DatabasesClient { return m.databasesClient }
-func (m *mockDatabaseClient) Backups() aruba.BackupsClient     { return m.backupsClient }
-func (m *mockDatabaseClient) Users() aruba.UsersClient         { return m.usersClient }
-func (m *mockDatabaseClient) Grants() aruba.GrantsClient       { return nil }
-
-type mockDBaaSClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSList], error)
-	getFn    func(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.DBaaSRequest, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error)
-	updateFn func(ctx context.Context, projectID string, dbaasID string, body types.DBaaSRequest, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error)
-	deleteFn func(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockDBaaSClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.DBaaSList]{StatusCode: 200, Data: &types.DBaaSList{}}, nil
-}
-func (m *mockDBaaSClient) Get(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, dbaasID, params)
-	}
-	return &types.Response[types.DBaaSResponse]{StatusCode: 200, Data: &types.DBaaSResponse{}}, nil
-}
-func (m *mockDBaaSClient) Create(ctx context.Context, projectID string, body types.DBaaSRequest, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
+// newArubaTestServer stands up the fake API and a real aruba.Client pointed at
+// it. The server is torn down automatically via t.Cleanup.
+func newArubaTestServer(t *testing.T) *arubaTestServer {
+	t.Helper()
+	a := &arubaTestServer{
+		t:      t,
+		routes: map[string]http.HandlerFunc{},
 	}
-	return &types.Response[types.DBaaSResponse]{StatusCode: 200, Data: &types.DBaaSResponse{}}, nil
-}
-func (m *mockDBaaSClient) Update(ctx context.Context, projectID, dbaasID string, body types.DBaaSRequest, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, dbaasID, body, params)
-	}
-	return &types.Response[types.DBaaSResponse]{StatusCode: 200, Data: &types.DBaaSResponse{}}, nil
-}
-func (m *mockDBaaSClient) Delete(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, dbaasID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
+	a.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := a.routes[key]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("arubaTestServer: unregistered route %q (have: %v)", key, a.routeKeys())
+		http.Error(w, "unregistered route", http.StatusNotFound)
+	}))
+	t.Cleanup(a.srv.Close)
 
-type mockDatabasesClient struct {
-	listFn   func(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseList], error)
-	getFn    func(ctx context.Context, projectID string, dbaasID string, dbID string, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error)
-	createFn func(ctx context.Context, projectID string, dbaasID string, body types.DatabaseRequest, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error)
-	updateFn func(ctx context.Context, projectID string, dbaasID string, dbID string, body types.DatabaseRequest, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error)
-	deleteFn func(ctx context.Context, projectID string, dbaasID string, dbID string, params *types.RequestParameters) (*types.Response[any], error)
-}
-
-func (m *mockDatabasesClient) List(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, dbaasID, params)
-	}
-	return &types.Response[types.DatabaseList]{StatusCode: 200, Data: &types.DatabaseList{}}, nil
-}
-func (m *mockDatabasesClient) Get(ctx context.Context, projectID, dbaasID, dbID string, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, dbaasID, dbID, params)
-	}
-	return &types.Response[types.DatabaseResponse]{StatusCode: 200, Data: &types.DatabaseResponse{}}, nil
-}
-func (m *mockDatabasesClient) Create(ctx context.Context, projectID, dbaasID string, body types.DatabaseRequest, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, dbaasID, body, params)
-	}
-	return &types.Response[types.DatabaseResponse]{StatusCode: 200, Data: &types.DatabaseResponse{}}, nil
-}
-func (m *mockDatabasesClient) Update(ctx context.Context, projectID, dbaasID, dbID string, body types.DatabaseRequest, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, dbaasID, dbID, body, params)
-	}
-	return &types.Response[types.DatabaseResponse]{StatusCode: 200, Data: &types.DatabaseResponse{}}, nil
-}
-func (m *mockDatabasesClient) Delete(ctx context.Context, projectID, dbaasID, dbID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, dbaasID, dbID, params)
+	opts := aruba.NewOptions().
+		WithBaseURL(a.srv.URL).
+		WithToken("test-token").
+		WithNoLogs()
+	client, err := aruba.NewClient(opts)
+	if err != nil {
+		t.Fatalf("newArubaTestServer: %v", err)
 	}
-	return &types.Response[any]{StatusCode: 200}, nil
+	a.client = client
+	return a
 }
 
-type mockDBBackupsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BackupList], error)
-	getFn    func(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[types.BackupResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.BackupRequest, params *types.RequestParameters) (*types.Response[types.BackupResponse], error)
-	deleteFn func(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[any], error)
-}
+// Client returns the real aruba.Client pointed at the fake server.
+func (a *arubaTestServer) Client() aruba.Client { return a.client }
 
-func (m *mockDBBackupsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BackupList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.BackupList]{StatusCode: 200, Data: &types.BackupList{}}, nil
-}
-func (m *mockDBBackupsClient) Get(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, backupID, params)
-	}
-	return &types.Response[types.BackupResponse]{StatusCode: 200, Data: &types.BackupResponse{}}, nil
-}
-func (m *mockDBBackupsClient) Create(ctx context.Context, projectID string, body types.BackupRequest, params *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.BackupResponse]{StatusCode: 200, Data: &types.BackupResponse{}}, nil
-}
-func (m *mockDBBackupsClient) Delete(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, backupID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
+// On registers a handler for an exact "METHOD /path" key.
+func (a *arubaTestServer) On(method, path string, h http.HandlerFunc) *arubaTestServer {
+	a.routes[method+" "+path] = h
+	return a
 }
 
-type mockUsersClient struct {
-	listFn   func(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.UserList], error)
-	getFn    func(ctx context.Context, projectID string, dbaasID string, userID string, params *types.RequestParameters) (*types.Response[types.UserResponse], error)
-	createFn func(ctx context.Context, projectID string, dbaasID string, body types.UserRequest, params *types.RequestParameters) (*types.Response[types.UserResponse], error)
-	updateFn func(ctx context.Context, projectID string, dbaasID string, userID string, body types.UserRequest, params *types.RequestParameters) (*types.Response[types.UserResponse], error)
-	deleteFn func(ctx context.Context, projectID string, dbaasID string, userID string, params *types.RequestParameters) (*types.Response[any], error)
+// OnGet registers a GET handler.
+func (a *arubaTestServer) OnGet(path string, h http.HandlerFunc) *arubaTestServer {
+	return a.On(http.MethodGet, path, h)
 }
 
-func (m *mockUsersClient) List(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.UserList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, dbaasID, params)
-	}
-	return &types.Response[types.UserList]{StatusCode: 200, Data: &types.UserList{}}, nil
-}
-func (m *mockUsersClient) Get(ctx context.Context, projectID, dbaasID, userID string, params *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, dbaasID, userID, params)
-	}
-	return &types.Response[types.UserResponse]{StatusCode: 200, Data: &types.UserResponse{}}, nil
-}
-func (m *mockUsersClient) Create(ctx context.Context, projectID, dbaasID string, body types.UserRequest, params *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, dbaasID, body, params)
-	}
-	return &types.Response[types.UserResponse]{StatusCode: 200, Data: &types.UserResponse{}}, nil
-}
-func (m *mockUsersClient) Update(ctx context.Context, projectID, dbaasID, userID string, body types.UserRequest, params *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, dbaasID, userID, body, params)
-	}
-	return &types.Response[types.UserResponse]{StatusCode: 200, Data: &types.UserResponse{}}, nil
+// OnPost registers a POST handler.
+func (a *arubaTestServer) OnPost(path string, h http.HandlerFunc) *arubaTestServer {
+	return a.On(http.MethodPost, path, h)
 }
-func (m *mockUsersClient) Delete(ctx context.Context, projectID, dbaasID, userID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, dbaasID, userID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
 
-// ─── container ────────────────────────────────────────────────────────────────
-
-type mockContainerClient struct {
-	kaasClient              aruba.KaaSClient
-	containerRegistryClient aruba.ContainerRegistryClient
+// OnPut registers a PUT handler.
+func (a *arubaTestServer) OnPut(path string, h http.HandlerFunc) *arubaTestServer {
+	return a.On(http.MethodPut, path, h)
 }
 
-func (m *mockContainerClient) KaaS() aruba.KaaSClient { return m.kaasClient }
-func (m *mockContainerClient) ContainerRegistry() aruba.ContainerRegistryClient {
-	return m.containerRegistryClient
+// OnDelete registers a DELETE handler.
+func (a *arubaTestServer) OnDelete(path string, h http.HandlerFunc) *arubaTestServer {
+	return a.On(http.MethodDelete, path, h)
 }
 
-type mockKaaSClient struct {
-	listFn               func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSList], error)
-	getFn                func(ctx context.Context, projectID string, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
-	createFn             func(ctx context.Context, projectID string, body types.KaaSRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
-	updateFn             func(ctx context.Context, projectID string, kaasID string, body types.KaaSUpdateRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
-	deleteFn             func(ctx context.Context, projectID string, kaasID string, params *types.RequestParameters) (*types.Response[any], error)
-	downloadKubeconfigFn func(ctx context.Context, projectID string, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSKubeconfigResponse], error)
+// OnPatch registers a PATCH handler.
+func (a *arubaTestServer) OnPatch(path string, h http.HandlerFunc) *arubaTestServer {
+	return a.On(http.MethodPatch, path, h)
 }
 
-func (m *mockKaaSClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.KaaSList]{StatusCode: 200, Data: &types.KaaSList{}}, nil
-}
-func (m *mockKaaSClient) Get(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, kaasID, params)
-	}
-	return &types.Response[types.KaaSResponse]{StatusCode: 200, Data: &types.KaaSResponse{}}, nil
-}
-func (m *mockKaaSClient) Create(ctx context.Context, projectID string, body types.KaaSRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.KaaSResponse]{StatusCode: 200, Data: &types.KaaSResponse{}}, nil
-}
-func (m *mockKaaSClient) Update(ctx context.Context, projectID, kaasID string, body types.KaaSUpdateRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, kaasID, body, params)
-	}
-	return &types.Response[types.KaaSResponse]{StatusCode: 200, Data: &types.KaaSResponse{}}, nil
-}
-func (m *mockKaaSClient) Delete(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, kaasID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-func (m *mockKaaSClient) DownloadKubeconfig(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSKubeconfigResponse], error) {
-	if m.downloadKubeconfigFn != nil {
-		return m.downloadKubeconfigFn(ctx, projectID, kaasID, params)
+// routeKeys returns the registered route keys for diagnostic messages.
+func (a *arubaTestServer) routeKeys() []string {
+	keys := make([]string, 0, len(a.routes))
+	for k := range a.routes {
+		keys = append(keys, k)
 	}
-	return &types.Response[types.KaaSKubeconfigResponse]{StatusCode: 200, Data: &types.KaaSKubeconfigResponse{}}, nil
-}
-
-type mockContainerRegistryClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error)
-	getFn    func(ctx context.Context, projectID string, registryID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
-	updateFn func(ctx context.Context, projectID string, registryID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
-	deleteFn func(ctx context.Context, projectID string, registryID string, params *types.RequestParameters) (*types.Response[any], error)
+	return keys
 }
 
-func (m *mockContainerRegistryClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.ContainerRegistryList]{StatusCode: 200, Data: &types.ContainerRegistryList{}}, nil
-}
-func (m *mockContainerRegistryClient) Get(ctx context.Context, projectID, registryID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, registryID, params)
-	}
-	return &types.Response[types.ContainerRegistryResponse]{StatusCode: 200, Data: &types.ContainerRegistryResponse{}}, nil
-}
-func (m *mockContainerRegistryClient) Create(ctx context.Context, projectID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.ContainerRegistryResponse]{StatusCode: 200, Data: &types.ContainerRegistryResponse{}}, nil
-}
-func (m *mockContainerRegistryClient) Update(ctx context.Context, projectID, registryID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, registryID, body, params)
-	}
-	return &types.Response[types.ContainerRegistryResponse]{StatusCode: 200, Data: &types.ContainerRegistryResponse{}}, nil
-}
-func (m *mockContainerRegistryClient) Delete(ctx context.Context, projectID, registryID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, registryID, params)
+// jsonResponse writes status + JSON-marshalled body. body is typically a
+// types.*Response or types.*List value that the SDK adapter expects.
+func jsonResponse(status int, body any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != nil {
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				// This runs inside a live httptest handler; panic surfaces in the test.
+				panic("jsonResponse: encode: " + err.Error())
+			}
+		}
 	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── schedule ─────────────────────────────────────────────────────────────────
-
-type mockScheduleClient struct {
-	jobsClient aruba.JobsClient
-}
-
-func (m *mockScheduleClient) Jobs() aruba.JobsClient { return m.jobsClient }
-
-type mockJobsClient struct {
-	listFn   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.JobList], error)
-	getFn    func(ctx context.Context, projectID string, jobID string, params *types.RequestParameters) (*types.Response[types.JobResponse], error)
-	createFn func(ctx context.Context, projectID string, body types.JobRequest, params *types.RequestParameters) (*types.Response[types.JobResponse], error)
-	updateFn func(ctx context.Context, projectID string, jobID string, body types.JobRequest, params *types.RequestParameters) (*types.Response[types.JobResponse], error)
-	deleteFn func(ctx context.Context, projectID string, jobID string, params *types.RequestParameters) (*types.Response[any], error)
 }
 
-func (m *mockJobsClient) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.JobList], error) {
-	if m.listFn != nil {
-		return m.listFn(ctx, projectID, params)
-	}
-	return &types.Response[types.JobList]{StatusCode: 200, Data: &types.JobList{}}, nil
+// errorResponse writes status + a types.ErrorResponse JSON body so the SDK
+// adapter surfaces it as an *aruba.HTTPError (which apiErrFromV2 formats).
+func errorResponse(status int, title, detail string) http.HandlerFunc {
+	return jsonResponse(status, types.ErrorResponse{
+		Title:  &title,
+		Detail: &detail,
+	})
 }
-func (m *mockJobsClient) Get(ctx context.Context, projectID, jobID string, params *types.RequestParameters) (*types.Response[types.JobResponse], error) {
-	if m.getFn != nil {
-		return m.getFn(ctx, projectID, jobID, params)
-	}
-	return &types.Response[types.JobResponse]{StatusCode: 200, Data: &types.JobResponse{}}, nil
-}
-func (m *mockJobsClient) Create(ctx context.Context, projectID string, body types.JobRequest, params *types.RequestParameters) (*types.Response[types.JobResponse], error) {
-	if m.createFn != nil {
-		return m.createFn(ctx, projectID, body, params)
-	}
-	return &types.Response[types.JobResponse]{StatusCode: 200, Data: &types.JobResponse{}}, nil
-}
-func (m *mockJobsClient) Update(ctx context.Context, projectID, jobID string, body types.JobRequest, params *types.RequestParameters) (*types.Response[types.JobResponse], error) {
-	if m.updateFn != nil {
-		return m.updateFn(ctx, projectID, jobID, body, params)
-	}
-	return &types.Response[types.JobResponse]{StatusCode: 200, Data: &types.JobResponse{}}, nil
-}
-func (m *mockJobsClient) Delete(ctx context.Context, projectID, jobID string, params *types.RequestParameters) (*types.Response[any], error) {
-	if m.deleteFn != nil {
-		return m.deleteFn(ctx, projectID, jobID, params)
-	}
-	return &types.Response[any]{StatusCode: 200}, nil
-}
-
-// ─── security (KMS is a concrete SDK type — cannot be mocked externally) ─────
-
-type mockSecurityClient struct{}
-
-// KMS returns nil. The KMS SDK client (aruba.KMSClient = *security.KMSClientWrapper)
-// is a concrete internal type that cannot be constructed outside the SDK vendor tree.
-// KMS command tests are therefore not supported via this mock infrastructure.
-func (m *mockSecurityClient) KMS() aruba.KMSClient { return nil }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 // strPtr returns a pointer to s. Convenience for building SDK response structs in tests.
 func strPtr(s string) *string { return &s }
-
-// newMockClient constructs a mockClient wired to the given sub-mocks.
-// Pass nil for sub-mocks that the test doesn't exercise.
-func newMockClient(opts ...func(*mockClient)) *mockClient {
-	c := &mockClient{}
-	for _, o := range opts {
-		o(c)
-	}
-	return c
-}
-
-// withNetwork attaches a network client built with the supplied VPCs mock.
-func withNetwork(vpcs *mockVPCsClient) func(*mockClient) {
-	return func(c *mockClient) {
-		c.networkClient = &mockNetworkClient{vpcsMock: vpcs}
-	}
-}
-
-// withCompute attaches a compute client built with the supplied CloudServers mock.
-func withCompute(cs *mockCloudServersClient) func(*mockClient) {
-	return func(c *mockClient) {
-		c.computeClient = &mockComputeClient{cloudServersClient: cs}
-	}
-}
-
-// withStorage attaches a storage client built with the supplied Volumes mock.
-func withStorage(v *mockVolumesClient) func(*mockClient) {
-	return func(c *mockClient) {
-		c.storageClient = &mockStorageClient{volumesMock: v}
-	}
-}
-
-// withProject attaches a project client mock.
-func withProject(p *mockProjectClient) func(*mockClient) {
-	return func(c *mockClient) {
-		c.projectClient = p
-	}
-}
-
-// withNetworkMock attaches a pre-built network mock (all sub-clients configurable).
-func withNetworkMock(n *mockNetworkClient) func(*mockClient) {
-	return func(c *mockClient) { c.networkClient = n }
-}
-
-// withComputeMock attaches a pre-built compute mock.
-func withComputeMock(cm *mockComputeClient) func(*mockClient) {
-	return func(c *mockClient) { c.computeClient = cm }
-}
-
-// withStorageMock attaches a pre-built storage mock.
-func withStorageMock(s *mockStorageClient) func(*mockClient) {
-	return func(c *mockClient) { c.storageClient = s }
-}
-
-// withDatabase attaches a database client mock.
-func withDatabase(d *mockDatabaseClient) func(*mockClient) {
-	return func(c *mockClient) { c.databaseClient = d }
-}
-
-// withContainer attaches a container client mock.
-func withContainer(con *mockContainerClient) func(*mockClient) {
-	return func(c *mockClient) { c.containerClient = con }
-}
-
-// withSchedule attaches a schedule client mock.
-func withSchedule(s *mockScheduleClient) func(*mockClient) {
-	return func(c *mockClient) { c.scheduleClient = s }
-}
 
 // resetCmdFlags walks the entire command tree and marks every flag as "not
 // changed". This is required because cobra/pflag tracks a "changed" bit per
@@ -1180,9 +157,6 @@ func runCmd(mock aruba.Client, args []string) error {
 	rootCmd.SetArgs(args)
 	return rootCmd.Execute()
 }
-
-// errSDK returns a non-nil SDK error suitable for injection in test cases.
-func errSDK(msg string) error { return errors.New(msg) }
 
 // runCmdCapture executes rootCmd with the given args (via runCmd) and returns
 // everything written to os.Stdout during the call. Use this instead of runCmd


### PR DESCRIPTION
Closes #101. Part of #99.

## Summary
- Replaces the v0.1.x mock-struct tree in `cmd/mock_test.go` (root `mockClient`,
  6 aggregator mocks, 24 `*Fn` leaf structs, `newMockClient` + 10 options) with an
  **httptest-server harness** (1202 → 178 lines, net -1037).
- Adds `arubaTestServer` + `newArubaTestServer(t)`: stands up an `httptest.Server`
  and a real `aruba.Client` pointed at it (`WithToken` → `StaticTokenManager`,
  no OAuth). Routes registered via `On`/`OnGet`/`OnPost`/`OnPut`/`OnDelete`/`OnPatch`;
  responders built with `jsonResponse` / `errorResponse`.
- Keeps `runCmd`, `runCmdCapture`, `resetCmdFlags`, `strPtr` unchanged — they
  already take an `aruba.Client` interface value.
- Updates the Test Conventions section of `ai/CONVENTIONS.md`.

## Why the harness instead of fake wrappers
#101's original plan was to hand-build hydrated `aruba.*` wrapper values via
constructors / setters / `json.Unmarshal`. All three were verified unworkable:
v0.2.0 wrapper types carry an unexported `meta` set only by the unexported
`fromResponse`; `New*()` returns empty request-builders; `.Named()` sets only
Name; no `UnmarshalJSON` exists. The only way to get a wrapper with real
`.ID()`/`.State()`/`List[T]` is to let a real SDK adapter hydrate it from a real
HTTP response — hence the httptest harness. Bonus: KMS/Grants/Keys/Kmips/Audit/
Metric become testable uniformly, with no special-casing.

## Build status
`cmd/mock_test.go` compiles **standalone** against v0.2.0. The consuming
`cmd/*_test.go` files remain red until their families migrate (#103-#110) — by
design per #101 acceptance. Verification was static signature review only;
whole-tree `go build`/`test`/`lint` are intentionally red on this integration
branch mid-migration.

## Verification results
- `gofmt -l cmd/mock_test.go` — clean (no output)
- `go vet ./cmd/ 2>&1 | grep "mock_test.go"` — no errors in `mock_test.go`
- All 13 required symbols confirmed present (signature review below)

```
32: func newArubaTestServer(t *testing.T) *arubaTestServer
62: func (a *arubaTestServer) Client() aruba.Client
65: func (a *arubaTestServer) On(method, path string, h http.HandlerFunc) *arubaTestServer
71: func (a *arubaTestServer) OnGet(path string, h http.HandlerFunc) *arubaTestServer
76: func (a *arubaTestServer) OnPost(path string, h http.HandlerFunc) *arubaTestServer
81: func (a *arubaTestServer) OnPut(path string, h http.HandlerFunc) *arubaTestServer
86: func (a *arubaTestServer) OnDelete(path string, h http.HandlerFunc) *arubaTestServer
106: func jsonResponse(status int, body any) http.HandlerFunc
121: func errorResponse(status int, title, detail string) http.HandlerFunc
131: func strPtr(s string) *string
138: func resetCmdFlags(cmd *cobra.Command)
152: func runCmd(mock aruba.Client, args []string) error
164: func runCmdCapture(mock aruba.Client, args []string) (string, error)
```

- `grep -n "mockClient\|newMockClient\|errSDK\|with[A-Z]" cmd/mock_test.go` — no output (old tree fully removed)

## Test plan
- [ ] `gofmt -l cmd/mock_test.go` — clean
- [ ] `go vet ./cmd/` — confirm no errors originate in `mock_test.go`
- [ ] Spot-check harness signatures match #101 acceptance