### PR TITLE
feat(sdk): migrate compute (cloudserver, keypair) to SDK v0.2.0 wrapper API (#103)

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -69,6 +69,33 @@ string`). Use `aruba.URI("/projects/"+id)` (wrapped by `projectRef` in `cmd/root
 for top-level refs and chain `IntoProject(proj)` / `IntoVPC(vpc)` on wrappers for
 scoped resources.
 
+**Combined-URI Refs for project-scoped Get/Delete** — `List` and builder `IntoProject`
+only need the project Ref (`projectRef(id)`). `Get` and `Delete` on project-scoped
+resources require a single Ref encoding *both* the project and resource IDs. Declare
+a file-local helper for each resource:
+
+```go
+func cloudServerRef(projectID, serverID string) aruba.Ref {
+    return aruba.URI("/projects/" + projectID +
+        "/providers/Aruba.Compute/cloudServers/" + serverID)
+}
+```
+
+**Operational methods on hydrated wrappers** — some operations (`PowerOn`, `PowerOff`,
+`SetPassword`) are methods on `*aruba.<T>`, not on the sub-client. They require a
+prior hydrating `Get`; calling them on a freshly-constructed `New<T>()` wrapper will
+fail. `PowerOn`/`PowerOff` re-hydrate the wrapper from the response; `SetPassword`
+does not — render from the pre-`Get` result:
+
+```go
+cs, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(pid, id))
+if err != nil { return fmt.Errorf("powering on cloud server: %w", apiErrFromV2(err)) }
+if err := cs.PowerOn(ctx); err != nil {
+    return fmt.Errorf("powering on cloud server: %w", apiErrFromV2(err))
+}
+// cs is now re-hydrated; render from cs.Raw()
+```
+
 **Error handling** — non-2xx responses surface as `*aruba.HTTPError` in the error
 return. There is no `response.IsError()` check. Use `apiErrFromV2(err)` (in
 `cmd/root.go`) to format HTTP errors while passing transport errors through. Always
@@ -83,12 +110,17 @@ if err != nil {
 
 **Rendering** — wrapper types (`*aruba.<T>`) carry only unexported fields and are not
 JSON-marshalable. For table columns the wrapper exposes (`.ID()`, `.Name()`,
-`.State()`, `.CreatedAt()`, …) use the accessors directly. For fields the wrapper
-omits (e.g. `ResourcesNumber` on `*aruba.Project`) and for `-o json`/`-o yaml`
-payloads, re-parse the typed `types.<T>Response` from the wrapper's `RawHTTP()` raw
-body via a file-local `<resource>FromRaw` helper. For list `-o json`, extract the
-typed list via `list.Raw()` (stores the original `*types.Response[types.<T>List]`)
-via a file-local `<resource>ListPayload` helper.
+`.State()`, `.CreatedAt()`, …) use the accessors directly. Two cases for full-payload
+rendering:
+
+- **`Raw()` returns the full typed response** (e.g. `*aruba.CloudServer.Raw()` →
+  `*types.CloudServerResponse`) — use it directly; no re-parse helper needed.
+- **`Raw()` returns only metadata** (e.g. `*aruba.Project`) — re-parse the typed
+  `types.<T>Response` from the wrapper's `RawHTTP()` raw body via a file-local
+  `<resource>FromRaw` helper.
+
+For list `-o json`, extract the typed list via `list.Raw()` (stores the original
+`*types.Response[types.<T>List]`) via a file-local `<resource>ListPayload` helper.
 
 **`ctx`** — use `newCtx()` (30-second timeout, in `cmd/root.go`) for all SDK calls.
 Completion functions that run interactively may keep `context.Background()`.

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -184,10 +184,14 @@ responses surface as `*aruba.HTTPError` in the error return — there is no sepa
 a verb prefix for all error sites.
 
 **Wrapper note:** `*aruba.<T>` wrapper types carry only unexported fields and are not
-JSON-marshalable. For fields the wrapper does not expose as an accessor, and for
-`-o json`/`-o yaml` payloads, re-parse the wire `types.<T>Response` from the
-wrapper's `RawHTTP()` body via a file-local `<resource>FromRaw` helper (see the
-`management.project.go` reference implementation).
+JSON-marshalable. For single-resource rendering and `-o json`/`-o yaml` payloads,
+use `.Raw()` directly when the wrapper exposes the full typed response (e.g.
+`*aruba.CloudServer.Raw()` → `*types.CloudServerResponse`). Only fall back to re-
+parsing via `RawHTTP()` when `.Raw()` returns only metadata (e.g. `*aruba.Project`
+— see `management.project.go`). For project-scoped resources, build the create
+wrapper with `.IntoProject(projectRef(projectID))` and use a file-local
+`<resource>Ref(projectID, id)` helper (encoding both project + resource IDs in the
+URI) for `Get` and `Delete`.
 
 ### list
 ```go

--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -83,18 +84,19 @@ func init() {
 	cloudserverConnectCmd.ValidArgsFunction = completeCloudServerID
 }
 
-// Helper function to extract ID from URI
-func extractIDFromURI(uri string) string {
-	if uri == "" {
-		return ""
+// cloudServerRef builds the combined project+server Ref that v0.2.0 Get/Delete need.
+func cloudServerRef(projectID, serverID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID +
+		"/providers/Aruba.Compute/cloudServers/" + serverID)
+}
+
+// csListPayload extracts the typed list for -o json/yaml; the List wrapper is not
+// JSON-marshalable. Mirrors projectListPayload from the #102 playbook.
+func csListPayload(l *aruba.List[*aruba.CloudServer]) any {
+	if r, ok := l.Raw().(*types.Response[types.CloudServerList]); ok && r != nil {
+		return r.Data
 	}
-	// URI format: /projects/{projectId}/providers/Aruba.Compute/cloudServers/{serverId}
-	parts := strings.Split(uri, "/")
-	if len(parts) > 0 {
-		// Get the last part which should be the ID
-		return parts[len(parts)-1]
-	}
-	return ""
+	return nil
 }
 
 // Completion functions for compute resources
@@ -110,24 +112,20 @@ func completeCloudServerID(cmd *cobra.Command, args []string, toComplete string)
 	}
 
 	ctx := context.Background()
-	response, err := client.FromCompute().CloudServers().List(ctx, projectID, nil)
+	list, err := client.FromCompute().CloudServers().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, server := range response.Data.Values {
-			if server.Metadata.ID == nil || *server.Metadata.ID == "" {
+	if list != nil {
+		for _, cs := range list.Items() {
+			id := cs.ID()
+			if id == "" {
 				continue
 			}
-			id := *server.Metadata.ID
-			var name string
-			if server.Metadata.Name != nil {
-				name = *server.Metadata.Name
-			}
 			if toComplete == "" || strings.HasPrefix(id, toComplete) {
-				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, cs.Name()))
 			}
 		}
 	}
@@ -161,7 +159,6 @@ Billing period: Hour (default), Month, or Year.`,
     --security-group-uri /projects/<proj-id>/providers/Aruba.Network/securityGroups/<sg-id>`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get new network flags
 		vpcURI, _ := cmd.Flags().GetString("vpc-uri")
 		subnetURIs, _ := cmd.Flags().GetStringSlice("subnet-uri")
 		securityGroupURIs, _ := cmd.Flags().GetStringSlice("security-group-uri")
@@ -185,80 +182,46 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		// Note: Template (image) should be provided as a ReferenceResource URI
-		// Format: /projects/{projectId}/providers/Aruba.Compute/templates/{templateId}
-		// Use bootDiskURI for BootVolume
-		bootVolumeURI := bootDiskURI
-
-		createRequest := types.CloudServerRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.CloudServerPropertiesRequest{
-				Zone:       zone,
-				FlavorName: &flavor,
-				BootVolume: types.ReferenceResource{
-					URI: bootVolumeURI,
-				},
-				VPC: types.ReferenceResource{URI: vpcURI},
-				Subnets: func() []types.ReferenceResource {
-					var refs []types.ReferenceResource
-					for _, s := range subnetURIs {
-						refs = append(refs, types.ReferenceResource{URI: s})
-					}
-					return refs
-				}(),
-				SecurityGroups: func() []types.ReferenceResource {
-					var refs []types.ReferenceResource
-					for _, sg := range securityGroupURIs {
-						refs = append(refs, types.ReferenceResource{URI: sg})
-					}
-					return refs
-				}(),
-			},
+		cs := aruba.NewCloudServer().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			InZone(aruba.Zone(zone)).
+			OfFlavor(aruba.CloudServerFlavor(flavor)).
+			WithBootVolume(aruba.URI(bootDiskURI)).
+			WithVPC(aruba.URI(vpcURI))
+		if len(tags) > 0 {
+			cs.ReplaceTags(tags...)
 		}
-
-		// Optionally set Elastic IP
-		if elasticIPURI != "" {
-			createRequest.Properties.ElasticIP = &types.ReferenceResource{URI: elasticIPURI}
+		for _, s := range subnetURIs {
+			cs.AddSubnet(aruba.URI(s))
 		}
-
+		for _, sg := range securityGroupURIs {
+			cs.AddSecurityGroup(aruba.URI(sg))
+		}
 		if keypairURI != "" {
-			createRequest.Properties.KeyPair = &types.ReferenceResource{
-				URI: keypairURI,
-			}
+			cs.WithKeyPair(aruba.URI(keypairURI))
 		}
-
-		// Handle userData file if provided
+		if elasticIPURI != "" {
+			cs.WithElasticIP(aruba.URI(elasticIPURI))
+		}
 		if userDataFile != "" {
 			fileContent, err := os.ReadFile(userDataFile)
 			if err != nil {
 				return fmt.Errorf("reading user-data file: %w", err)
 			}
-			// Encode file content to base64
-			userDataBase64 := base64.StdEncoding.EncodeToString(fileContent)
-			createRequest.Properties.UserData = &userDataBase64
+			cs.WithUserData(base64.StdEncoding.EncodeToString(fileContent))
 		}
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromCompute().CloudServers().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromCompute().CloudServers().Create(ctx, cs)
 		if err != nil {
-			return fmt.Errorf("creating cloud server: %w", err)
+			return fmt.Errorf("creating cloud server: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		r := created.Raw()
+		if r != nil {
 			headers := []TableColumn{
 				{Header: "ID", Width: 30},
 				{Header: "NAME", Width: 40},
@@ -268,31 +231,31 @@ Billing period: Hour (default), Month, or Year.`,
 				{Header: "HD(GB)", Width: 15},
 				{Header: "REGION", Width: 20},
 			}
-			var id, name string
-			if response.Data.Metadata.ID != nil {
-				id = *response.Data.Metadata.ID
+			var id, csName string
+			if r.Metadata.ID != nil {
+				id = *r.Metadata.ID
 			}
-			if response.Data.Metadata.Name != nil {
-				name = *response.Data.Metadata.Name
+			if r.Metadata.Name != nil {
+				csName = *r.Metadata.Name
 			}
-			flavorName := response.Data.Properties.Flavor.Name
-			cpu := response.Data.Properties.Flavor.CPU
-			ram := response.Data.Properties.Flavor.RAM
-			hd := response.Data.Properties.Flavor.HD
+			flavorName := string(r.Properties.Flavor.Name)
+			cpu := r.Properties.Flavor.CPU
+			ram := r.Properties.Flavor.RAM
+			hd := r.Properties.Flavor.HD
 			regionValue := ""
-			if response.Data.Metadata.LocationResponse != nil {
-				regionValue = response.Data.Metadata.LocationResponse.Value
+			if r.Metadata.LocationResponse != nil {
+				regionValue = string(r.Metadata.LocationResponse.Value)
 			}
 			row := []string{
 				id,
-				name,
+				csName,
 				flavorName,
 				fmt.Sprintf("%d", cpu),
 				fmt.Sprintf("%d", ram),
 				fmt.Sprintf("%d", hd),
 				regionValue,
 			}
-			PrintOutput(response.Data, headers, [][]string{row})
+			PrintOutput(r, headers, [][]string{row})
 		} else {
 			fmt.Println(msgCreatedAsync("Cloud server", name))
 		}
@@ -319,67 +282,60 @@ var cloudserverGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
+		got, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", err)
+			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			server := resp.Data
-
+		r := got.Raw()
+		if r != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(server, nil, nil)
+				PrintOutput(r, nil, nil)
 				return nil
 			}
 
 			fmt.Println("\nCloud Server Details:")
 			fmt.Println("====================")
 
-			if server.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *server.Metadata.ID)
+			if r.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *r.Metadata.ID)
 			}
-			if server.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *server.Metadata.Name)
+			if r.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *r.Metadata.Name)
 			}
-			if server.Metadata.LocationResponse != nil && server.Metadata.LocationResponse.Value != "" {
-				fmt.Printf("Region:          %s\n", server.Metadata.LocationResponse.Value)
-			}
-
-			// Flavor is a direct struct, not a pointer
-			if server.Properties.Flavor.Name != "" {
-				fmt.Printf("Flavor:          %s\n", server.Properties.Flavor.Name)
-			}
-			fmt.Printf("CPU:             %d\n", server.Properties.Flavor.CPU)
-			fmt.Printf("RAM:             %d GB\n", server.Properties.Flavor.RAM)
-			fmt.Printf("HD:              %d GB\n", server.Properties.Flavor.HD)
-
-			if server.Properties.BootVolume.URI != "" {
-				fmt.Printf("Boot Volume URI: %s\n", server.Properties.BootVolume.URI)
+			if r.Metadata.LocationResponse != nil && r.Metadata.LocationResponse.Value != "" {
+				fmt.Printf("Region:          %s\n", r.Metadata.LocationResponse.Value)
 			}
 
-			if server.Properties.KeyPair.URI != "" {
-				fmt.Printf("Keypair URI:     %s\n", server.Properties.KeyPair.URI)
+			if r.Properties.Flavor.Name != "" {
+				fmt.Printf("Flavor:          %s\n", r.Properties.Flavor.Name)
+			}
+			fmt.Printf("CPU:             %d\n", r.Properties.Flavor.CPU)
+			fmt.Printf("RAM:             %d GB\n", r.Properties.Flavor.RAM)
+			fmt.Printf("HD:              %d GB\n", r.Properties.Flavor.HD)
+
+			if r.Properties.BootVolume.URI != "" {
+				fmt.Printf("Boot Volume URI: %s\n", r.Properties.BootVolume.URI)
 			}
 
-			if server.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *server.Status.State)
+			if r.Properties.KeyPair.URI != "" {
+				fmt.Printf("Keypair URI:     %s\n", r.Properties.KeyPair.URI)
 			}
 
-			if len(server.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", server.Metadata.Tags)
+			if r.Status.State != nil {
+				fmt.Printf("Status:          %s\n", *r.Status.State)
+			}
+
+			if len(r.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", r.Metadata.Tags)
 			} else {
 				fmt.Printf("Tags:            []\n")
 			}
 
-			// Show JSON output if verbose
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			if verbose {
-				jsonData, _ := json.MarshalIndent(server, "", "  ")
+				jsonData, _ := json.MarshalIndent(r, "", "  ")
 				fmt.Println("\nFull JSON Response:")
 				fmt.Println("==================")
 				fmt.Println(string(jsonData))
@@ -401,7 +357,7 @@ var cloudserverUpdateCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		if name == "" && len(tags) == 0 {
+		if name == "" && !cmd.Flags().Changed("tags") {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
@@ -417,78 +373,31 @@ var cloudserverUpdateCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
+		cur, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 		if err != nil {
-			return fmt.Errorf("getting cloud server details: %w", err)
+			return fmt.Errorf("fetching current cloud server: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
-			return fmt.Errorf("cloud server not found")
-		}
-
-		current := getResponse.Data
-
-		// Get region value
-		var regionValue string
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for cloud server")
-		}
-
-		// Build the update request, preserving existing values
-		flavorName := current.Properties.Flavor.Name
-
-		var currentName string
-		if current.Metadata.Name != nil {
-			currentName = *current.Metadata.Name
-		}
-
-		updateRequest := types.CloudServerRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: currentName,
-					Tags: current.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.CloudServerPropertiesRequest{
-				FlavorName: &flavorName,
-				BootVolume: current.Properties.BootVolume,
-			},
-		}
-
-		if current.Properties.KeyPair.URI != "" {
-			updateRequest.Properties.KeyPair = &current.Properties.KeyPair
-		}
-
-		// Apply updates
 		if name != "" {
-			updateRequest.Metadata.Name = name
+			cur.Named(name)
 		}
-		if len(tags) > 0 {
-			updateRequest.Metadata.Tags = tags
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
 		}
 
-		response, err := client.FromCompute().CloudServers().Update(ctx, projectID, serverID, updateRequest, nil)
+		updated, err := client.FromCompute().CloudServers().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating cloud server: %w", err)
+			return fmt.Errorf("updating cloud server: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		r := updated.Raw()
+		if r != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Cloud server", serverID))
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *response.Data.Metadata.Name)
+			if r.Metadata.Name != nil {
+				fmt.Printf("Name:    %s\n", *r.Metadata.Name)
 			}
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", response.Data.Metadata.Tags)
+			if len(r.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:    %v\n", r.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("Cloud server", serverID))
@@ -504,7 +413,6 @@ var cloudserverDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		serverID := args[0]
 
-		// Confirmation prompt
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 		if !skipConfirm {
 			ok, err := confirmDelete("cloud server", serverID)
@@ -531,21 +439,16 @@ var cloudserverDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
+			_, err = client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 			if err != nil {
-				return fmt.Errorf("dry-run: cloud server not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: cloud server not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("cloud server", serverID))
 			return nil
 		}
 
-		response, err := client.FromCompute().CloudServers().Delete(ctx, projectID, serverID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting cloud server: %w", err)
-		}
-
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		if err := client.FromCompute().CloudServers().Delete(ctx, cloudServerRef(projectID, serverID)); err != nil {
+			return fmt.Errorf("deleting cloud server: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Cloud server", serverID))
@@ -570,15 +473,12 @@ var cloudserverListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromCompute().CloudServers().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromCompute().CloudServers().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing cloud servers: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing cloud servers: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 25},
 				{Header: "ID", Width: 30},
@@ -588,30 +488,16 @@ var cloudserverListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, server := range response.Data.Values {
-				if server.Metadata.ID == nil || *server.Metadata.ID == "" {
+			for _, cs := range list.Items() {
+				if cs.ID() == "" {
 					continue
 				}
-				id := *server.Metadata.ID
-				var name string
-				if server.Metadata.Name != nil {
-					name = *server.Metadata.Name
-				}
-				var location string
-				if server.Metadata.LocationResponse != nil {
-					location = server.Metadata.LocationResponse.Value
-				}
-				flavor := server.Properties.Flavor.Name
-				status := ""
-				if server.Status.State != nil {
-					status = *server.Status.State
-				}
 				rows = append(rows, []string{
-					name,
-					id,
-					location,
-					flavor,
-					status,
+					cs.Name(),
+					cs.ID(),
+					string(cs.Region()),
+					string(cs.Flavor()),
+					cs.State(),
 				})
 			}
 
@@ -619,7 +505,7 @@ var cloudserverListCmd = &cobra.Command{
 				fmt.Println("No cloud servers found")
 				return nil
 			}
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(csListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No cloud servers found")
 		}
@@ -646,22 +532,22 @@ var cloudserverPowerOnCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromCompute().CloudServers().PowerOn(ctx, projectID, serverID, nil)
+		cs, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 		if err != nil {
-			return fmt.Errorf("powering on cloud server: %w", err)
+			return fmt.Errorf("powering on cloud server: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		if err := cs.PowerOn(ctx); err != nil {
+			return fmt.Errorf("powering on cloud server: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
+		if cs.Raw() != nil {
 			fmt.Println(msgAction("Cloud server", serverID, "powered on"))
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Server: %s\n", *response.Data.Metadata.Name)
+			if cs.Raw().Metadata.Name != nil {
+				fmt.Printf("Server: %s\n", *cs.Raw().Metadata.Name)
 			}
-			if response.Data.Status.State != nil {
-				fmt.Printf("Status: %s\n", *response.Data.Status.State)
+			if cs.Raw().Status.State != nil {
+				fmt.Printf("Status: %s\n", *cs.Raw().Status.State)
 			}
 		} else {
 			fmt.Println(msgAction("Cloud server", serverID, "power-on initiated"))
@@ -689,22 +575,22 @@ var cloudserverPowerOffCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromCompute().CloudServers().PowerOff(ctx, projectID, serverID, nil)
+		cs, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 		if err != nil {
-			return fmt.Errorf("powering off cloud server: %w", err)
+			return fmt.Errorf("powering off cloud server: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		if err := cs.PowerOff(ctx); err != nil {
+			return fmt.Errorf("powering off cloud server: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
+		if cs.Raw() != nil {
 			fmt.Println(msgAction("Cloud server", serverID, "powered off"))
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Server: %s\n", *response.Data.Metadata.Name)
+			if cs.Raw().Metadata.Name != nil {
+				fmt.Printf("Server: %s\n", *cs.Raw().Metadata.Name)
 			}
-			if response.Data.Status.State != nil {
-				fmt.Printf("Status: %s\n", *response.Data.Status.State)
+			if cs.Raw().Status.State != nil {
+				fmt.Printf("Status: %s\n", *cs.Raw().Status.State)
 			}
 		} else {
 			fmt.Println(msgAction("Cloud server", serverID, "power-off initiated"))
@@ -737,35 +623,25 @@ var cloudserverSetPasswordCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		passwordRequest := types.CloudServerPasswordRequest{
-			Password: password,
-		}
-
-		response, err := client.FromCompute().CloudServers().SetPassword(ctx, projectID, serverID, passwordRequest, nil)
+		cs, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 		if err != nil {
-			return fmt.Errorf("setting password for cloud server: %w", err)
+			return fmt.Errorf("setting cloud server password: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		// SetPassword does not re-hydrate cs; name/state are from the prior Get.
+		if err := cs.SetPassword(ctx, password); err != nil {
+			return fmt.Errorf("setting cloud server password: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			// Try to cast to CloudServerResponse to get detailed info
-			// response.Data is *any, so we need to dereference and assert
-			if data, ok := (*response.Data).(*types.CloudServerResponse); ok && data != nil {
-				fmt.Println(msgAction("Cloud server", serverID, "password set"))
-				if data.Metadata.Name != nil {
-					fmt.Printf("Server: %s\n", *data.Metadata.Name)
-				}
-				if data.Status.State != nil {
-					fmt.Printf("Status: %s\n", *data.Status.State)
-				}
-			} else {
-				fmt.Println(msgAction("Cloud server", serverID, "password set"))
+		fmt.Println(msgAction("Cloud server", serverID, "password set"))
+		r := cs.Raw()
+		if r != nil {
+			if r.Metadata.Name != nil {
+				fmt.Printf("Server: %s\n", *r.Metadata.Name)
 			}
-		} else {
-			fmt.Println(msgAction("Cloud server", serverID, "password set"))
+			if r.Status.State != nil {
+				fmt.Printf("Status: %s\n", *r.Status.State)
+			}
 		}
 		return nil
 	},
@@ -802,26 +678,19 @@ var cloudserverConnectCmd = &cobra.Command{
 		ctx, cancel := newCtx()
 		defer cancel()
 
-		// First, get the cloud server details
-		serverResp, err := client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
+		cs, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(projectID, serverID))
 		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", err)
+			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
 		}
 
-		if serverResp != nil && serverResp.IsError() {
-			return apiErrFromResp(serverResp.StatusCode, serverResp.Error)
-		}
-
-		if serverResp == nil || serverResp.Data == nil {
+		r := cs.Raw()
+		if r == nil {
 			fmt.Println("Cloud server not found or no data returned.")
 			return nil
 		}
 
-		server := serverResp.Data
-
-		// Check for ElasticIP in linked resources
 		var elasticIPURI string
-		for _, linkedResource := range server.Properties.LinkedResources {
+		for _, linkedResource := range r.Properties.LinkedResources {
 			if strings.Contains(linkedResource.URI, "providers/Aruba.Network/elasticIps") {
 				elasticIPURI = linkedResource.URI
 				break
@@ -834,35 +703,18 @@ var cloudserverConnectCmd = &cobra.Command{
 			return nil
 		}
 
-		// Extract ElasticIP ID from URI
-		elasticIPID := extractIDFromURI(elasticIPURI)
-		if elasticIPID == "" {
-			return fmt.Errorf("could not extract Elastic IP ID from URI: %s", elasticIPURI)
-		}
-
-		// Get ElasticIP details
-		eipResp, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, elasticIPID, nil)
+		eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.URI(elasticIPURI))
 		if err != nil {
-			return fmt.Errorf("getting Elastic IP details: %w", err)
+			return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
 		}
 
-		if eipResp != nil && eipResp.IsError() {
-			return apiErrFromResp(eipResp.StatusCode, eipResp.Error)
-		}
-
-		if eipResp == nil || eipResp.Data == nil {
-			fmt.Println("Elastic IP not found or no data returned.")
-			return nil
-		}
-
-		eip := eipResp.Data
-		if eip.Properties.Address == nil || *eip.Properties.Address == "" {
+		addr := eip.Address()
+		if addr == "" {
 			fmt.Println("Elastic IP address not available.")
 			return nil
 		}
 
-		// Print SSH connection command
-		fmt.Printf("Connect by running: ssh %s@%s\n", user, *eip.Properties.Address)
+		fmt.Printf("Connect by running: ssh %s@%s\n", user, addr)
 		return nil
 	},
 }

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -14,25 +12,22 @@ import (
 func TestCloudServerListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockCloudServersClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockCloudServersClient) {
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-					return &types.Response[types.CloudServerList]{
-						StatusCode: 200,
-						Data: &types.CloudServerList{
-							Values: []types.CloudServerResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+					Values: []types.CloudServerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "cs-001") {
@@ -42,43 +37,34 @@ func TestCloudServerListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockCloudServersClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-					return &types.Response[types.CloudServerList]{StatusCode: 200, Data: &types.CloudServerList{}}, nil
-				}
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{}))
 			},
 		},
 		{
 			name: "skips entries with nil ID",
-			setupMock: func(m *mockCloudServersClient) {
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-					return &types.Response[types.CloudServerList]{
-						StatusCode: 200,
-						Data: &types.CloudServerList{
-							Values: []types.CloudServerResponse{
-								{Metadata: types.ResourceMetadataResponse{Name: &name}},
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+					Values: []types.CloudServerResponse{
+						{Metadata: types.ResourceMetadataResponse{Name: &name}},
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockCloudServersClient) {
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-					return &types.Response[types.CloudServerList]{
-						StatusCode: 200,
-						Data: &types.CloudServerList{
-							Values: []types.CloudServerResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+					Values: []types.CloudServerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -88,24 +74,19 @@ func TestCloudServerListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-					return &types.Response[types.CloudServerList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -113,15 +94,11 @@ func TestCloudServerListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"compute", "cloudserver", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withCompute(m)), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -133,21 +110,18 @@ func TestCloudServerListCmd(t *testing.T) {
 func TestCloudServerGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockCloudServersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockCloudServersClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{
-						StatusCode: 200,
-						Data:       &types.CloudServerResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "cs-001") {
@@ -156,24 +130,17 @@ func TestCloudServerGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -181,11 +148,11 @@ func TestCloudServerGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "get", "cs-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"compute", "cloudserver", "get", "cs-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -210,7 +177,7 @@ func TestCloudServerCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockCloudServersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -218,14 +185,11 @@ func TestCloudServerCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: baseArgs,
-			setupMock: func(m *mockCloudServersClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-new", "my-cs"
-				m.createFn = func(_ context.Context, _ string, _ types.CloudServerRequest, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{
-						StatusCode: 200,
-						Data:       &types.CloudServerResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "cs-new") {
@@ -246,12 +210,10 @@ func TestCloudServerCreateCmd(t *testing.T) {
 			errContains: "region",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: baseArgs,
-			setupMock: func(m *mockCloudServersClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.CloudServerRequest, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -259,13 +221,8 @@ func TestCloudServerCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: baseArgs,
-			setupMock: func(m *mockCloudServersClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.CloudServerRequest, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -273,11 +230,82 @@ func TestCloudServerCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withCompute(m)), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestCloudServerUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"compute", "cloudserver", "update", "cs-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "cs-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "missing flags",
+			args:        []string{"compute", "cloudserver", "update", "cs-001", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "pre-Get API error",
+			args: []string{"compute", "cloudserver", "update", "cs-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "Update server error",
+			args: []string{"compute", "cloudserver", "update", "cs-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -289,17 +317,15 @@ func TestCloudServerCreateCmd(t *testing.T) {
 func TestCloudServerDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockCloudServersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockCloudServersClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "cs-001") {
@@ -309,11 +335,12 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockCloudServersClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				// Only register Get; an erroneous DELETE would trip the harness t.Errorf.
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "cs-001") {
@@ -322,24 +349,17 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -347,15 +367,15 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
 			args := []string{"compute", "cloudserver", "delete", "cs-001", "--project-id", "proj-123", "--yes"}
 			if tc.name == "--dry-run: prints intent, does not call Delete" {
 				args = append(args, "--dry-run")
 			}
-			out, err := runCmdCapture(newMockClient(withCompute(m)), args)
+			out, err := runCmdCapture(srv.Client(), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -367,37 +387,42 @@ func TestCloudServerDeleteCmd(t *testing.T) {
 func TestCloudServerPowerOnCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockCloudServersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockCloudServersClient) {
-				m.powerOnFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweron", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.powerOnFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return nil, fmt.Errorf("server busy")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweron", errorResponse(500, "Internal Server Error", "server busy"))
 			},
 			wantErr:     true,
 			errContains: "power",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.powerOnFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweron", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -405,11 +430,11 @@ func TestCloudServerPowerOnCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			err := runCmd(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "power-on", "cs-001", "--project-id", "proj-123"})
+			err := runCmd(srv.Client(), []string{"compute", "cloudserver", "power-on", "cs-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 		})
 	}
@@ -418,37 +443,42 @@ func TestCloudServerPowerOnCmd(t *testing.T) {
 func TestCloudServerPowerOffCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockCloudServersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockCloudServersClient) {
-				m.powerOffFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{StatusCode: 200, Data: &types.CloudServerResponse{}}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweroff", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.powerOffFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return nil, fmt.Errorf("server busy")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweroff", errorResponse(500, "Internal Server Error", "server busy"))
 			},
 			wantErr:     true,
 			errContains: "power",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.powerOffFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.CloudServerResponse], error) {
-					return &types.Response[types.CloudServerResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweroff", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -456,11 +486,11 @@ func TestCloudServerPowerOffCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			err := runCmd(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "power-off", "cs-001", "--project-id", "proj-123"})
+			err := runCmd(srv.Client(), []string{"compute", "cloudserver", "power-off", "cs-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 		})
 	}
@@ -469,37 +499,40 @@ func TestCloudServerPowerOffCmd(t *testing.T) {
 func TestCloudServerSetPasswordCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockCloudServersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockCloudServersClient) {
-				m.setPasswordFn = func(_ context.Context, _, _ string, _ types.CloudServerPasswordRequest, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/password", jsonResponse(200, nil))
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.setPasswordFn = func(_ context.Context, _, _ string, _ types.CloudServerPasswordRequest, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("invalid password")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/password", errorResponse(500, "Internal Server Error", "invalid password"))
 			},
 			wantErr:     true,
 			errContains: "password",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockCloudServersClient) {
-				m.setPasswordFn = func(_ context.Context, _, _ string, _ types.CloudServerPasswordRequest, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/password", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -507,13 +540,38 @@ func TestCloudServerSetPasswordCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockCloudServersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			err := runCmd(newMockClient(withCompute(m)), []string{"compute", "cloudserver", "set-password", "cs-001", "--project-id", "proj-123", "--password", "Pass1!"})
+			err := runCmd(srv.Client(), []string{"compute", "cloudserver", "set-password", "cs-001", "--project-id", "proj-123", "--password", "Pass1!"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 		})
+	}
+}
+
+func TestCompleteCloudServerID(t *testing.T) {
+	id, name := "cs-001", "test-server"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+		Values: []types.CloudServerResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	cmd := cloudserverGetCmd
+	if err := cmd.Flags().Set("project-id", "proj-123"); err != nil {
+		cmd.Flags().String("project-id", "proj-123", "")
+	}
+
+	completions, directive := completeCloudServerID(cmd, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected NoFileComp directive, got %v", directive)
+	}
+	if len(completions) != 1 {
+		t.Errorf("expected 1 completion, got %d: %v", len(completions), completions)
 	}
 }
 
@@ -529,58 +587,6 @@ func checkErr(t *testing.T, err error, wantErr bool, errContains string) {
 		}
 	} else if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestExtractIDFromURI(t *testing.T) {
-	cases := []struct {
-		uri  string
-		want string
-	}{
-		{"/projects/p1/providers/Aruba.Compute/cloudServers/cs-123", "cs-123"},
-		{"cs-abc", "cs-abc"},
-		{"", ""},
-	}
-	for _, c := range cases {
-		got := extractIDFromURI(c.uri)
-		if got != c.want {
-			t.Errorf("extractIDFromURI(%q) = %q, want %q", c.uri, got, c.want)
-		}
-	}
-}
-
-func TestCompleteCloudServerID(t *testing.T) {
-	id := "cs-001"
-	name := "test-server"
-	m := &mockCloudServersClient{
-		listFn: func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
-			return &types.Response[types.CloudServerList]{
-				StatusCode: 200,
-				Data: &types.CloudServerList{
-					Values: []types.CloudServerResponse{
-						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					},
-				},
-			}, nil
-		},
-	}
-	setClientForTesting(newMockClient(withCompute(m)))
-	defer resetClientState()
-
-	cmd := cloudserverCmd
-	_ = cmd.Flags().Lookup("project-id") // ensure flag exists
-	if cmd.Flags().Lookup("project-id") == nil {
-		cmd.Flags().String("project-id", "proj-123", "")
-	} else {
-		_ = cmd.Flags().Set("project-id", "proj-123")
-	}
-
-	completions, directive := completeCloudServerID(cmd, nil, "")
-	if directive != cobra.ShellCompDirectiveNoFileComp {
-		t.Errorf("expected NoFileComp directive, got %v", directive)
-	}
-	if len(completions) != 1 {
-		t.Errorf("expected 1 completion, got %d: %v", len(completions), completions)
 	}
 }
 

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,22 @@ func init() {
 	keypairDeleteCmd.ValidArgsFunction = completeKeyPairID
 }
 
-// Completion functions for keypair resources
+// keypairRef builds the combined project+keypair Ref that v0.2.0 Get/Delete need.
+func keypairRef(projectID, name string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID +
+		"/providers/Aruba.Compute/keypairs/" + name)
+}
+
+// keypairListPayload extracts the typed list for -o json/yaml; the List wrapper is not
+// JSON-marshalable.
+func keypairListPayload(l *aruba.List[*aruba.KeyPair]) any {
+	if r, ok := l.Raw().(*types.Response[types.KeyPairListResponse]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
+// completeKeyPairID provides shell completion for keypair names.
 func completeKeyPairID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
@@ -59,19 +75,20 @@ func completeKeyPairID(cmd *cobra.Command, args []string, toComplete string) ([]
 	}
 
 	ctx := context.Background()
-	response, err := client.FromCompute().KeyPairs().List(ctx, projectID, nil)
+	list, err := client.FromCompute().KeyPairs().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, keypair := range response.Data.Values {
-			if keypair.Metadata.Name != nil {
-				name := *keypair.Metadata.Name
-				if toComplete == "" || strings.HasPrefix(name, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\tKeypair", name))
-				}
+	if list != nil {
+		for _, kp := range list.Items() {
+			name := kp.Name()
+			if name == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(name, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\tKeypair", name))
 			}
 		}
 	}
@@ -109,50 +126,38 @@ The public key must be an OpenSSH-formatted RSA, ECDSA, or Ed25519 public key
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		// KeyPairRequest may use RegionalResourceMetadataRequest even though keypairs don't have regions
-		createRequest := types.KeyPairRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-				},
-				// Location may be optional for keypairs
-			},
-			Properties: types.KeyPairPropertiesRequest{
-				Value: publicKey,
-			},
-		}
+		kp := aruba.NewKeyPair().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			WithPublicKey(publicKey)
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromCompute().KeyPairs().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromCompute().KeyPairs().Create(ctx, kp)
 		if err != nil {
-			return fmt.Errorf("creating keypair: %w", err)
+			return fmt.Errorf("creating keypair: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		r := created.Raw()
+		if r != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 40},
 				{Header: "PUBLIC_KEY", Width: 60},
 			}
-			publicKeyValue := response.Data.Properties.Value
+			publicKeyValue := r.Properties.Value
 			if len(publicKeyValue) > 50 {
 				publicKeyValue = publicKeyValue[:50] + "..."
 			}
 			row := []string{
 				func() string {
-					if response.Data.Metadata.Name != nil {
-						return *response.Data.Metadata.Name
+					if r.Metadata.Name != nil {
+						return *r.Metadata.Name
 					}
 					return ""
 				}(),
 				publicKeyValue,
 			}
-			PrintOutput(response.Data, headers, [][]string{row})
+			PrintOutput(r, headers, [][]string{row})
 		} else {
 			fmt.Println(msgCreatedAsync("Keypair", name))
 		}
@@ -179,50 +184,45 @@ var keypairGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromCompute().KeyPairs().Get(ctx, projectID, keypairName, nil)
+		got, err := client.FromCompute().KeyPairs().Get(ctx, keypairRef(projectID, keypairName))
 		if err != nil {
-			return fmt.Errorf("getting keypair: %w", err)
+			return fmt.Errorf("getting keypair: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			keypair := resp.Data
-
+		r := got.Raw()
+		if r != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(keypair, nil, nil)
+				PrintOutput(r, nil, nil)
 				return nil
 			}
 
 			fmt.Println("\nKeypair Details:")
 			fmt.Println("===============")
 
-			if keypair.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *keypair.Metadata.Name)
+			if r.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *r.Metadata.Name)
 			}
-			if keypair.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *keypair.Metadata.URI)
+			if r.Metadata.URI != nil {
+				fmt.Printf("URI:             %s\n", *r.Metadata.URI)
 			}
-			if keypair.Properties.Value != "" {
-				fmt.Printf("Public Key:      %s\n", keypair.Properties.Value)
+			if r.Properties.Value != "" {
+				fmt.Printf("Public Key:      %s\n", r.Properties.Value)
 			}
 			// Show status as 'Active' for consistency
 			fmt.Printf("Status:          Active\n")
 
-			if keypair.Metadata.CreationDate != nil && !keypair.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", keypair.Metadata.CreationDate.Format(DateLayout))
+			if r.Metadata.CreationDate != nil && !r.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", r.Metadata.CreationDate.Format(DateLayout))
 			}
-			if keypair.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *keypair.Metadata.CreatedBy)
+			if r.Metadata.CreatedBy != nil {
+				fmt.Printf("Created By:      %s\n", *r.Metadata.CreatedBy)
 			}
 
 			// Show JSON output if verbose
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			if verbose {
-				jsonData, _ := json.MarshalIndent(keypair, "", "  ")
+				jsonData, _ := json.MarshalIndent(r, "", "  ")
 				fmt.Println("\nFull JSON Response:")
 				fmt.Println("==================")
 				fmt.Println(string(jsonData))
@@ -283,21 +283,16 @@ var keypairDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromCompute().KeyPairs().Get(ctx, projectID, keypairName, nil)
+			_, err = client.FromCompute().KeyPairs().Get(ctx, keypairRef(projectID, keypairName))
 			if err != nil {
-				return fmt.Errorf("dry-run: key pair not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: keypair not found or inaccessible: %w", apiErrFromV2(err))
 			}
-			fmt.Println(msgDryRun("key pair", keypairName))
+			fmt.Println(msgDryRun("keypair", keypairName))
 			return nil
 		}
 
-		response, err := client.FromCompute().KeyPairs().Delete(ctx, projectID, keypairName, nil)
-		if err != nil {
-			return fmt.Errorf("deleting keypair: %w", err)
-		}
-
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		if err := client.FromCompute().KeyPairs().Delete(ctx, keypairRef(projectID, keypairName)); err != nil {
+			return fmt.Errorf("deleting keypair: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Keypair", keypairName))
@@ -322,15 +317,12 @@ var keypairListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromCompute().KeyPairs().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromCompute().KeyPairs().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing keypairs: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing keypairs: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 40},
 				{Header: "ID", Width: 30},
@@ -339,31 +331,24 @@ var keypairListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, keypair := range response.Data.Values {
-				if keypair.Metadata.ID == nil || *keypair.Metadata.ID == "" {
+			for _, kp := range list.Items() {
+				id := kp.KeyPairID()
+				if id == "" {
 					continue
 				}
-				id := *keypair.Metadata.ID
-				name := ""
-				if keypair.Metadata.Name != nil {
-					name = *keypair.Metadata.Name
+				name := kp.Name()
+				publicKey := kp.PublicKey()
+				if len(publicKey) > 50 {
+					publicKey = publicKey[:50] + "..."
 				}
-				publicKey := ""
-				if keypair.Properties.Value != "" {
-					publicKey = keypair.Properties.Value
-					if len(publicKey) > 50 {
-						publicKey = publicKey[:50] + "..."
-					}
-				}
-				status := "Active"
-				rows = append(rows, []string{name, id, publicKey, status})
+				rows = append(rows, []string{name, id, publicKey, "Active"})
 			}
 
 			if len(rows) == 0 {
 				fmt.Println("No keypairs found")
 				return nil
 			}
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(keypairListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No keypairs found")
 		}

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,71 +11,59 @@ import (
 func TestKeyPairListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockKeyPairsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockKeyPairsClient) {
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				kpID, kpName := "kp-001", "my-kp"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-					return &types.Response[types.KeyPairListResponse]{
-						StatusCode: 200,
-						Data: &types.KeyPairListResponse{
-							Values: []types.KeyPairResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs", jsonResponse(200, types.KeyPairListResponse{
+					Values: []types.KeyPairResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "kp-001") {
-					t.Errorf("expected ID in output, got: %s", out)
+				if !strings.Contains(out, "my-kp") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-					return &types.Response[types.KeyPairListResponse]{StatusCode: 200, Data: &types.KeyPairListResponse{}}, nil
-				}
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs", jsonResponse(200, types.KeyPairListResponse{}))
 			},
 		},
 		{
-			name: "skips entries with nil ID",
-			setupMock: func(m *mockKeyPairsClient) {
+			name: "skips entries with empty ID",
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				kpID, kpName := "kp-001", "my-kp"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-					return &types.Response[types.KeyPairListResponse]{
-						StatusCode: 200,
-						Data: &types.KeyPairListResponse{
-							Values: []types.KeyPairResponse{
-								{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
-								{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs", jsonResponse(200, types.KeyPairListResponse{
+					Values: []types.KeyPairResponse{
+						{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
+						{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+					},
+				}))
 			},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockKeyPairsClient) {
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				kpID, kpName := "kp-001", "my-kp"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-					return &types.Response[types.KeyPairListResponse]{
-						StatusCode: 200,
-						Data: &types.KeyPairListResponse{
-							Values: []types.KeyPairResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs", jsonResponse(200, types.KeyPairListResponse{
+					Values: []types.KeyPairResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -87,24 +73,19 @@ func TestKeyPairListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairListResponse], error) {
-					return &types.Response[types.KeyPairListResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -112,15 +93,11 @@ func TestKeyPairListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockKeyPairsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"compute", "keypair", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -132,21 +109,18 @@ func TestKeyPairListCmd(t *testing.T) {
 func TestKeyPairGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockKeyPairsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockKeyPairsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				kpName := "my-kp"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-					return &types.Response[types.KeyPairResponse]{
-						StatusCode: 200,
-						Data:       &types.KeyPairResponse{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", jsonResponse(200, types.KeyPairResponse{
+					Metadata: types.ResourceMetadataResponse{Name: &kpName},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-kp") {
@@ -155,24 +129,17 @@ func TestKeyPairGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-					return &types.Response[types.KeyPairResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -180,12 +147,11 @@ func TestKeyPairGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockKeyPairsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})),
-				[]string{"compute", "keypair", "get", "kp-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"compute", "keypair", "get", "kp-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -198,7 +164,7 @@ func TestKeyPairCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockKeyPairsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -206,14 +172,11 @@ func TestKeyPairCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"compute", "keypair", "create", "--project-id", "proj-123", "--name", "my-kp", "--public-key", "ssh-rsa AAAA"},
-			setupMock: func(m *mockKeyPairsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				kpName := "my-kp"
-				m.createFn = func(_ context.Context, _ string, _ types.KeyPairRequest, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-					return &types.Response[types.KeyPairResponse]{
-						StatusCode: 200,
-						Data:       &types.KeyPairResponse{Metadata: types.ResourceMetadataResponse{Name: &kpName}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/keypairs", jsonResponse(200, types.KeyPairResponse{
+					Metadata: types.ResourceMetadataResponse{Name: &kpName},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-kp") {
@@ -234,12 +197,10 @@ func TestKeyPairCreateCmd(t *testing.T) {
 			errContains: "public-key",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"compute", "keypair", "create", "--project-id", "proj-123", "--name", "my-kp", "--public-key", "ssh-rsa AAAA"},
-			setupMock: func(m *mockKeyPairsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.KeyPairRequest, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-					return nil, fmt.Errorf("duplicate name")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/keypairs", errorResponse(500, "Internal Server Error", "duplicate name"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -247,13 +208,8 @@ func TestKeyPairCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"compute", "keypair", "create", "--project-id", "proj-123", "--name", "my-kp", "--public-key", "ssh-rsa AAAA"},
-			setupMock: func(m *mockKeyPairsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.KeyPairRequest, _ *types.RequestParameters) (*types.Response[types.KeyPairResponse], error) {
-					return &types.Response[types.KeyPairResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Compute/keypairs", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -261,11 +217,11 @@ func TestKeyPairCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockKeyPairsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -274,60 +230,63 @@ func TestKeyPairCreateCmd(t *testing.T) {
 	}
 }
 
+func TestKeyPairUpdateCmd(t *testing.T) {
+	// keypairUpdateCmd is a pure stub — no API call is made.
+	// Registering no routes means any HTTP call would trip the harness t.Errorf.
+	srv := newArubaTestServer(t)
+	out, err := runCmdCapture(srv.Client(), []string{"compute", "keypair", "update", "kp-001", "--project-id", "proj-123"})
+	checkErr(t, err, false, "")
+	if !strings.Contains(out, "not supported") {
+		t.Errorf("expected 'not supported' in output, got: %s", out)
+	}
+}
+
 func TestKeyPairDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockKeyPairsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "kp-001") {
-					t.Errorf("expected ID in output, got: %s", out)
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				kpName := "my-kp"
+				// Only register Get; an erroneous DELETE would trip the harness t.Errorf.
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", jsonResponse(200, types.KeyPairResponse{
+					Metadata: types.ResourceMetadataResponse{Name: &kpName},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "kp-001") {
-					t.Errorf("expected ID in dry-run output, got: %s", out)
+					t.Errorf("expected name in dry-run output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", errorResponse(500, "Internal Server Error", "not found"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockKeyPairsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -335,15 +294,15 @@ func TestKeyPairDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockKeyPairsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
 			args := []string{"compute", "keypair", "delete", "kp-001", "--project-id", "proj-123", "--yes"}
 			if tc.name == "--dry-run: prints intent, does not call Delete" {
 				args = append(args, "--dry-run")
 			}
-			out, err := runCmdCapture(newMockClient(withComputeMock(&mockComputeClient{keyPairsClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)


### PR DESCRIPTION
## Summary

- Migrates all 13 `cloudserver` + 6 `keypair` SDK call sites from the v0.1.x flat client to the v0.2.0 fluent wrapper API
- Adds `cloudServerRef`/`keypairRef` combined-URI ref helpers and `csListPayload`/`keypairListPayload` list-extraction helpers
- Operational methods (`PowerOn`, `PowerOff`, `SetPassword`) now called on the hydrated wrapper after a prior `Get`
- `connect` command uses `eip.Address()` accessor and passes the full linked URI to `aruba.URI()`
- `extractIDFromURI` helper and `TestExtractIDFromURI` removed (orphaned by the migration)
- `--billing-period` flag kept declared but unread (byte-identical CLI surface per #99); upstream SDK issue filed: Arubacloud/sdk-go#267
- Tests rewritten onto the `arubaTestServer` httptest harness; `TestCloudServerUpdateCmd` and `TestKeyPairUpdateCmd` added
- `ai/ARCHITECTURE.md` and `ai/CONVENTIONS.md` updated with combined-URI Ref and operational-wrapper-method patterns

## Build status

A green whole-package `go build`/`go test ./cmd` is not achievable until sub-issues #104–#110 land (remaining cmd files still red). Scoped static review:

- `gofmt -l` on all four cmd files → no output (clean)
- `go vet ./cmd/ 2>&1 | grep compute` → no output (no new errors in compute files)
- Checklist grep for v0.1.x patterns → no matches

## Notes

- `connect` command test omitted: needs a cross-family EIP fixture that would couple this PR to the network family migration (#109); noted for the epic exit.

Closes #103