### PR TITLE
feat(sdk): migrate management.project to SDK v0.2.0 wrapper API (#102)

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -43,31 +43,55 @@ If `LoadConfig()` fails (missing `~/.acloud.yaml`), the error is wrapped:
 
 ## SDK Call Pattern
 
-All resource operations follow the builder pattern through the client:
+SDK v0.2.0 uses a fluent **wrapper layer**. `client.From<Svc>()` returns a typed
+sub-client; each CRUD method returns a hydrated wrapper type or `*aruba.List[T]`
+rather than raw `types.*Response` structs.
 
 ```go
-client.FromStorage().Volumes().Create(ctx, projectID, request, nil)
-client.FromCompute().CloudServers().Get(ctx, projectID, id, nil)
-client.FromNetwork().VPCs().List(ctx, projectID, nil)
+// Top-level resources (e.g. project) — addressed by aruba.Ref:
+client.FromProject().Get(ctx, projectRef(id))      // → (*aruba.Project, error)
+client.FromProject().List(ctx, listOpts(cmd)...)   // → (*aruba.List[*aruba.Project], error)
+client.FromProject().Create(ctx, proj)             // → (*aruba.Project, error)
+client.FromProject().Update(ctx, proj)             // → (*aruba.Project, error)
+client.FromProject().Delete(ctx, projectRef(id))   // → error
+
+// Project-scoped resources — wrapper built with IntoProject(projectRef):
+client.FromCompute().CloudServers().Get(ctx, ref)  // → (*aruba.CloudServer, error)
+client.FromStorage().BlockStorages().List(ctx, ...)// → (*aruba.List[*aruba.BlockStorage], error)
+
+// Regional resources carry .InRegion(region) on the wrapper builder.
+// Zonal resources additionally carry .InZone(zone).
+// Resources that need WaitUntilActive call it on the returned wrapper.
 ```
 
-- The 4th argument (`options`) is always `nil` in current commands.
-- `ctx` is always `context.Background()`, declared inline in the handler.
-- The response carries `.IsError()`, `.StatusCode`, `.Error.Title`, `.Error.Detail`, and `.Data`.
+**Ref addressing** — resources are addressed by `aruba.Ref` (an interface with `URI()
+string`). Use `aruba.URI("/projects/"+id)` (wrapped by `projectRef` in `cmd/root.go`)
+for top-level refs and chain `IntoProject(proj)` / `IntoVPC(vpc)` on wrappers for
+scoped resources.
 
-**Response error check pattern:**
+**Error handling** — non-2xx responses surface as `*aruba.HTTPError` in the error
+return. There is no `response.IsError()` check. Use `apiErrFromV2(err)` (in
+`cmd/root.go`) to format HTTP errors while passing transport errors through. Always
+wrap with a verb prefix:
+
 ```go
-if response != nil && response.IsError() && response.Error != nil {
-    fmt.Printf("Failed - Status: %d\n", response.StatusCode)
-    if response.Error.Title != nil {
-        fmt.Printf("Error: %s\n", *response.Error.Title)
-    }
-    if response.Error.Detail != nil {
-        fmt.Printf("Detail: %s\n", *response.Error.Detail)
-    }
-    return
+result, err := client.From<Svc>().<Resource>().Op(ctx, ...)
+if err != nil {
+    return fmt.Errorf("<verb> <resource>: %w", apiErrFromV2(err))
 }
 ```
+
+**Rendering** — wrapper types (`*aruba.<T>`) carry only unexported fields and are not
+JSON-marshalable. For table columns the wrapper exposes (`.ID()`, `.Name()`,
+`.State()`, `.CreatedAt()`, …) use the accessors directly. For fields the wrapper
+omits (e.g. `ResourcesNumber` on `*aruba.Project`) and for `-o json`/`-o yaml`
+payloads, re-parse the typed `types.<T>Response` from the wrapper's `RawHTTP()` raw
+body via a file-local `<resource>FromRaw` helper. For list `-o json`, extract the
+typed list via `list.Raw()` (stores the original `*types.Response[types.<T>List]`)
+via a file-local `<resource>ListPayload` helper.
+
+**`ctx`** — use `newCtx()` (30-second timeout, in `cmd/root.go`) for all SDK calls.
+Completion functions that run interactively may keep `context.Background()`.
 
 ---
 

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -176,29 +176,41 @@ Never dereference a response pointer without a nil guard.
 
 ## Standard Command Bodies
 
+SDK v0.2.0 uses a fluent wrapper layer. `client.From<Svc>().<Resource>()` returns a
+typed client whose CRUD methods take/return hydrated wrapper types (`*aruba.<T>`,
+`*aruba.List[*aruba.<T>]`) rather than raw request/response structs. Non-2xx
+responses surface as `*aruba.HTTPError` in the error return — there is no separate
+`response.IsError()` check. Use `apiErrFromV2(err)` to format HTTP errors; wrap with
+a verb prefix for all error sites.
+
+**Wrapper note:** `*aruba.<T>` wrapper types carry only unexported fields and are not
+JSON-marshalable. For fields the wrapper does not expose as an accessor, and for
+`-o json`/`-o yaml` payloads, re-parse the wire `types.<T>Response` from the
+wrapper's `RawHTTP()` body via a file-local `<resource>FromRaw` helper (see the
+`management.project.go` reference implementation).
+
 ### list
 ```go
-projectID, err := GetProjectID(cmd)
-if err != nil { fmt.Printf("Error: %v\n", err); return }
-
 client, err := GetArubaClient()
-if err != nil { fmt.Printf("Error initializing client: %v\n", err); return }
+if err != nil { return fmt.Errorf("initializing client: %w", err) }
 
-ctx := context.Background()
-response, err := client.From<Svc>().<Resource>().List(ctx, projectID, nil)
-if err != nil { fmt.Printf("Error listing <resources>: %v\n", err); return }
+ctx, cancel := newCtx()
+defer cancel()
+list, err := client.From<Svc>().<Resource>().List(ctx, listOpts(cmd)...)
+if err != nil { return fmt.Errorf("listing <resources>: %w", apiErrFromV2(err)) }
 
-if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+if list != nil && len(list.Items()) > 0 {
     headers := []TableColumn{
         {Header: "NAME", Width: 30},
         {Header: "ID",   Width: 26},
         // ...
     }
     var rows [][]string
-    for _, r := range response.Data.Values {
-        rows = append(rows, []string{safePtrStr(r.Metadata.Name), safePtrStr(r.Metadata.ID), ...})
+    for _, r := range list.Items() {
+        rows = append(rows, []string{r.Name(), r.ID(), ...})
     }
-    PrintOutput(response.Data, headers, rows)
+    // For -o json/yaml, extract the typed list from Raw() — see <resource>ListPayload.
+    PrintOutput(<resource>ListPayload(list), headers, rows)
 } else {
     fmt.Println("No <resources> found")
 }
@@ -207,46 +219,71 @@ if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
 ### get
 ```go
 resourceID := args[0]
-// GetProjectID, GetArubaClient, context.Background() ...
-resp, err := client.From<Svc>().<Resource>().Get(ctx, projectID, resourceID, nil)
-if err != nil { ... return }
-// check resp.IsError() ...
+client, err := GetArubaClient()
+if err != nil { return fmt.Errorf("initializing client: %w", err) }
 
-// Honour -o json / -o yaml before the human-formatted block
-format := resolveOutputFormat()
-if format == OutputFormatJSON || format == OutputFormatYAML {
-    PrintOutput(resp.Data, nil, nil)
-    return nil
+ctx, cancel := newCtx()
+defer cancel()
+got, err := client.From<Svc>().<Resource>().Get(ctx, <ref>, ...)
+if err != nil { return fmt.Errorf("getting <resource>: %w", apiErrFromV2(err)) }
+
+// Re-parse for fields the wrapper omits and for -o json/yaml (wrapper is not marshalable).
+resource := <resource>FromRaw(got)
+if resource != nil {
+    format := resolveOutputFormat()
+    if format == OutputFormatJSON || format == OutputFormatYAML {
+        PrintOutput(resource, nil, nil)
+        return nil
+    }
+    fmt.Println("\n<Resource> Details:")
+    fmt.Println("===================")
+    if resource.Metadata.ID != nil { fmt.Printf("ID:   %s\n", *resource.Metadata.ID) }
+    // ...
+} else {
+    fmt.Println("<Resource> not found")
 }
-
-fmt.Println("\n<Resource> Details:")
-fmt.Println("===================")
-if resp.Data.Metadata.ID != nil { fmt.Printf("ID:   %s\n", *resp.Data.Metadata.ID) }
-// ...
 ```
 
 ### create
 ```go
-// 1. GetProjectID
-// 2. Extract flags; validate required ones early
-// 3. GetArubaClient
-// 4. Build types.<Resource>Request{} (nested struct)
-// 5. Call .Create(ctx, projectID, request, nil)
-// 6. Check err, then response.IsError()
-// 7. PrintOutput with single-row result (pass response.Data as first arg)
-PrintOutput(response.Data, headers, [][]string{row})
+// 1. Extract flags; validate required ones early
+// 2. GetArubaClient
+// 3. Build wrapper via aruba.New<T>() fluent setters:
+wrapper := aruba.New<T>().Named(name)
+if description != "" { wrapper.WithDescription(description) }
+// ...
+// 4. Call Create:
+ctx, cancel := newCtx()
+defer cancel()
+created, err := client.From<Svc>().<Resource>().Create(ctx, wrapper, ...)
+if err != nil { return fmt.Errorf("creating <resource>: %w", apiErrFromV2(err)) }
+// 5. Re-parse for output (wrapper not marshalable; may expose extra fields):
+resource := <resource>FromRaw(created)
+if resource != nil {
+    PrintOutput(resource, headers, [][]string{row})
+} else {
+    fmt.Println(msgCreatedAsync("<Resource>", name))
+}
 ```
 
 ### update
 ```go
-// 1. Get current resource via .Get() to preserve unmodified fields
-// 2. Build request from current values
-// 3. Overwrite only flags that were explicitly Changed:
-if name != "" { updateReq.Metadata.Name = name }
-if cmd.Flags().Changed("tags") { updateReq.Metadata.Tags = tags }
-// 4. Call .Update(ctx, projectID, id, request, nil)
-// 5. PrintOutput with single-row result
-PrintOutput(response.Data, headers, [][]string{row})
+// 1. Get current resource via Get to preserve unmodified fields:
+current, err := client.From<Svc>().<Resource>().Get(ctx, <ref>, ...)
+if err != nil { return fmt.Errorf("fetching current <resource>: %w", apiErrFromV2(err)) }
+// 2. Apply only the flags that were explicitly Changed:
+if description != "" { current.WithDescription(description) }
+if cmd.Flags().Changed("tags") { current.ReplaceTags(tags...) }
+// 3. Call Update with the hydrated wrapper (ID is preserved from Get):
+updated, err := client.From<Svc>().<Resource>().Update(ctx, current, ...)
+if err != nil { return fmt.Errorf("updating <resource>: %w", apiErrFromV2(err)) }
+// 4. Re-parse and render:
+resource := <resource>FromRaw(updated)
+if resource != nil {
+    PrintOutput(resource, headers, [][]string{row})
+} else {
+    fmt.Println(msgUpdatedAsync("<Resource>", id))
+}
 ```
 
 ### delete
@@ -254,8 +291,8 @@ PrintOutput(response.Data, headers, [][]string{row})
 // 1. --dry-run: call Get to validate existence, print msgDryRun, return nil
 dryRun, _ := cmd.Flags().GetBool("dry-run")
 if dryRun {
-    // GetProjectID, GetArubaClient, call .Get() to validate
-    if err != nil { return fmt.Errorf("getting <resource>: %w", err) }
+    _, err := client.From<Svc>().<Resource>().Get(ctx, <ref>)
+    if err != nil { return fmt.Errorf("dry-run: <resource> not found or inaccessible: %w", apiErrFromV2(err)) }
     fmt.Println(msgDryRun("<resource type>", id))
     return nil
 }
@@ -265,9 +302,12 @@ confirmed, err := confirmDelete("<resource type>", id)
 if err != nil { return err }
 if !confirmed { return nil }
 
-// 3. GetProjectID, GetArubaClient, .Delete(ctx, projectID, id, nil)
-// 4. Success message:
-fmt.Println(msgDeleted("<resource type>", id))
+// 3. GetArubaClient, Delete — returns error only (no response object):
+if err := client.From<Svc>().<Resource>().Delete(ctx, <ref>); err != nil {
+    return fmt.Errorf("deleting <resource>: %w", apiErrFromV2(err))
+}
+// 4. Success output (use PrintOutput for -o json support):
+PrintOutput(result, headers, [][]string{row})
 ```
 
 `confirmDelete(resourceType, id string) (bool, error)` is a helper in `cmd/root.go` that detects non-interactive stdin and skips the prompt when `--yes` is set or when stdin is not a terminal. Use it — do not inline the prompt.

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -43,6 +45,36 @@ func init() {
 	projectListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 }
 
+// projectFromRaw re-parses the full types.ProjectResponse from a Project
+// wrapper's raw HTTP body. The v0.2.0 *aruba.Project has only unexported fields
+// (not JSON-marshalable) and no accessor for Properties.ResourcesNumber, so
+// commands that render the RESOURCES column or emit -o json/yaml re-parse the
+// wire shape here. Returns nil on empty/malformed body — mirrors the v0.1.x
+// `response.Data == nil` async branch.
+func projectFromRaw(p *aruba.Project) *types.ProjectResponse {
+	if p == nil {
+		return nil
+	}
+	_, body := p.RawHTTP()
+	if len(body) == 0 {
+		return nil
+	}
+	var pr types.ProjectResponse
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return nil
+	}
+	return &pr
+}
+
+// projectListPayload extracts the typed *types.ProjectList from a List wrapper
+// for -o json/yaml rendering; the List[*Project] wrapper is not JSON-marshalable.
+func projectListPayload(l *aruba.List[*aruba.Project]) any {
+	if r, ok := l.Raw().(*types.Response[types.ProjectList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
 // completeProjectID provides completion for project IDs
 func completeProjectID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Allow completion even if args exist - user might be completing a partial ID
@@ -55,21 +87,22 @@ func completeProjectID(cmd *cobra.Command, args []string, toComplete string) ([]
 
 	// List projects
 	ctx := context.Background()
-	response, err := client.FromProject().List(ctx, nil)
+	list, err := client.FromProject().List(ctx)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, project := range response.Data.Values {
-			if project.Metadata.ID != nil && project.Metadata.Name != nil {
-				id := *project.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					// Format: "id\tname" - the tab separates the completion from the description
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *project.Metadata.Name))
-				}
+	if list != nil {
+		for _, project := range list.Items() {
+			id := project.ID()
+			if id == "" {
+				continue
+			}
+			// Filter by partial input - use HasPrefix for more reliable matching
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				// Format: "id\tname" - the tab separates the completion from the description
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, project.Name()))
 			}
 		}
 	}
@@ -108,19 +141,13 @@ Use 'acloud context set-project' to switch the active project at any time.`,
 		}
 
 		// Build the create request
-		createRequest := types.ProjectRequest{
-			Metadata: types.ResourceMetadataRequest{
-				Name: name,
-				Tags: tags,
-			},
-			Properties: types.ProjectPropertiesRequest{
-				Default: setDefault,
-			},
-		}
-
-		// Add description if provided
+		proj := aruba.NewProject().Named(name)
+		proj.ReplaceTags(tags...)
 		if description != "" {
-			createRequest.Properties.Description = &description
+			proj.WithDescription(description)
+		}
+		if setDefault {
+			proj.AsDefault()
 		}
 
 		// Debug output if verbose
@@ -140,16 +167,13 @@ Use 'acloud context set-project' to switch the active project at any time.`,
 		// Create the project using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromProject().Create(ctx, createRequest, nil)
+		created, err := client.FromProject().Create(ctx, proj)
 		if err != nil {
-			return fmt.Errorf("creating project: %w", err)
+			return fmt.Errorf("creating project: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		pr := projectFromRaw(created)
+		if pr != nil {
 			headers := []TableColumn{
 				{Header: "ID", Width: 30},
 				{Header: "NAME", Width: 40},
@@ -158,26 +182,26 @@ Use 'acloud context set-project' to switch the active project at any time.`,
 			}
 			row := []string{
 				func() string {
-					if response.Data.Metadata.ID != nil {
-						return *response.Data.Metadata.ID
+					if pr.Metadata.ID != nil {
+						return *pr.Metadata.ID
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Metadata.Name != nil {
-						return *response.Data.Metadata.Name
+					if pr.Metadata.Name != nil {
+						return *pr.Metadata.Name
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Properties.Default {
+					if pr.Properties.Default {
 						return "Yes"
 					}
 					return "No"
 				}(),
-				fmt.Sprintf("%d", response.Data.Properties.ResourcesNumber),
+				fmt.Sprintf("%d", pr.Properties.ResourcesNumber),
 			}
-			PrintOutput(response.Data, headers, [][]string{row})
+			PrintOutput(pr, headers, [][]string{row})
 		} else {
 			fmt.Println(msgCreatedAsync("Project", name))
 		}
@@ -201,18 +225,13 @@ var projectGetCmd = &cobra.Command{
 		// Get project details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromProject().Get(ctx, projectID, nil)
+		got, err := projectWrapper(ctx, client, projectID)
 		if err != nil {
 			return fmt.Errorf("getting project: %w", err)
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
-			project := response.Data
-
+		project := projectFromRaw(got)
+		if project != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
 				PrintOutput(project, nil, nil)
@@ -290,58 +309,37 @@ var projectUpdateCmd = &cobra.Command{
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current project details to preserve existing values
+		// First, get the current project details to preserve existing values.
+		// projectWrapper calls Get and normalises any API error via apiErrFromV2.
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromProject().Get(ctx, projectID, nil)
+		current, err := projectWrapper(ctx, client, projectID)
 		if err != nil {
 			return fmt.Errorf("fetching current project: %w", err)
 		}
 
-		if getResponse != nil && getResponse.IsError() {
-			return apiErrFromResp(getResponse.StatusCode, getResponse.Error)
-		}
-
-		if getResponse == nil || getResponse.Data == nil {
+		if current.ID() == "" {
 			return fmt.Errorf("project not found or no data returned")
 		}
 
-		currentProject := getResponse.Data
-
-		// Build the update request with current values as defaults
-		updateRequest := types.ProjectRequest{
-			Metadata: types.ResourceMetadataRequest{
-				Name: *currentProject.Metadata.Name,
-				Tags: currentProject.Metadata.Tags,
-			},
-			Properties: types.ProjectPropertiesRequest{
-				Default: currentProject.Properties.Default,
-			},
-		}
-
-		// Update description if provided
+		// Apply overrides on the hydrated wrapper — current already carries the
+		// fetched name/tags/description/default, so only changed flags need setting.
+		// This also fixes the v0.1.x nil-panic on *currentProject.Metadata.Name.
 		if description != "" {
-			updateRequest.Properties.Description = &description
-		} else if currentProject.Properties.Description != nil {
-			updateRequest.Properties.Description = currentProject.Properties.Description
+			current.WithDescription(description)
 		}
-
-		// Update tags if provided
 		if cmd.Flags().Changed("tags") {
-			updateRequest.Metadata.Tags = tags
+			current.ReplaceTags(tags...)
 		}
 
 		// Update the project using the SDK
-		response, err := client.FromProject().Update(ctx, projectID, updateRequest, nil)
+		updated, err := client.FromProject().Update(ctx, current)
 		if err != nil {
-			return fmt.Errorf("updating project: %w", err)
+			return fmt.Errorf("updating project: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		pr := projectFromRaw(updated)
+		if pr != nil {
 			headers := []TableColumn{
 				{Header: "ID", Width: 30},
 				{Header: "NAME", Width: 40},
@@ -350,26 +348,26 @@ var projectUpdateCmd = &cobra.Command{
 			}
 			row := []string{
 				func() string {
-					if response.Data.Metadata.ID != nil {
-						return *response.Data.Metadata.ID
+					if pr.Metadata.ID != nil {
+						return *pr.Metadata.ID
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Metadata.Name != nil {
-						return *response.Data.Metadata.Name
+					if pr.Metadata.Name != nil {
+						return *pr.Metadata.Name
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Properties.Default {
+					if pr.Properties.Default {
 						return "Yes"
 					}
 					return "No"
 				}(),
-				fmt.Sprintf("%d", response.Data.Properties.ResourcesNumber),
+				fmt.Sprintf("%d", pr.Properties.ResourcesNumber),
 			}
-			PrintOutput(response.Data, headers, [][]string{row})
+			PrintOutput(pr, headers, [][]string{row})
 		} else {
 			fmt.Println(msgUpdatedAsync("Project", projectID))
 		}
@@ -409,7 +407,7 @@ var projectDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromProject().Get(ctx, projectID, nil)
+			_, err = projectWrapper(ctx, client, projectID)
 			if err != nil {
 				return fmt.Errorf("dry-run: project not found or inaccessible: %w", err)
 			}
@@ -418,13 +416,8 @@ var projectDeleteCmd = &cobra.Command{
 		}
 
 		// Delete the project using the SDK
-		resp, err := client.FromProject().Delete(ctx, projectID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting project: %w", err)
-		}
-
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
+		if err := client.FromProject().Delete(ctx, projectRef(projectID)); err != nil {
+			return fmt.Errorf("deleting project: %w", apiErrFromV2(err))
 		}
 
 		headers := []TableColumn{
@@ -455,16 +448,12 @@ var projectListCmd = &cobra.Command{
 		// List projects using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromProject().List(ctx, listParams(cmd))
+		list, err := client.FromProject().List(ctx, listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing projects: %w", err)
+			return fmt.Errorf("listing projects: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			// Define table columns
 			headers := []TableColumn{
 				{Header: "NAME", Width: 40},
@@ -474,28 +463,21 @@ var projectListCmd = &cobra.Command{
 
 			// Build rows
 			var rows [][]string
-			for _, project := range response.Data.Values {
-				name := ""
-				if project.Metadata.Name != nil && *project.Metadata.Name != "" {
-					name = *project.Metadata.Name
-				}
-
-				id := ""
-				if project.Metadata.ID != nil && *project.Metadata.ID != "" {
-					id = *project.Metadata.ID
-				}
+			for _, project := range list.Items() {
+				name := project.Name()
+				id := project.ID()
 
 				// Format creation date as dd-mm-yyyy
 				creationDate := "N/A"
-				if project.Metadata.CreationDate != nil && !project.Metadata.CreationDate.IsZero() {
-					creationDate = project.Metadata.CreationDate.Format("02-01-2006")
+				if ca := project.CreatedAt(); !ca.IsZero() {
+					creationDate = ca.Format("02-01-2006")
 				}
 
 				rows = append(rows, []string{name, id, creationDate})
 			}
 
 			// Print the table
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(projectListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No projects found")
 		}

--- a/cmd/management.project_test.go
+++ b/cmd/management.project_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,26 +11,23 @@ import (
 func TestProjectListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockProjectClient)
+		setupSrv    func(*arubaTestServer)
+		args        []string
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockProjectClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-001", "my-project"
-				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
-					return &types.Response[types.ProjectList]{
-						StatusCode: 200,
-						Data: &types.ProjectList{
-							Values: []types.ProjectResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+					Values: []types.ProjectResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
+			args: []string{"management", "project", "list"},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "proj-001") {
 					t.Errorf("expected ID in output, got: %s", out)
@@ -41,27 +36,22 @@ func TestProjectListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockProjectClient) {
-				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
-					return &types.Response[types.ProjectList]{StatusCode: 200, Data: &types.ProjectList{}}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectList{}))
 			},
+			args: []string{"management", "project", "list"},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockProjectClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-001", "my-project"
-				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
-					return &types.Response[types.ProjectList]{
-						StatusCode: 200,
-						Data: &types.ProjectList{
-							Values: []types.ProjectResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+					Values: []types.ProjectResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
+			args: []string{"management", "project", "list", "--output", "json"},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
 				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
@@ -70,40 +60,31 @@ func TestProjectListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockProjectClient) {
-				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects", errorResponse(500, "Internal Server Error", "boom"))
 			},
+			args:        []string{"management", "project", "list"},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockProjectClient) {
-				m.listFn = func(_ context.Context, _ *types.RequestParameters) (*types.Response[types.ProjectList], error) {
-					return &types.Response[types.ProjectList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects", errorResponse(404, "Not Found", "resource not found"))
 			},
+			args:        []string{"management", "project", "list"},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockProjectClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"management", "project", "list"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withProject(m)), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestProjectListCmd(t *testing.T) {
 func TestProjectGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockProjectClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockProjectClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-001", "my-project"
-				m.getFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return &types.Response[types.ProjectResponse]{
-						StatusCode: 200,
-						Data:       &types.ProjectResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-001", jsonResponse(200, types.ProjectResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "proj-001") {
@@ -138,24 +116,17 @@ func TestProjectGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockProjectClient) {
-				m.getFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockProjectClient) {
-				m.getFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return &types.Response[types.ProjectResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,11 +134,11 @@ func TestProjectGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockProjectClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withProject(m)), []string{"management", "project", "get", "proj-001"})
+			out, err := runCmdCapture(srv.Client(), []string{"management", "project", "get", "proj-001"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -180,7 +151,7 @@ func TestProjectCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockProjectClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -188,14 +159,11 @@ func TestProjectCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"management", "project", "create", "--name", "my-project"},
-			setupMock: func(m *mockProjectClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-new", "my-project"
-				m.createFn = func(_ context.Context, _ types.ProjectRequest, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return &types.Response[types.ProjectResponse]{
-						StatusCode: 200,
-						Data:       &types.ProjectResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects", jsonResponse(200, types.ProjectResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "proj-new") {
@@ -210,12 +178,10 @@ func TestProjectCreateCmd(t *testing.T) {
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"management", "project", "create", "--name", "my-project"},
-			setupMock: func(m *mockProjectClient) {
-				m.createFn = func(_ context.Context, _ types.ProjectRequest, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -223,13 +189,8 @@ func TestProjectCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"management", "project", "create", "--name", "my-project"},
-			setupMock: func(m *mockProjectClient) {
-				m.createFn = func(_ context.Context, _ types.ProjectRequest, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return &types.Response[types.ProjectResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -237,11 +198,82 @@ func TestProjectCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockProjectClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withProject(m)), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestProjectUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"management", "project", "update", "proj-001", "--description", "new desc"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "proj-001", "my-project"
+				srv.OnGet("/projects/proj-001", jsonResponse(200, types.ProjectResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPut("/projects/proj-001", jsonResponse(200, types.ProjectResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "proj-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "missing flags",
+			args:        []string{"management", "project", "update", "proj-001"},
+			wantErr:     true,
+			errContains: "at least one of",
+		},
+		{
+			name: "pre-Get API error",
+			args: []string{"management", "project", "update", "proj-001", "--description", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "Update server error",
+			args: []string{"management", "project", "update", "proj-001", "--description", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "proj-001", "my-project"
+				srv.OnGet("/projects/proj-001", jsonResponse(200, types.ProjectResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPut("/projects/proj-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -253,17 +285,17 @@ func TestProjectCreateCmd(t *testing.T) {
 func TestProjectDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockProjectClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockProjectClient) {
-				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"management", "project", "delete", "proj-001", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "proj-001") {
@@ -273,18 +305,14 @@ func TestProjectDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockProjectClient) {
+			args: []string{"management", "project", "delete", "proj-001", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-001", "my-project"
-				m.getFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ProjectResponse], error) {
-					return &types.Response[types.ProjectResponse]{
-						StatusCode: 200,
-						Data:       &types.ProjectResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
-				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+				// Only register Get; if Delete is called the harness t.Errorf on the
+				// unregistered DELETE route — stronger than the old t.Fatal guard.
+				srv.OnGet("/projects/proj-001", jsonResponse(200, types.ProjectResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "proj-001") {
@@ -293,24 +321,19 @@ func TestProjectDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockProjectClient) {
-				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"management", "project", "delete", "proj-001", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockProjectClient) {
-				m.deleteFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"management", "project", "delete", "proj-001", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -318,15 +341,11 @@ func TestProjectDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockProjectClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"management", "project", "delete", "proj-001", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withProject(m)), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)


### PR DESCRIPTION
Closes #102. Part of #99.

## Summary
- Migrates `cmd/management.project.go` (8 SDK call sites) from the v0.1.x flat
  `FromProject().X(ctx, …, nil)` surface to the v0.2.0 fluent wrapper API
  (`*aruba.Project`, `*aruba.List[*aruba.Project]`, `aruba.Ref`).
- `apiErrFromResp` → `apiErrFromV2`; `listParams` → `listOpts`; the two-step
  `err` + `response.IsError()` check collapses to one unified
  `fmt.Errorf("<verb> project: %w", apiErrFromV2(err))`.
- Adds `projectFromRaw` / `projectListPayload`: the v0.2.0 `*aruba.Project`
  wrapper has only unexported fields (not JSON-marshalable) and no accessor for
  `Properties.ResourcesNumber`, so the RESOURCES column, the `get` "Resources:"
  line, and `-o json`/`-o yaml` payloads are preserved by re-parsing the typed
  response from `RawHTTP()`. CLI output stays byte-identical.
- Reuses the #100 `projectWrapper` helper for the 3 Get call sites.
- Fixes a latent nil-panic: v0.1.x `update` did an unguarded
  `*currentProject.Metadata.Name` deref — the wrapper's nil-safe `fromResponse`
  removes it.
- Rewrites `cmd/management.project_test.go` onto the #101 `arubaTestServer`
  httptest harness and adds the previously-missing `TestProjectUpdateCmd`.
- Refreshes the stale v0.1.x playbook docs: `ai/CONVENTIONS.md` "Standard Command
  Bodies" and `ai/ARCHITECTURE.md` "SDK Call Pattern".

## Build status
Per #102 acceptance, `management.project.{go,_test.go}` are migrated correctly to
v0.2.0; the rest of `cmd/` stays red until #103-#110 land. Verification was scoped
static review: `gofmt -l` clean on both changed files, `go vet ./cmd/` shows no new
diagnostics citing `management.project*.go` (only one pre-existing error from
un-migrated `network.vpntunnel.go`), plus a manual call-site checklist.

## Test plan
- [x] `gofmt -l cmd/management.project.go cmd/management.project_test.go` — clean
- [x] `go vet ./cmd/` — no diagnostics originate in `management.project*.go`
- [x] Manual review: 8 call sites migrated, unified error pattern, helpers present,
      imports correct, `TestProjectUpdateCmd` added