### PR TITLE
feat(sdk): migrate network family to SDK v0.2.0 wrapper API (#104)

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -81,6 +81,49 @@ func cloudServerRef(projectID, serverID string) aruba.Ref {
 }
 ```
 
+**Multi-level nested Refs (network family)** — VPC-scoped resources (Subnet,
+SecurityGroup, VPCPeering) require 3-segment Refs; deeper resources (SecurityRule,
+VPCPeeringRoute, VPNRoute) require 4-segment Refs encoding the full ancestry. The
+path-segment casing matters: `subnets`, `securitygroups`, `securityrules`,
+`loadbalancers` are lowercase; `vpcPeerings`, `vpcPeeringRoutes`, `vpnTunnels`,
+`vpnRoutes`, `elasticIps` are camelCase (matches
+`internal/clients/network/path.go`, which is `internal/` and not importable).
+Each file declares a file-local `<resource>Ref` helper and reuses the parent Ref
+helper from the sibling file where it is defined once:
+
+| Helper | Defined in | URI template |
+|---|---|---|
+| `vpcRef(pid, vid)` | `network.vpc.go` | `/projects/<pid>/providers/Aruba.Network/vpcs/<vid>` |
+| `securityGroupRef(pid, vid, sgid)` | `network.securitygroup.go` | `…/vpcs/<vid>/securitygroups/<sgid>` |
+| `vpcPeeringRef(pid, vid, peerid)` | `network.vpcpeering.go` | `…/vpcs/<vid>/vpcPeerings/<peerid>` |
+| `vpnTunnelRef(pid, tid)` | `network.vpntunnel.go` | `…/vpnTunnels/<tid>` |
+
+**Read-only sub-client** — `LoadBalancersClient` exposes only `List` and `Get`.
+There is no `NewLoadBalancer()` factory and no Create/Update/Delete. The
+`network.loadbalancer.go` command file reflects this: it has only `list` and `get`
+subcommands.
+
+**Deeply-nested VPN sub-builders** — `aruba.NewVPNTunnel()` composes four
+independent sub-builders: `NewVPNIPConfig()`, `NewVPNIKE()`, `NewVPNESP()`,
+`NewVPNPSK()`. Each is constructed separately and attached via
+`WithIPConfig`/`WithIKESettings`/`WithESPSettings`/`WithPSKSettings`.
+
+**VPN `fromResponse` does not rehydrate sub-builders** — `VPNTunnel.fromResponse()`
+only populates top-level fields (`vpnType`, `vpnClientProtocol`, `billingPeriod`,
+`peerClientPublicIP`). A naïve wrapper `Update` would drop the IKE/ESP/PSK/IPConfig
+sub-builders from the PUT body. `network.vpntunnel.go` works around this with a
+file-local `vpnTunnelReattachSettings(cur *aruba.VPNTunnel)` helper that
+reconstructs the sub-builders from `cur.Raw().Properties.*` and re-attaches them
+before calling `Update`.
+
+**VPN crypto enums split per direction** — v0.2.0 replaces the unified
+`types.VPNEncryption*` / `types.VPNHash*` / `types.VPNDHGroup*` / etc. constants
+with per-direction types: `aruba.IKEEncryption` / `aruba.ESPEncryption`,
+`aruba.IKEHash` / `aruba.ESPHash`, `aruba.IKEDHGroup`, `aruba.IKEDPDAction`,
+`aruba.ESPPFSGroup`. The CLI exposes seven separate `[]string` enum slices
+(`vpnIKEEncryptionAlgorithms`, `vpnESPEncryptionAlgorithms`, etc.) and keys each
+`--ike-*` / `--esp-*` flag to the correct family in the validation table.
+
 **Operational methods on hydrated wrappers** — some operations (`PowerOn`, `PowerOff`,
 `SetPassword`) are methods on `*aruba.<T>`, not on the sub-client. They require a
 prior hydrating `Get`; calling them on a freshly-constructed `New<T>()` wrapper will

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -193,6 +193,19 @@ wrapper with `.IntoProject(projectRef(projectID))` and use a file-local
 `<resource>Ref(projectID, id)` helper (encoding both project + resource IDs in the
 URI) for `Get` and `Delete`.
 
+**Multi-segment ancestry Refs** — For nested resources (e.g. `Subnet` inside `VPC`,
+`SecurityRule` inside `SecurityGroup` inside `VPC`), each file declares a file-local
+`<resource>Ref(...)` helper that hand-builds the full URI string including all
+ancestor IDs. Parent Ref helpers (`vpcRef`, `securityGroupRef`, `vpcPeeringRef`,
+`vpnTunnelRef`) are defined once in their respective files and imported by sibling
+files — never redefined. Path-segment casing must match the API exactly (see
+`ARCHITECTURE.md` for the casing table).
+
+**Read-only resources** — Resources that the API exposes as read-only (e.g.
+`LoadBalancer`) have only `list` and `get` subcommands; no `create`, `update`, or
+`delete`. Do not add a `NewLoadBalancer()` builder call or Create/Update/Delete
+command vars.
+
 ### list
 ```go
 client, err := GetArubaClient()

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -28,7 +28,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-019 | `--dry-run` flag added to all 24 delete commands; in dry-run mode a `Get` validates existence and access then prints `[dry-run] Would delete …` without calling `Delete`; `msgDryRun` helper added to `cmd/root.go` |
 | TD-015 | Raw-JSON `response.RawBody` ID extraction removed from `cloudserver` and `keypair` list commands; typed `Metadata.ID` used directly; entries with nil/empty ID are discarded (SDK bumped to v0.1.26) |
 | TD-023 | Verbose error-body dump in `storage.backup` / `storage.restore` now uses `json.MarshalIndent(response.Error, …)`; generic `map[string]interface{}` unmarshal removed |
-| TD-024 | VPN IKE/ESP enum values documented: `vpnEncryptionAlgorithms`, `vpnHashAlgorithms`, `vpnDHGroups`, `vpnDPDActions`, `vpnPFSGroups` vars added to `cmd/network.vpntunnel.go`; `vpnValidateEnum` helper validates all enum flags client-side before the API call; `docs/website/docs/resources/network/vpntunnel.md` updated with full reference tables |
+| TD-024 | VPN crypto enums split per-direction in v0.2.0: the five unified slices (`vpnEncryptionAlgorithms`, `vpnHashAlgorithms`, `vpnDHGroups`, `vpnDPDActions`, `vpnPFSGroups`) are replaced with seven per-direction slices (`vpnIKEEncryptionAlgorithms`, `vpnESPEncryptionAlgorithms`, `vpnIKEHashAlgorithms`, `vpnESPHashAlgorithms`, `vpnIKEDHGroups`, `vpnIKEDPDActions`, `vpnESPPFSGroups`) built from `aruba.IKE*`/`aruba.ESP*` constants; each `--ike-*`/`--esp-*` flag is keyed to its correct family in the validation table; accepted string values are unchanged (CLI behaviour byte-identical) |
 
 ---
 
@@ -42,9 +42,13 @@ Issues are grouped by severity. Address Critical items before new features ship;
 ---
 
 ### TD-022 · Pre-release SDK version (v0.1.x → v0.2.0 migration in progress)
-`go.mod` now depends on `github.com/Arubacloud/sdk-go v0.2.0`. The bump was the first step of the multi-PR migration tracked in #99; foundations (shared helpers in `cmd/root.go`, `StateActive` constant) landed via #100. Per-family migrations (#101-#110) and behavioural fixups (#111) are still open — `go build ./cmd` will remain red until those merge.
+`go.mod` now depends on `github.com/Arubacloud/sdk-go v0.2.0`. Migration status:
+- #100 (shared helpers), #101 (`arubaTestServer` harness), #102 (`management.project`), #103 (`compute`: cloudserver + keypair), #104 (`network` family: 10 resources) — all merged onto `feat/sdk-v0.2.0-upgrade`.
+- #105–#110 (storage, database, container, kms, other families) — still open.
 
-**Fix:** Close out #99's exit criteria, then mark TD-022 resolved.
+`go build ./cmd` remains red until #105–#110 land. `make e2e-network` requires live credentials (validated after integration branch complete).
+
+**Fix:** Close out #99's exit criteria (#105–#110 + #111), then mark TD-022 resolved.
 
 ---
 

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -44,11 +45,20 @@ func init() {
 	elasticipDeleteCmd.ValidArgsFunction = completeElasticIPID
 }
 
+func elasticIPRef(projectID, eipID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/elasticIps/" + eipID)
+}
+
+func elasticIPListPayload(l *aruba.List[*aruba.ElasticIP]) any {
+	if r, ok := l.Raw().(*types.Response[types.ElasticList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
 // Completion functions for network resources
 
 func completeElasticIPID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -60,20 +70,21 @@ func completeElasticIPID(cmd *cobra.Command, args []string, toComplete string) (
 	}
 
 	ctx := context.Background()
-	response, err := client.FromNetwork().ElasticIPs().List(ctx, projectID, nil)
+	list, err := client.FromNetwork().ElasticIPs().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, eip := range response.Data.Values {
-			if eip.Metadata.ID != nil && eip.Metadata.Name != nil {
-				id := *eip.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *eip.Metadata.Name))
-				}
+	if list != nil {
+		for _, eip := range list.Items() {
+			id := eip.ElasticIPID()
+			name := eip.Name()
+			if id == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
@@ -100,67 +111,51 @@ Billing period: Hour (default), Month, or Year.`,
   acloud network elasticip create --name prod-eip --region IT-BG --billing-period Month`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		billingPeriod, _ := cmd.Flags().GetString("billing-period")
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		createRequest := types.ElasticIPRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.ElasticIPPropertiesRequest{
-				BillingPlan: types.BillingPeriodResource{
-					BillingPeriod: billingPeriod,
-				},
-			},
+		eip := aruba.NewElasticIP().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+		if len(tags) > 0 {
+			eip.ReplaceTags(tags...)
 		}
 
-		// Create the Elastic IP using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().ElasticIPs().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromNetwork().ElasticIPs().Create(ctx, eip)
 		if err != nil {
-			return fmt.Errorf("creating Elastic IP: %w", err)
+			return fmt.Errorf("creating Elastic IP: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		r := created.Raw()
+		if r != nil {
 			fmt.Printf("\n%s\n", msgCreated("Elastic IP", name))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *response.Data.Metadata.ID)
+			if r.Metadata.ID != nil {
+				fmt.Printf("ID:      %s\n", *r.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *response.Data.Metadata.Name)
+			if r.Metadata.Name != nil {
+				fmt.Printf("Name:    %s\n", *r.Metadata.Name)
 			}
-			if response.Data.Properties.Address != nil {
-				fmt.Printf("Address: %s\n", *response.Data.Properties.Address)
+			if r.Properties.Address != nil {
+				fmt.Printf("Address: %s\n", *r.Properties.Address)
 			}
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", response.Data.Metadata.Tags)
+			if len(r.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:    %v\n", r.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("Elastic IP", name))
@@ -174,31 +169,24 @@ var elasticipListCmd = &cobra.Command{
 	Short: "List all Elastic IPs",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// List Elastic IPs using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().ElasticIPs().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromNetwork().ElasticIPs().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing Elastic IPs: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing Elastic IPs: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
-			// Define table columns
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -207,39 +195,31 @@ var elasticipListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 
-			// Build rows
 			var rows [][]string
-			for _, eip := range response.Data.Values {
-				name := ""
-				if eip.Metadata.Name != nil && *eip.Metadata.Name != "" {
-					name = *eip.Metadata.Name
-				}
-
-				id := ""
-				if eip.Metadata.ID != nil {
-					id = *eip.Metadata.ID
-				}
+			for _, eip := range list.Items() {
+				r := eip.Raw()
+				name := eip.Name()
+				id := eip.ElasticIPID()
 
 				region := ""
-				if eip.Metadata.LocationResponse != nil {
-					region = eip.Metadata.LocationResponse.Value
-				}
-
 				address := ""
-				if eip.Properties.Address != nil {
-					address = *eip.Properties.Address
-				}
-
 				status := ""
-				if eip.Status.State != nil {
-					status = *eip.Status.State
+				if r != nil {
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					if r.Properties.Address != nil {
+						address = *r.Properties.Address
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 
 				rows = append(rows, []string{name, id, region, address, status})
 			}
 
-			// Print the table
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(elasticIPListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No Elastic IPs found")
 		}
@@ -254,33 +234,25 @@ var elasticipGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		eipID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get Elastic IP details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
+		got, err := client.FromNetwork().ElasticIPs().Get(ctx, elasticIPRef(projectID, eipID))
 		if err != nil {
-			return fmt.Errorf("getting Elastic IP details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			eip := response.Data
-
-			// Display Elastic IP details
+		eip := got.Raw()
+		if eip != nil {
 			fmt.Println("\nElastic IP Details:")
 			fmt.Println("===================")
 
@@ -300,7 +272,9 @@ var elasticipGetCmd = &cobra.Command{
 				fmt.Printf("Address:         %s\n", *eip.Properties.Address)
 			}
 
-			fmt.Printf("Billing Period:  %s\n", eip.Properties.BillingPlan.BillingPeriod)
+			if eip.Properties.BillingPeriod != nil {
+				fmt.Printf("Billing Period:  %s\n", *eip.Properties.BillingPeriod)
+			}
 			fmt.Printf("Linked Resources: %d\n", len(eip.Properties.LinkedResources))
 
 			if eip.Metadata.CreationDate != nil {
@@ -331,93 +305,62 @@ var elasticipUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		eipID := args[0]
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one update flag must be provided
 		if name == "" && len(tags) == 0 {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current Elastic IP to preserve existing properties
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
+		cur, err := client.FromNetwork().ElasticIPs().Get(ctx, elasticIPRef(projectID, eipID))
 		if err != nil {
-			return fmt.Errorf("getting Elastic IP details: %w", err)
+			return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
+		r := cur.Raw()
+		if r == nil {
 			return fmt.Errorf("Elastic IP not found")
 		}
 
-		// Check if Elastic IP is in InCreation state
-		if getResponse.Data.Status.State != nil && *getResponse.Data.Status.State == StateInCreation {
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update Elastic IP while it is in 'InCreation' state. Please wait until the Elastic IP is fully created")
 		}
 
-		// Get region value
-		regionValue := ""
-		if getResponse.Data.Metadata.LocationResponse != nil {
-			regionValue = getResponse.Data.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for Elastic IP")
-		}
-
-		// Build the update request, preserving existing values
-		updateRequest := types.ElasticIPRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *getResponse.Data.Metadata.Name,
-					Tags: getResponse.Data.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.ElasticIPPropertiesRequest{
-				BillingPlan: getResponse.Data.Properties.BillingPlan,
-			},
-		}
-
-		// Apply updates
 		if name != "" {
-			updateRequest.Metadata.Name = name
+			cur.Named(name)
 		}
-		if len(tags) > 0 {
-			updateRequest.Metadata.Tags = tags
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
 		}
 
-		// Update the Elastic IP using the SDK
-		response, err := client.FromNetwork().ElasticIPs().Update(ctx, projectID, eipID, updateRequest, nil)
+		updated, err := client.FromNetwork().ElasticIPs().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating Elastic IP: %w", err)
+			return fmt.Errorf("updating Elastic IP: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
+		ur := updated.Raw()
+		if ur != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Elastic IP", eipID))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *response.Data.Metadata.ID)
+			if ur.Metadata.ID != nil {
+				fmt.Printf("ID:      %s\n", *ur.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *response.Data.Metadata.Name)
+			if ur.Metadata.Name != nil {
+				fmt.Printf("Name:    %s\n", *ur.Metadata.Name)
 			}
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", response.Data.Metadata.Tags)
+			if len(ur.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:    %v\n", ur.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("Elastic IP", eipID))
@@ -433,10 +376,8 @@ var elasticipDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		eipID := args[0]
 
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("Elastic IP", eipID)
 			if err != nil {
@@ -447,13 +388,11 @@ var elasticipDeleteCmd = &cobra.Command{
 			}
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -464,21 +403,16 @@ var elasticipDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
+			_, err = client.FromNetwork().ElasticIPs().Get(ctx, elasticIPRef(projectID, eipID))
 			if err != nil {
-				return fmt.Errorf("dry-run: elastic IP not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: elastic IP not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("elastic IP", eipID))
 			return nil
 		}
 
-		// Delete the Elastic IP using the SDK
-		deleteResp, err := client.FromNetwork().ElasticIPs().Delete(ctx, projectID, eipID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting Elastic IP: %w", err)
-		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+		if err := client.FromNetwork().ElasticIPs().Delete(ctx, elasticIPRef(projectID, eipID)); err != nil {
+			return fmt.Errorf("deleting Elastic IP: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Elastic IP", eipID))

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,22 @@ import (
 func TestElasticIPListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockElasticIPsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockElasticIPsClient) {
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "eip-001", "my-eip"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
-					return &types.Response[types.ElasticList]{
-						StatusCode: 200,
-						Data: &types.ElasticList{
-							Values: []types.ElasticIPResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+					Values: []types.ElasticIPResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "eip-001") {
@@ -41,26 +36,21 @@ func TestElasticIPListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
-					return &types.Response[types.ElasticList]{StatusCode: 200, Data: &types.ElasticList{}}, nil
-				}
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockElasticIPsClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "eip-001", "my-eip"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
-					return &types.Response[types.ElasticList]{
-						StatusCode: 200,
-						Data: &types.ElasticList{
-							Values: []types.ElasticIPResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+					Values: []types.ElasticIPResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +60,19 @@ func TestElasticIPListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticList], error) {
-					return &types.Response[types.ElasticList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +80,11 @@ func TestElasticIPListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockElasticIPsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "elasticip", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestElasticIPListCmd(t *testing.T) {
 func TestElasticIPGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockElasticIPsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockElasticIPsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "eip-001", "my-eip"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-					return &types.Response[types.ElasticIPResponse]{
-						StatusCode: 200,
-						Data:       &types.ElasticIPResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "eip-001") {
@@ -138,24 +116,17 @@ func TestElasticIPGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-					return &types.Response[types.ElasticIPResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +134,11 @@ func TestElasticIPGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockElasticIPsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})),
-				[]string{"network", "elasticip", "get", "eip-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"network", "elasticip", "get", "eip-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -181,62 +151,52 @@ func TestElasticIPCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockElasticIPsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG"},
-			setupMock: func(m *mockElasticIPsClient) {
-				id, name := "eip-new", "my-eip"
-				m.createFn = func(_ context.Context, _ string, _ types.ElasticIPRequest, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-					return &types.Response[types.ElasticIPResponse]{
-						StatusCode: 200,
-						Data:       &types.ElasticIPResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG", "--billing-period", "monthly"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "eip-new") {
+				if !strings.Contains(out, "eip-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name:        "missing required flag --name",
-			args:        []string{"network", "elasticip", "create", "--project-id", "proj-123", "--region", "IT-BG"},
+			args:        []string{"network", "elasticip", "create", "--project-id", "proj-123", "--region", "IT-BG", "--billing-period", "monthly"},
 			wantErr:     true,
 			errContains: "name",
 		},
 		{
 			name:        "missing required flag --region",
-			args:        []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip"},
+			args:        []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--billing-period", "monthly"},
 			wantErr:     true,
 			errContains: "region",
 		},
 		{
-			name: "SDK error propagates",
-			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG"},
-			setupMock: func(m *mockElasticIPsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.ElasticIPRequest, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			name: "server error propagates",
+			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG", "--billing-period", "monthly"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/elasticIps", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
 		},
 		{
 			name: "API error propagates",
-			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG"},
-			setupMock: func(m *mockElasticIPsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.ElasticIPRequest, _ *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error) {
-					return &types.Response[types.ElasticIPResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "elasticip", "create", "--project-id", "proj-123", "--name", "my-eip", "--region", "IT-BG", "--billing-period", "monthly"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/elasticIps", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -244,11 +204,86 @@ func TestElasticIPCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockElasticIPsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestElasticIPUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "elasticip", "update", "eip-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "eip-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no flags error",
+			args:        []string{"network", "elasticip", "update", "eip-001", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "pre-Get server error",
+			args: []string{"network", "elasticip", "update", "eip-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "update server error",
+			args: []string{"network", "elasticip", "update", "eip-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -260,17 +295,17 @@ func TestElasticIPCreateCmd(t *testing.T) {
 func TestElasticIPDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockElasticIPsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "eip-001") {
@@ -280,11 +315,12 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			args: []string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "eip-001") {
@@ -293,24 +329,19 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockElasticIPsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -318,15 +349,11 @@ func TestElasticIPDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockElasticIPsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "elasticip", "delete", "eip-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{elasticIPsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -26,10 +28,19 @@ func init() {
 
 }
 
+func loadBalancerRef(projectID, lbID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/loadbalancers/" + lbID)
+}
+
+func loadBalancerListPayload(l *aruba.List[*aruba.LoadBalancer]) any {
+	if r, ok := l.Raw().(*types.Response[types.LoadBalancerList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
 // Completion functions for network resources
 func completeLoadBalancerID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -41,20 +52,21 @@ func completeLoadBalancerID(cmd *cobra.Command, args []string, toComplete string
 	}
 
 	ctx := context.Background()
-	response, err := client.FromNetwork().LoadBalancers().List(ctx, projectID, nil)
+	list, err := client.FromNetwork().LoadBalancers().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, lb := range response.Data.Values {
-			if lb.Metadata.ID != nil && lb.Metadata.Name != nil {
-				id := *lb.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *lb.Metadata.Name))
-				}
+	if list != nil {
+		for _, lb := range list.Items() {
+			id := lb.LoadBalancerID()
+			name := lb.Name()
+			if id == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
@@ -74,31 +86,24 @@ var loadbalancerListCmd = &cobra.Command{
 	Short: "List all Load Balancers",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// List Load Balancers using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().LoadBalancers().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromNetwork().LoadBalancers().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing Load Balancers: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing Load Balancers: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
-			// Define table columns
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -107,39 +112,31 @@ var loadbalancerListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 
-			// Build rows
 			var rows [][]string
-			for _, lb := range response.Data.Values {
-				name := ""
-				if lb.Metadata.Name != nil && *lb.Metadata.Name != "" {
-					name = *lb.Metadata.Name
-				}
-
-				id := ""
-				if lb.Metadata.ID != nil {
-					id = *lb.Metadata.ID
-				}
+			for _, lb := range list.Items() {
+				r := lb.Raw()
+				name := lb.Name()
+				id := lb.LoadBalancerID()
 
 				region := ""
-				if lb.Metadata.LocationResponse != nil {
-					region = lb.Metadata.LocationResponse.Value
-				}
-
 				address := ""
-				if lb.Properties.Address != nil {
-					address = *lb.Properties.Address
-				}
-
 				status := ""
-				if lb.Status.State != nil {
-					status = *lb.Status.State
+				if r != nil {
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					if r.Properties.Address != nil {
+						address = *r.Properties.Address
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 
 				rows = append(rows, []string{name, id, region, address, status})
 			}
 
-			// Print the table
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(loadBalancerListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No Load Balancers found")
 		}
@@ -154,33 +151,25 @@ var loadbalancerGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lbID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get Load Balancer details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().LoadBalancers().Get(ctx, projectID, lbID, nil)
+		got, err := client.FromNetwork().LoadBalancers().Get(ctx, loadBalancerRef(projectID, lbID))
 		if err != nil {
-			return fmt.Errorf("getting Load Balancer details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting Load Balancer details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			lb := response.Data
-
-			// Display Load Balancer details
+		lb := got.Raw()
+		if lb != nil {
 			fmt.Println("\nLoad Balancer Details:")
 			fmt.Println("======================")
 

--- a/cmd/network.loadbalancer_test.go
+++ b/cmd/network.loadbalancer_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,22 @@ import (
 func TestLoadBalancerListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockLoadBalancersClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockLoadBalancersClient) {
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "lb-001", "my-lb"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
-					return &types.Response[types.LoadBalancerList]{
-						StatusCode: 200,
-						Data: &types.LoadBalancerList{
-							Values: []types.LoadBalancerResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers", jsonResponse(200, types.LoadBalancerList{
+					Values: []types.LoadBalancerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "lb-001") {
@@ -41,26 +36,21 @@ func TestLoadBalancerListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockLoadBalancersClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
-					return &types.Response[types.LoadBalancerList]{StatusCode: 200, Data: &types.LoadBalancerList{}}, nil
-				}
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers", jsonResponse(200, types.LoadBalancerList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockLoadBalancersClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "lb-001", "my-lb"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
-					return &types.Response[types.LoadBalancerList]{
-						StatusCode: 200,
-						Data: &types.LoadBalancerList{
-							Values: []types.LoadBalancerResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers", jsonResponse(200, types.LoadBalancerList{
+					Values: []types.LoadBalancerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +60,19 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockLoadBalancersClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockLoadBalancersClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
-					return &types.Response[types.LoadBalancerList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +80,11 @@ func TestLoadBalancerListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockLoadBalancersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "loadbalancer", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{loadBalancersMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestLoadBalancerListCmd(t *testing.T) {
 func TestLoadBalancerGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockLoadBalancersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockLoadBalancersClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "lb-001", "my-lb"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error) {
-					return &types.Response[types.LoadBalancerResponse]{
-						StatusCode: 200,
-						Data:       &types.LoadBalancerResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers/lb-001", jsonResponse(200, types.LoadBalancerResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "lb-001") {
@@ -138,45 +116,29 @@ func TestLoadBalancerGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockLoadBalancersClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers/lb-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockLoadBalancersClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error) {
-					return &types.Response[types.LoadBalancerResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadbalancers/lb-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
-		{
-			name: "nil data",
-			setupMock: func(m *mockLoadBalancersClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error) {
-					return &types.Response[types.LoadBalancerResponse]{StatusCode: 200}, nil
-				}
-			},
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockLoadBalancersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{loadBalancersMock: m})),
-				[]string{"network", "loadbalancer", "get", "lb-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"network", "loadbalancer", "get", "lb-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -3,9 +3,22 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+// securityGroupRef is shared with securityrule.go and subnet.go (via vpcRef).
+func securityGroupRef(projectID, vpcID, sgID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID + "/securitygroups/" + sgID)
+}
+
+func securityGroupListPayload(l *aruba.List[*aruba.SecurityGroup]) any {
+	if r, ok := l.Raw().(*types.Response[types.SecurityGroupList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
 
 func init() {
 	// SecurityGroup
@@ -67,20 +80,21 @@ after the group is created.`,
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		req := types.SecurityGroupRequest{
-			Metadata: types.ResourceMetadataRequest{
-				Name: name,
-				Tags: tags,
-			},
+
+		sg := aruba.NewSecurityGroup().
+			IntoVPC(vpcRef(projectID, vpcID)).
+			Named(name)
+		if len(tags) > 0 {
+			sg.ReplaceTags(tags...)
 		}
-		resp, err := client.FromNetwork().SecurityGroups().Create(ctx, projectID, vpcID, req, nil)
+
+		created, err := client.FromNetwork().SecurityGroups().Create(ctx, sg)
 		if err != nil {
-			return fmt.Errorf("creating security group: %w", err)
+			return fmt.Errorf("creating security group: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
+
+		r := created.Raw()
+		if r != nil && r.Metadata.ID != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -88,22 +102,14 @@ after the group is created.`,
 				{Header: "STATUS", Width: 15},
 			}
 			region := ""
-			if resp.Data.Metadata.LocationResponse != nil {
-				region = resp.Data.Metadata.LocationResponse.Value
+			if r.Metadata.LocationResponse != nil {
+				region = string(r.Metadata.LocationResponse.Value)
 			}
-			row := []string{
-				name,
-				*resp.Data.Metadata.ID,
-				region,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					} else {
-						return ""
-					}
-				}(),
+			status := ""
+			if r.Status.State != nil {
+				status = *r.Status.State
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			PrintOutput(r, headers, [][]string{{name, *r.Metadata.ID, region, status}})
 		} else {
 			fmt.Println(msgCreatedAsync("Security group", name))
 		}
@@ -128,15 +134,13 @@ var securitygroupGetCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().SecurityGroups().Get(ctx, projectID, vpcID, sgID, nil)
+		got, err := client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(projectID, vpcID, sgID))
 		if err != nil {
-			return fmt.Errorf("getting security group: %w", err)
+			return fmt.Errorf("getting security group: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil {
-			sg := resp.Data
+
+		sg := got.Raw()
+		if sg != nil {
 			fmt.Println("\nSecurity Group Details:")
 			fmt.Println("======================")
 			if sg.Metadata.ID != nil {
@@ -149,9 +153,7 @@ var securitygroupGetCmd = &cobra.Command{
 				fmt.Printf("Name:            %s\n", *sg.Metadata.Name)
 			}
 			if sg.Metadata.LocationResponse != nil {
-				if sg.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", sg.Metadata.LocationResponse.Value)
-				}
+				fmt.Printf("Region:          %s\n", sg.Metadata.LocationResponse.Value)
 			}
 			if sg.Metadata.CreationDate != nil {
 				fmt.Printf("Creation Date:   %s\n", sg.Metadata.CreationDate.Format(DateLayout))
@@ -190,14 +192,12 @@ var securitygroupListCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().SecurityGroups().List(ctx, projectID, vpcID, listParams(cmd))
+		list, err := client.FromNetwork().SecurityGroups().List(ctx, vpcRef(projectID, vpcID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing security groups: %w", err)
+			return fmt.Errorf("listing security groups: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -205,26 +205,23 @@ var securitygroupListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 			var rows [][]string
-			for _, sg := range resp.Data.Values {
-				name := ""
-				if sg.Metadata.Name != nil {
-					name = *sg.Metadata.Name
-				}
-				id := ""
-				if sg.Metadata.ID != nil {
-					id = *sg.Metadata.ID
-				}
+			for _, sg := range list.Items() {
+				r := sg.Raw()
+				name := sg.Name()
+				id := sg.SecurityGroupID()
 				region := ""
-				if sg.Metadata.LocationResponse != nil {
-					region = sg.Metadata.LocationResponse.Value
-				}
 				status := ""
-				if sg.Status.State != nil {
-					status = *sg.Status.State
+				if r != nil {
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 				rows = append(rows, []string{name, id, region, status})
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(securityGroupListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No security groups found.")
 		}
@@ -254,87 +251,56 @@ var securitygroupUpdateCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		// Fetch current security group details
-		getResp, err := client.FromNetwork().SecurityGroups().Get(ctx, projectID, vpcID, sgID, nil)
-		if err != nil || getResp == nil || getResp.Data == nil {
-			return fmt.Errorf("fetching current security group: %w", err)
+
+		cur, err := client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(projectID, vpcID, sgID))
+		if err != nil {
+			return fmt.Errorf("fetching current security group: %w", apiErrFromV2(err))
 		}
-		current := getResp.Data
-		// Block update if security group is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == StateInCreation {
+		r := cur.Raw()
+		if r == nil {
+			return fmt.Errorf("security group not found")
+		}
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update security group while it is in 'InCreation' state. Please wait until the security group is fully created")
 		}
-		// Get region value
-		regionValue := ""
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
+
+		if name != "" {
+			cur.Named(name)
 		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for security group")
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
 		}
-		// Build update request by merging user input with all current valid fields
-		req := types.SecurityGroupRequest{
-			Metadata: types.ResourceMetadataRequest{
-				Name: func() string {
-					if name != "" {
-						return name
-					}
-					if current.Metadata.Name != nil {
-						return *current.Metadata.Name
-					}
-					return ""
-				}(),
-				Tags: func() []string {
-					if cmd.Flags().Changed("tags") {
-						return tags
-					}
-					if current.Metadata.Tags != nil {
-						return current.Metadata.Tags
-					}
-					return []string{}
-				}(),
-			},
-		}
-		resp, err := client.FromNetwork().SecurityGroups().Update(ctx, projectID, vpcID, sgID, req, nil)
+
+		updated, err := client.FromNetwork().SecurityGroups().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating security group: %w", err)
+			return fmt.Errorf("updating security group: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil {
+
+		ur := updated.Raw()
+		if ur != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
 				{Header: "REGION", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			updateRegion := ""
-			if resp.Data.Metadata.LocationResponse != nil {
-				updateRegion = resp.Data.Metadata.LocationResponse.Value
+			updName := ""
+			if ur.Metadata.Name != nil {
+				updName = *ur.Metadata.Name
 			}
-			row := []string{
-				func() string {
-					if resp.Data.Metadata.Name != nil {
-						return *resp.Data.Metadata.Name
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.ID != nil {
-						return *resp.Data.Metadata.ID
-					}
-					return ""
-				}(),
-				updateRegion,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			updID := ""
+			if ur.Metadata.ID != nil {
+				updID = *ur.Metadata.ID
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			updRegion := ""
+			if ur.Metadata.LocationResponse != nil {
+				updRegion = string(ur.Metadata.LocationResponse.Value)
+			}
+			updStatus := ""
+			if ur.Status.State != nil {
+				updStatus = *ur.Status.State
+			}
+			PrintOutput(ur, headers, [][]string{{updName, updID, updRegion, updStatus}})
 		} else {
 			fmt.Println(msgUpdatedAsync("Security group", sgID))
 		}
@@ -350,10 +316,7 @@ var securitygroupDeleteCmd = &cobra.Command{
 		vpcID := args[0]
 		sgID := args[1]
 
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("security group", sgID)
 			if err != nil {
@@ -377,21 +340,18 @@ var securitygroupDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().SecurityGroups().Get(ctx, projectID, vpcID, sgID, nil)
+			_, err = client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(projectID, vpcID, sgID))
 			if err != nil {
-				return fmt.Errorf("dry-run: security group not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: security group not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("security group", sgID))
 			return nil
 		}
 
-		resp, err := client.FromNetwork().SecurityGroups().Delete(ctx, projectID, vpcID, sgID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting security group: %w", err)
+		if err := client.FromNetwork().SecurityGroups().Delete(ctx, securityGroupRef(projectID, vpcID, sgID)); err != nil {
+			return fmt.Errorf("deleting security group: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
+
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},
 			{Header: "STATUS", Width: 15},

--- a/cmd/network.securitygroup_test.go
+++ b/cmd/network.securitygroup_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,22 @@ import (
 func TestSecurityGroupListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSecurityGroupsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockSecurityGroupsClient) {
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sg-001", "my-sg"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
-					return &types.Response[types.SecurityGroupList]{
-						StatusCode: 200,
-						Data: &types.SecurityGroupList{
-							Values: []types.SecurityGroupResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", jsonResponse(200, types.SecurityGroupList{
+					Values: []types.SecurityGroupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sg-001") {
@@ -41,26 +36,21 @@ func TestSecurityGroupListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
-					return &types.Response[types.SecurityGroupList]{StatusCode: 200, Data: &types.SecurityGroupList{}}, nil
-				}
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", jsonResponse(200, types.SecurityGroupList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockSecurityGroupsClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sg-001", "my-sg"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
-					return &types.Response[types.SecurityGroupList]{
-						StatusCode: 200,
-						Data: &types.SecurityGroupList{
-							Values: []types.SecurityGroupResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", jsonResponse(200, types.SecurityGroupList{
+					Values: []types.SecurityGroupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +60,19 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
-					return &types.Response[types.SecurityGroupList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +80,11 @@ func TestSecurityGroupListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestSecurityGroupListCmd(t *testing.T) {
 func TestSecurityGroupGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSecurityGroupsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockSecurityGroupsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sg-001", "my-sg"
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-					return &types.Response[types.SecurityGroupResponse]{
-						StatusCode: 200,
-						Data:       &types.SecurityGroupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sg-001") {
@@ -138,24 +116,17 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-					return &types.Response[types.SecurityGroupResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +134,11 @@ func TestSecurityGroupGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})),
-				[]string{"network", "securitygroup", "get", "vpc-001", "sg-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"network", "securitygroup", "get", "vpc-001", "sg-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -181,7 +151,7 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockSecurityGroupsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -189,17 +159,14 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"network", "securitygroup", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-sg", "--region", "IT-BG"},
-			setupMock: func(m *mockSecurityGroupsClient) {
-				id, name := "sg-new", "my-sg"
-				m.createFn = func(_ context.Context, _, _ string, _ types.SecurityGroupRequest, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-					return &types.Response[types.SecurityGroupResponse]{
-						StatusCode: 200,
-						Data:       &types.SecurityGroupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", jsonResponse(200, types.SecurityGroupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "sg-new") {
+				if !strings.Contains(out, "sg-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
@@ -217,12 +184,10 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 			errContains: "region",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"network", "securitygroup", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-sg", "--region", "IT-BG"},
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.SecurityGroupRequest, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -230,13 +195,8 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"network", "securitygroup", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-sg", "--region", "IT-BG"},
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.SecurityGroupRequest, _ *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error) {
-					return &types.Response[types.SecurityGroupResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -244,12 +204,90 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			err := runCmd(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestSecurityGroupUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "securitygroup", "update", "vpc-001", "sg-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sg-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no flags error",
+			args:        []string{"network", "securitygroup", "update", "vpc-001", "sg-001", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "pre-Get server error",
+			args: []string{"network", "securitygroup", "update", "vpc-001", "sg-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "update server error",
+			args: []string{"network", "securitygroup", "update", "vpc-001", "sg-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
 		})
 	}
 }
@@ -257,17 +295,17 @@ func TestSecurityGroupCreateCmd(t *testing.T) {
 func TestSecurityGroupDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSecurityGroupsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sg-001") {
@@ -277,11 +315,12 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			args: []string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sg-001") {
@@ -290,24 +329,19 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSecurityGroupsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -315,15 +349,11 @@ func TestSecurityGroupDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "securitygroup", "delete", "vpc-001", "sg-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -7,9 +7,21 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+func securityRuleRef(projectID, vpcID, sgID, ruleID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID + "/securitygroups/" + sgID + "/securityrules/" + ruleID)
+}
+
+func securityRuleListPayload(l *aruba.List[*aruba.SecurityRule]) any {
+	if r, ok := l.Raw().(*types.Response[types.SecurityRuleList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
 
 func init() {
 
@@ -59,7 +71,6 @@ func init() {
 	securityruleDeleteCmd.ValidArgsFunction = completeSecurityRuleID
 }
 
-// Completion functions for network resources
 func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) < 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -79,20 +90,21 @@ func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string
 	securityGroupID := args[1]
 
 	ctx := context.Background()
-	response, err := client.FromNetwork().SecurityGroupRules().List(ctx, projectID, vpcID, securityGroupID, nil)
+	list, err := client.FromNetwork().SecurityGroupRules().List(ctx, securityGroupRef(projectID, vpcID, securityGroupID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, rule := range response.Data.Values {
-			if rule.Metadata.ID != nil && rule.Metadata.Name != nil {
-				id := *rule.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *rule.Metadata.Name))
-				}
+	if list != nil {
+		for _, rule := range list.Items() {
+			id := rule.SecurityRuleID()
+			name := rule.Name()
+			if id == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
@@ -157,32 +169,6 @@ Example target values:
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build target
-		target := &types.RuleTarget{
-			Kind:  types.EndpointTypeDto(targetKind),
-			Value: targetValue,
-		}
-
-		// Build the create request
-		req := types.SecurityRuleRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.SecurityRulePropertiesRequest{
-				Direction: types.RuleDirection(direction),
-				Protocol:  protocol,
-				Port:      port,
-				Target:    target,
-			},
-		}
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("Creating security rule with the following parameters:")
 			fmt.Printf("  Name:         %s\n", name)
@@ -198,18 +184,31 @@ Example target values:
 			fmt.Println()
 		}
 
+		rule := aruba.NewSecurityRule().
+			IntoSecurityGroup(securityGroupRef(projectID, vpcID, securityGroupID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			WithDirection(types.RuleDirection(direction)).
+			WithProtocol(aruba.RuleProtocol(protocol)).
+			WithPort(port)
+		if targetKind == string(types.EndpointTypeSecurityGroup) {
+			rule.WithTargetSecurityGroup(aruba.URI(targetValue))
+		} else {
+			rule.WithTargetCIDR(targetValue)
+		}
+		if len(tags) > 0 {
+			rule.ReplaceTags(tags...)
+		}
+
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().SecurityGroupRules().Create(ctx, projectID, vpcID, securityGroupID, req, nil)
+		created, err := client.FromNetwork().SecurityGroupRules().Create(ctx, rule)
 		if err != nil {
-			return fmt.Errorf("creating security rule: %w", err)
+			return fmt.Errorf("creating security rule: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
+		r := created.Raw()
+		if r != nil && r.Metadata.ID != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -218,20 +217,11 @@ Example target values:
 				{Header: "PORT", Width: 12},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				name,
-				*resp.Data.Metadata.ID,
-				direction,
-				protocol,
-				port,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			status := ""
+			if r.Status.State != nil {
+				status = *r.Status.State
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			PrintOutput(r, headers, [][]string{{name, *r.Metadata.ID, direction, protocol, port, status}})
 		} else {
 			fmt.Println(msgCreatedAsync("Security rule", name))
 		}
@@ -260,17 +250,13 @@ var securityruleGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().SecurityGroupRules().Get(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
+		got, err := client.FromNetwork().SecurityGroupRules().Get(ctx, securityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
 		if err != nil {
-			return fmt.Errorf("getting security rule: %w", err)
+			return fmt.Errorf("getting security rule: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			rule := resp.Data
+		rule := got.Raw()
+		if rule != nil {
 			fmt.Println("\nSecurity Rule Details:")
 			fmt.Println("=====================")
 			if rule.Metadata.ID != nil {
@@ -283,9 +269,7 @@ var securityruleGetCmd = &cobra.Command{
 				fmt.Printf("Name:            %s\n", *rule.Metadata.Name)
 			}
 			if rule.Metadata.LocationResponse != nil {
-				if rule.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", rule.Metadata.LocationResponse.Value)
-				}
+				fmt.Printf("Region:          %s\n", rule.Metadata.LocationResponse.Value)
 			}
 			fmt.Printf("Direction:       %s\n", rule.Properties.Direction)
 			fmt.Printf("Protocol:        %s\n", rule.Properties.Protocol)
@@ -335,16 +319,12 @@ var securityruleListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().SecurityGroupRules().List(ctx, projectID, vpcID, securityGroupID, listParams(cmd))
+		list, err := client.FromNetwork().SecurityGroupRules().List(ctx, securityGroupRef(projectID, vpcID, securityGroupID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing security rules: %w", err)
+			return fmt.Errorf("listing security rules: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -355,29 +335,29 @@ var securityruleListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 			var rows [][]string
-			for _, rule := range resp.Data.Values {
-				name := ""
-				if rule.Metadata.Name != nil {
-					name = *rule.Metadata.Name
-				}
-				id := ""
-				if rule.Metadata.ID != nil {
-					id = *rule.Metadata.ID
-				}
-				direction := string(rule.Properties.Direction)
-				protocol := rule.Properties.Protocol
-				port := rule.Properties.Port
+			for _, rule := range list.Items() {
+				r := rule.Raw()
+				name := rule.Name()
+				id := rule.SecurityRuleID()
+				direction := ""
+				protocol := ""
+				port := ""
 				target := ""
-				if rule.Properties.Target != nil {
-					target = fmt.Sprintf("%s:%s", rule.Properties.Target.Kind, rule.Properties.Target.Value)
-				}
 				status := ""
-				if rule.Status.State != nil {
-					status = *rule.Status.State
+				if r != nil {
+					direction = string(r.Properties.Direction)
+					protocol = string(r.Properties.Protocol)
+					port = r.Properties.Port
+					if r.Properties.Target != nil {
+						target = fmt.Sprintf("%s:%s", r.Properties.Target.Kind, r.Properties.Target.Value)
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 				rows = append(rows, []string{name, id, direction, protocol, port, target, status})
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(securityRuleListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No security rules found.")
 		}
@@ -397,7 +377,6 @@ var securityruleUpdateCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
 			return fmt.Errorf("at least one field (--name or --tags) must be provided for update")
 		}
@@ -415,90 +394,35 @@ var securityruleUpdateCmd = &cobra.Command{
 		ctx, cancel := newCtx()
 		defer cancel()
 
-		// Fetch current security rule details
-		getResp, err := client.FromNetwork().SecurityGroupRules().Get(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
+		cur, err := client.FromNetwork().SecurityGroupRules().Get(ctx, securityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
 		if err != nil {
-			return fmt.Errorf("fetching current security rule: %w", err)
+			return fmt.Errorf("fetching current security rule: %w", apiErrFromV2(err))
 		}
-
-		if getResp == nil {
-			return fmt.Errorf("no response received when fetching security rule")
+		r := cur.Raw()
+		if r == nil {
+			return fmt.Errorf("security rule not found")
 		}
-
-		if getResp.IsError() {
-			return apiErrFromResp(getResp.StatusCode, getResp.Error)
-		}
-
-		if getResp.Data == nil {
-			return fmt.Errorf("security rule not found or no data returned")
-		}
-
-		current := getResp.Data
-
-		// Block update if security rule is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == StateInCreation {
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update security rule while it is in 'InCreation' state. Please wait until the security rule is fully created")
 		}
 
-		// Get region value from current rule, or fetch from VPC if not available
-		regionValue := ""
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
-		}
-
-		// If region value is not available from the rule, try to get it from the VPC
-		if regionValue == "" {
-			vpcResp, err := client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
-			if err == nil && vpcResp != nil && !vpcResp.IsError() && vpcResp.Data != nil {
-				if vpcResp.Data.Metadata.LocationResponse != nil {
-					regionValue = vpcResp.Data.Metadata.LocationResponse.Value
-				}
+		if cur.Region() == "" {
+			vpc, verr := client.FromNetwork().VPCs().Get(ctx, vpcRef(projectID, vpcID))
+			if verr == nil && vpc != nil && vpc.Raw() != nil && vpc.Raw().Metadata.LocationResponse != nil {
+				cur.InRegion(vpc.Raw().Metadata.LocationResponse.Value)
 			}
 		}
-
-		// If still no region value, we cannot proceed
-		if regionValue == "" {
+		if cur.Region() == "" {
 			return fmt.Errorf("unable to determine region value for security rule. Please ensure the VPC has a valid region")
 		}
 
-		// Build update request - only name and tags can be updated
-		// Properties (direction, protocol, port, target) must remain unchanged
-		req := types.SecurityRuleRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: func() string {
-						if name != "" {
-							return name
-						}
-						if current.Metadata.Name != nil {
-							return *current.Metadata.Name
-						}
-						return ""
-					}(),
-					Tags: func() []string {
-						if cmd.Flags().Changed("tags") {
-							return tags
-						}
-						if current.Metadata.Tags != nil {
-							return current.Metadata.Tags
-						}
-						return []string{}
-					}(),
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.SecurityRulePropertiesRequest{
-				// Properties cannot be updated - use current values
-				Direction: current.Properties.Direction,
-				Protocol:  current.Properties.Protocol,
-				Port:      current.Properties.Port,
-				Target:    current.Properties.Target,
-			},
+		if name != "" {
+			cur.Named(name)
+		}
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
 		}
 
-		// Check if debug flag is enabled
 		debugEnabled, _ := rootCmd.PersistentFlags().GetBool("debug")
 		if debugEnabled {
 			fmt.Fprintf(os.Stderr, "\n=== DEBUG: Security Rule Update Request ===\n")
@@ -506,30 +430,19 @@ var securityruleUpdateCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Security Group ID: %s\n", securityGroupID)
 			fmt.Fprintf(os.Stderr, "Security Rule ID: %s\n", securityRuleID)
 			fmt.Fprintf(os.Stderr, "Request Payload:\n")
-			if reqJSON, err := json.MarshalIndent(req, "", "  "); err == nil {
+			if reqJSON, err := json.MarshalIndent(cur.RawRequest(), "", "  "); err == nil {
 				fmt.Fprintf(os.Stderr, "%s\n", reqJSON)
 			}
 			fmt.Fprintf(os.Stderr, "==========================================\n\n")
 		}
 
-		resp, err := client.FromNetwork().SecurityGroupRules().Update(ctx, projectID, vpcID, securityGroupID, securityRuleID, req, nil)
+		updated, err := client.FromNetwork().SecurityGroupRules().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating security rule: %w", err)
+			return fmt.Errorf("updating security rule: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			if debugEnabled {
-				fmt.Fprintf(os.Stderr, "\n=== DEBUG: Error Response ===\n")
-				if resp.RawBody != nil {
-					fmt.Fprintf(os.Stderr, "Raw Response Body:\n%s\n", string(resp.RawBody))
-				}
-				fmt.Fprintf(os.Stderr, "Status Code: %d\n", resp.StatusCode)
-				fmt.Fprintf(os.Stderr, "===========================\n\n")
-			}
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
+		ur := updated.Raw()
+		if ur != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -538,30 +451,19 @@ var securityruleUpdateCmd = &cobra.Command{
 				{Header: "PORT", Width: 12},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				func() string {
-					if resp.Data.Metadata.Name != nil {
-						return *resp.Data.Metadata.Name
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.ID != nil {
-						return *resp.Data.Metadata.ID
-					}
-					return ""
-				}(),
-				string(resp.Data.Properties.Direction),
-				resp.Data.Properties.Protocol,
-				resp.Data.Properties.Port,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			updName := ""
+			if ur.Metadata.Name != nil {
+				updName = *ur.Metadata.Name
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			updID := ""
+			if ur.Metadata.ID != nil {
+				updID = *ur.Metadata.ID
+			}
+			updStatus := ""
+			if ur.Status.State != nil {
+				updStatus = *ur.Status.State
+			}
+			PrintOutput(ur, headers, [][]string{{updName, updID, string(ur.Properties.Direction), string(ur.Properties.Protocol), ur.Properties.Port, updStatus}})
 		} else {
 			fmt.Println(msgUpdatedAsync("Security rule", securityRuleID))
 		}
@@ -578,15 +480,7 @@ var securityruleDeleteCmd = &cobra.Command{
 		securityGroupID := args[1]
 		securityRuleID := args[2]
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("security rule", securityRuleID)
 			if err != nil {
@@ -595,6 +489,11 @@ var securityruleDeleteCmd = &cobra.Command{
 			if !ok {
 				return nil
 			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
@@ -607,21 +506,16 @@ var securityruleDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().SecurityGroupRules().Get(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
+			_, err = client.FromNetwork().SecurityGroupRules().Get(ctx, securityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
 			if err != nil {
-				return fmt.Errorf("dry-run: security rule not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: security rule not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("security rule", securityRuleID))
 			return nil
 		}
 
-		resp, err := client.FromNetwork().SecurityGroupRules().Delete(ctx, projectID, vpcID, securityGroupID, securityRuleID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting security rule: %w", err)
-		}
-
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
+		if err := client.FromNetwork().SecurityGroupRules().Delete(ctx, securityRuleRef(projectID, vpcID, securityGroupID, securityRuleID)); err != nil {
+			return fmt.Errorf("deleting security rule: %w", apiErrFromV2(err))
 		}
 
 		headers := []TableColumn{

--- a/cmd/network.securityrule_test.go
+++ b/cmd/network.securityrule_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,23 @@ import (
 func TestSecurityRuleListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSecurityGroupRulesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rule-001", "my-rule"
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
-					return &types.Response[types.SecurityRuleList]{
-						StatusCode: 200,
-						Data: &types.SecurityRuleList{
-							Values: []types.SecurityRuleResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					jsonResponse(200, types.SecurityRuleList{
+						Values: []types.SecurityRuleResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rule-001") {
@@ -41,26 +37,23 @@ func TestSecurityRuleListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
-					return &types.Response[types.SecurityRuleList]{StatusCode: 200, Data: &types.SecurityRuleList{}}, nil
-				}
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					jsonResponse(200, types.SecurityRuleList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rule-001", "my-rule"
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
-					return &types.Response[types.SecurityRuleList]{
-						StatusCode: 200,
-						Data: &types.SecurityRuleList{
-							Values: []types.SecurityRuleResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					jsonResponse(200, types.SecurityRuleList{
+						Values: []types.SecurityRuleResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +63,21 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
-					return &types.Response[types.SecurityRuleList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +85,11 @@ func TestSecurityRuleListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupRulesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +101,21 @@ func TestSecurityRuleListCmd(t *testing.T) {
 func TestSecurityRuleGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSecurityGroupRulesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
+			args: []string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rule-001", "my-rule"
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-					return &types.Response[types.SecurityRuleResponse]{
-						StatusCode: 200,
-						Data:       &types.SecurityRuleResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rule-001") {
@@ -138,24 +124,21 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-					return &types.Response[types.SecurityRuleResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +146,11 @@ func TestSecurityRuleGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupRulesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})),
-				[]string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -186,12 +168,12 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 		"--direction", "Ingress",
 		"--protocol", "TCP",
 		"--target-kind", "Ip",
-		"--target-value", "0.0.0.0/0",
+		"--target-value", "10.0.0.0/8",
 	}
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockSecurityGroupRulesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -199,14 +181,12 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: baseArgs,
-			setupMock: func(m *mockSecurityGroupRulesClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rule-new", "my-rule"
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.SecurityRuleRequest, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-					return &types.Response[types.SecurityRuleResponse]{
-						StatusCode: 200,
-						Data:       &types.SecurityRuleResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rule-new") {
@@ -227,26 +207,27 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 			errContains: "direction",
 		},
 		{
-			name: "SDK error propagates",
+			name:        "missing required flag --protocol",
+			args:        removeFlag(baseArgs, "--protocol", "TCP"),
+			wantErr:     true,
+			errContains: "protocol",
+		},
+		{
+			name: "server error propagates",
 			args: baseArgs,
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.SecurityRuleRequest, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-					return nil, fmt.Errorf("validation error")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "creating",
 		},
 		{
-			name: "API error propagates",
+			name: "API 404 propagates",
 			args: baseArgs,
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.SecurityRuleRequest, _ *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error) {
-					return &types.Response[types.SecurityRuleResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -254,11 +235,128 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupRulesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestSecurityRuleUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "securityrule", "update", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				region := types.Region("IT-BG")
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{
+							ID:               &id,
+							Name:             &name,
+							LocationResponse: &types.LocationResponse{Value: region},
+						},
+						Status: types.ResourceStatus{State: strPtr("Active")},
+					}))
+				updID, updName := "rule-001", "new-name"
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "rule-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no fields provided returns error",
+			args:        []string{"network", "securityrule", "update", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"},
+			setupSrv:    nil,
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "server error on update propagates",
+			args: []string{"network", "securityrule", "update", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				region := types.Region("IT-BG")
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{
+							ID:               &id,
+							Name:             &name,
+							LocationResponse: &types.LocationResponse{Value: region},
+						},
+						Status: types.ResourceStatus{State: strPtr("Active")},
+					}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+		{
+			name: "API 404 on get propagates",
+			args: []string{"network", "securityrule", "update", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "update falls back to VPC region when rule has no region",
+			args: []string{"network", "securityrule", "update", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				vpcID, vpcName := "vpc-001", "my-vpc"
+				region := types.Region("IT-BG")
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001",
+					jsonResponse(200, types.VPCResponse{
+						Metadata: types.ResourceMetadataResponse{
+							ID:               &vpcID,
+							Name:             &vpcName,
+							LocationResponse: &types.LocationResponse{Value: region},
+						},
+					}))
+				updID, updName := "rule-001", "new-name"
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
+					}))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -270,17 +368,18 @@ func TestSecurityRuleCreateCmd(t *testing.T) {
 func TestSecurityRuleDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSecurityGroupRulesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rule-001") {
@@ -289,12 +388,14 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name: "--dry-run registers only GET",
+			args: []string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					jsonResponse(200, types.SecurityRuleResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rule-001") {
@@ -303,24 +404,21 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockSecurityGroupRulesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securitygroups/sg-001/securityrules/rule-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -328,15 +426,11 @@ func TestSecurityRuleDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSecurityGroupRulesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "securityrule", "delete", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{securityGroupRules: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,17 @@ import (
 // splitRouteString splits a route string in format "destination:gateway"
 func splitRouteString(routeStr string) []string {
 	return strings.SplitN(routeStr, ":", 2)
+}
+
+func subnetRefURI(projectID, vpcID, subnetID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID + "/subnets/" + subnetID)
+}
+
+func subnetListPayload(l *aruba.List[*aruba.Subnet]) any {
+	if r, ok := l.Raw().(*types.Response[types.SubnetList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
 }
 
 // INIT
@@ -93,80 +105,44 @@ DHCP routes format: "destination:gateway" (e.g., "10.1.0.0/24:10.0.0.1").`,
 		ctx, cancel := newCtx()
 		defer cancel()
 
-		// Determine SubnetType: Advanced if CIDR is provided, Basic otherwise
-		var subnetType types.SubnetType = types.SubnetTypeBasic
+		s := aruba.NewSubnet().
+			IntoVPC(vpcRef(projectID, vpcID)).
+			Named(name).
+			InRegion(aruba.Region(region))
+		if len(tags) > 0 {
+			s.ReplaceTags(tags...)
+		}
+
 		if cidr != "" {
-			subnetType = types.SubnetTypeAdvanced
-			// For Advanced subnet type, DHCP enabled is required
 			if !dhcpEnabled {
 				return fmt.Errorf("--dhcp-enabled is required when creating an Advanced subnet (CIDR provided)")
 			}
-		}
+			s.OfType(aruba.SubnetTypeAdvanced).WithCIDR(cidr)
 
-		// Build DHCP configuration for Advanced subnet type
-		var dhcpConfig *types.SubnetDHCP
-		if subnetType == types.SubnetTypeAdvanced && dhcpEnabled {
-			dhcpConfig = &types.SubnetDHCP{
-				Enabled: dhcpEnabled,
-			}
-
-			// Parse DHCP routes if provided
-			if len(dhcpRoutes) > 0 {
-				var routes []types.SubnetDHCPRoute
-				for _, routeStr := range dhcpRoutes {
-					// Parse route in format "destination:gateway" (e.g., "0.0.0.0/0:10.0.0.1")
-					parts := splitRouteString(routeStr)
-					if len(parts) == 2 {
-						routes = append(routes, types.SubnetDHCPRoute{
-							Address: parts[0],
-							Gateway: parts[1],
-						})
-					} else {
-						fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
-					}
-				}
-				if len(routes) > 0 {
-					dhcpConfig.Routes = routes
+			d := aruba.NewSubnetDHCP().Enabled()
+			for _, routeStr := range dhcpRoutes {
+				parts := splitRouteString(routeStr)
+				if len(parts) == 2 {
+					d.AddRoute(parts[0], parts[1])
+				} else {
+					fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
 				}
 			}
-
-			// Set DNS servers if provided
-			if len(dhcpDNS) > 0 {
-				dhcpConfig.DNS = dhcpDNS
+			for _, ip := range dhcpDNS {
+				d.AddDNS(ip)
 			}
+			s.WithDHCP(d)
+		} else {
+			s.OfType(aruba.SubnetTypeBasic)
 		}
 
-		req := types.SubnetRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.SubnetPropertiesRequest{
-				Type: subnetType,
-				Network: func() *types.SubnetNetwork {
-					if cidr != "" {
-						return &types.SubnetNetwork{
-							Address: cidr,
-						}
-					}
-					return nil
-				}(),
-				DHCP: dhcpConfig,
-			},
-		}
-		resp, err := client.FromNetwork().Subnets().Create(ctx, projectID, vpcID, req, nil)
+		created, err := client.FromNetwork().Subnets().Create(ctx, s)
 		if err != nil {
-			return fmt.Errorf("creating subnet: %w", err)
+			return fmt.Errorf("creating subnet: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
+
+		r := created.Raw()
+		if r != nil && r.Metadata.ID != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -174,33 +150,22 @@ DHCP routes format: "destination:gateway" (e.g., "10.1.0.0/24:10.0.0.1").`,
 				{Header: "CIDR", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			// Get CIDR from response or use provided value
 			displayCIDR := cidr
-			if resp.Data.Properties.Network != nil && resp.Data.Properties.Network.Address != "" {
-				displayCIDR = resp.Data.Properties.Network.Address
+			if r.Properties.Network != nil && r.Properties.Network.Address != "" {
+				displayCIDR = r.Properties.Network.Address
 			}
 			if displayCIDR == "" {
 				displayCIDR = "N/A (Basic)"
 			}
-
 			createRegion := ""
-			if resp.Data.Metadata.LocationResponse != nil {
-				createRegion = resp.Data.Metadata.LocationResponse.Value
+			if r.Metadata.LocationResponse != nil {
+				createRegion = string(r.Metadata.LocationResponse.Value)
 			}
-			row := []string{
-				name,
-				*resp.Data.Metadata.ID,
-				createRegion,
-				displayCIDR,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					} else {
-						return ""
-					}
-				}(),
+			status := ""
+			if r.Status.State != nil {
+				status = *r.Status.State
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			PrintOutput(r, headers, [][]string{{name, *r.Metadata.ID, createRegion, displayCIDR, status}})
 		} else {
 			fmt.Println(msgCreatedAsync("Subnet", name))
 		}
@@ -225,15 +190,13 @@ var subnetGetCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().Subnets().Get(ctx, projectID, vpcID, subnetID, nil)
+		got, err := client.FromNetwork().Subnets().Get(ctx, subnetRefURI(projectID, vpcID, subnetID))
 		if err != nil {
-			return fmt.Errorf("getting subnet: %w", err)
+			return fmt.Errorf("getting subnet: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil {
-			subnet := resp.Data
+
+		subnet := got.Raw()
+		if subnet != nil {
 			fmt.Println("\nSubnet Details:")
 			fmt.Println("===============")
 			if subnet.Metadata.ID != nil {
@@ -254,7 +217,6 @@ var subnetGetCmd = &cobra.Command{
 			if subnet.Properties.Network != nil {
 				fmt.Printf("CIDR:            %s\n", subnet.Properties.Network.Address)
 			}
-			// Display DHCP information for Advanced subnets
 			if subnet.Properties.DHCP != nil {
 				fmt.Printf("DHCP Enabled:    %v\n", subnet.Properties.DHCP.Enabled)
 				if len(subnet.Properties.DHCP.Routes) > 0 {
@@ -304,14 +266,12 @@ var subnetListCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().Subnets().List(ctx, projectID, vpcID, listParams(cmd))
+		list, err := client.FromNetwork().Subnets().List(ctx, vpcRef(projectID, vpcID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing subnets: %w", err)
+			return fmt.Errorf("listing subnets: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -320,30 +280,27 @@ var subnetListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 			var rows [][]string
-			for _, subnet := range resp.Data.Values {
-				name := ""
-				if subnet.Metadata.Name != nil {
-					name = *subnet.Metadata.Name
-				}
-				id := ""
-				if subnet.Metadata.ID != nil {
-					id = *subnet.Metadata.ID
-				}
+			for _, subnet := range list.Items() {
+				r := subnet.Raw()
+				name := subnet.Name()
+				id := subnet.SubnetID()
 				region := ""
-				if subnet.Metadata.LocationResponse != nil {
-					region = subnet.Metadata.LocationResponse.Value
-				}
 				cidr := ""
-				if subnet.Properties.Network != nil {
-					cidr = subnet.Properties.Network.Address
-				}
 				status := ""
-				if subnet.Status.State != nil {
-					status = *subnet.Status.State
+				if r != nil {
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					if r.Properties.Network != nil {
+						cidr = r.Properties.Network.Address
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 				rows = append(rows, []string{name, id, region, cidr, status})
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(subnetListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No subnets found.")
 		}
@@ -375,154 +332,111 @@ var subnetUpdateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
-		// Enable debug logging if supported
-		if logger, ok := interface{}(client).(interface{ SetDebug(bool) }); ok {
-			logger.SetDebug(true)
-		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		// Fetch current subnet details
-		getResp, err := client.FromNetwork().Subnets().Get(ctx, projectID, vpcID, subnetID, nil)
-		if err != nil || getResp == nil || getResp.Data == nil {
-			return fmt.Errorf("fetching current subnet: %w", err)
+
+		cur, err := client.FromNetwork().Subnets().Get(ctx, subnetRefURI(projectID, vpcID, subnetID))
+		if err != nil {
+			return fmt.Errorf("fetching current subnet: %w", apiErrFromV2(err))
 		}
-		current := getResp.Data
-		// Block update if subnet is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == StateInCreation {
+		r := cur.Raw()
+		if r == nil {
+			return fmt.Errorf("subnet not found")
+		}
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update subnet while it is in 'InCreation' state. Please wait until the subnet is fully created")
 		}
-
-		// Get region value
-		regionValue := ""
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
+		if cur.Region() == "" {
 			return fmt.Errorf("unable to determine region value for subnet")
 		}
 
-		// Determine if this is an Advanced subnet
-		isAdvanced := current.Properties.Type == types.SubnetTypeAdvanced
+		if name != "" {
+			cur.Named(name)
+		}
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
+		}
+		if cidr != "" {
+			cur.WithCIDR(cidr)
+		}
 
-		// Build DHCP configuration for Advanced subnet type
-		var dhcpConfig *types.SubnetDHCP
-		if isAdvanced {
-			// Start with current DHCP config if it exists
-			if current.Properties.DHCP != nil {
-				dhcpConfig = &types.SubnetDHCP{
-					Enabled: current.Properties.DHCP.Enabled,
-					Routes:  current.Properties.DHCP.Routes,
-					DNS:     current.Properties.DHCP.DNS,
+		// Rebuild DHCP for Advanced subnets when DHCP flags are touched
+		if r.Properties.Type == types.SubnetTypeAdvanced {
+			if cmd.Flags().Changed("dhcp-enabled") || len(dhcpRoutes) > 0 || len(dhcpDNS) > 0 {
+				d := aruba.NewSubnetDHCP()
+				if r.Properties.DHCP != nil && r.Properties.DHCP.Enabled {
+					d.Enabled()
 				}
-			} else {
-				dhcpConfig = &types.SubnetDHCP{}
-			}
-
-			// Update DHCP enabled if flag is provided
-			if cmd.Flags().Changed("dhcp-enabled") {
-				dhcpConfig.Enabled = dhcpEnabled
-			}
-
-			// Update DHCP routes if provided
-			if len(dhcpRoutes) > 0 {
-				var routes []types.SubnetDHCPRoute
-				for _, routeStr := range dhcpRoutes {
-					parts := splitRouteString(routeStr)
-					if len(parts) == 2 {
-						routes = append(routes, types.SubnetDHCPRoute{
-							Address: parts[0],
-							Gateway: parts[1],
-						})
-					} else {
-						fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
+				if cmd.Flags().Changed("dhcp-enabled") && dhcpEnabled {
+					d.Enabled()
+				}
+				existingRoutes := []aruba.SubnetDHCPRoute{}
+				if r.Properties.DHCP != nil {
+					for _, rt := range r.Properties.DHCP.Routes {
+						existingRoutes = append(existingRoutes, aruba.SubnetDHCPRoute{Address: rt.Address, Gateway: rt.Gateway})
 					}
 				}
-				if len(routes) > 0 {
-					dhcpConfig.Routes = routes
+				if len(dhcpRoutes) > 0 {
+					for _, routeStr := range dhcpRoutes {
+						parts := splitRouteString(routeStr)
+						if len(parts) == 2 {
+							d.AddRoute(parts[0], parts[1])
+						} else {
+							fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
+						}
+					}
+				} else {
+					for _, rt := range existingRoutes {
+						d.AddRoute(rt.Address, rt.Gateway)
+					}
 				}
-			}
-
-			// Update DNS servers if provided
-			if len(dhcpDNS) > 0 {
-				dhcpConfig.DNS = dhcpDNS
+				existingDNS := []string{}
+				if r.Properties.DHCP != nil {
+					existingDNS = r.Properties.DHCP.DNS
+				}
+				if len(dhcpDNS) > 0 {
+					for _, ip := range dhcpDNS {
+						d.AddDNS(ip)
+					}
+				} else {
+					for _, ip := range existingDNS {
+						d.AddDNS(ip)
+					}
+				}
+				cur.WithDHCP(d)
 			}
 		}
 
-		// Build update request by merging user input with all current valid fields
-		req := types.SubnetRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: func() string {
-						if name != "" {
-							return name
-						}
-						if current.Metadata.Name != nil {
-							return *current.Metadata.Name
-						}
-						return ""
-					}(),
-					Tags: func() []string {
-						if cmd.Flags().Changed("tags") {
-							return tags
-						}
-						if current.Metadata.Tags != nil {
-							return current.Metadata.Tags
-						}
-						return []string{}
-					}(),
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.SubnetPropertiesRequest{
-				Type: current.Properties.Type,
-				Network: &types.SubnetNetwork{
-					Address: func() string {
-						if cidr != "" {
-							return cidr
-						}
-						if current.Properties.Network != nil {
-							return current.Properties.Network.Address
-						}
-						return ""
-					}(),
-				},
-				DHCP: dhcpConfig,
-			},
-		}
-
-		resp, err := client.FromNetwork().Subnets().Update(ctx, projectID, vpcID, subnetID, req, nil)
+		updated, err := client.FromNetwork().Subnets().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating subnet: %w", err)
+			return fmt.Errorf("updating subnet: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil {
+
+		ur := updated.Raw()
+		if ur != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
 				{Header: "CIDR", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			name := ""
-			if resp.Data.Metadata.Name != nil {
-				name = *resp.Data.Metadata.Name
+			updName := ""
+			if ur.Metadata.Name != nil {
+				updName = *ur.Metadata.Name
 			}
-			id := ""
-			if resp.Data.Metadata.ID != nil {
-				id = *resp.Data.Metadata.ID
+			updID := ""
+			if ur.Metadata.ID != nil {
+				updID = *ur.Metadata.ID
 			}
-			cidr := ""
-			if resp.Data.Properties.Network != nil {
-				cidr = resp.Data.Properties.Network.Address
+			updCIDR := ""
+			if ur.Properties.Network != nil {
+				updCIDR = ur.Properties.Network.Address
 			}
-			status := ""
-			if resp.Data.Status.State != nil {
-				status = *resp.Data.Status.State
+			updStatus := ""
+			if ur.Status.State != nil {
+				updStatus = *ur.Status.State
 			}
-			PrintOutput(resp.Data, headers, [][]string{{name, id, cidr, status}})
+			PrintOutput(ur, headers, [][]string{{updName, updID, updCIDR, updStatus}})
 		} else {
 			fmt.Println(msgUpdatedAsync("Subnet", subnetID))
 		}
@@ -538,10 +452,7 @@ var subnetDeleteCmd = &cobra.Command{
 		vpcID := args[0]
 		subnetID := args[1]
 
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("subnet", subnetID)
 			if err != nil {
@@ -565,21 +476,18 @@ var subnetDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().Subnets().Get(ctx, projectID, vpcID, subnetID, nil)
+			_, err = client.FromNetwork().Subnets().Get(ctx, subnetRefURI(projectID, vpcID, subnetID))
 			if err != nil {
-				return fmt.Errorf("dry-run: subnet not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: subnet not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("subnet", subnetID))
 			return nil
 		}
 
-		resp, err := client.FromNetwork().Subnets().Delete(ctx, projectID, vpcID, subnetID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting subnet: %w", err)
+		if err := client.FromNetwork().Subnets().Delete(ctx, subnetRefURI(projectID, vpcID, subnetID)); err != nil {
+			return fmt.Errorf("deleting subnet: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
+
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},
 			{Header: "STATUS", Width: 15},

--- a/cmd/network.subnet_test.go
+++ b/cmd/network.subnet_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,22 @@ import (
 func TestSubnetListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSubnetsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockSubnetsClient) {
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sub-001", "my-subnet"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
-					return &types.Response[types.SubnetList]{
-						StatusCode: 200,
-						Data: &types.SubnetList{
-							Values: []types.SubnetResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{
+					Values: []types.SubnetResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sub-001") {
@@ -41,26 +36,21 @@ func TestSubnetListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockSubnetsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
-					return &types.Response[types.SubnetList]{StatusCode: 200, Data: &types.SubnetList{}}, nil
-				}
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockSubnetsClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sub-001", "my-subnet"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
-					return &types.Response[types.SubnetList]{
-						StatusCode: 200,
-						Data: &types.SubnetList{
-							Values: []types.SubnetResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{
+					Values: []types.SubnetResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +60,19 @@ func TestSubnetListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSubnetsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSubnetsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetList], error) {
-					return &types.Response[types.SubnetList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +80,11 @@ func TestSubnetListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSubnetsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestSubnetListCmd(t *testing.T) {
 func TestSubnetGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSubnetsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockSubnetsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sub-001", "my-subnet"
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-					return &types.Response[types.SubnetResponse]{
-						StatusCode: 200,
-						Data:       &types.SubnetResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sub-001") {
@@ -138,24 +116,17 @@ func TestSubnetGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSubnetsClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSubnetsClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-					return &types.Response[types.SubnetResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +134,11 @@ func TestSubnetGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSubnetsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})),
-				[]string{"network", "subnet", "get", "vpc-001", "sub-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"network", "subnet", "get", "vpc-001", "sub-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -181,7 +151,7 @@ func TestSubnetCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockSubnetsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -189,17 +159,14 @@ func TestSubnetCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"network", "subnet", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-subnet", "--region", "IT-BG"},
-			setupMock: func(m *mockSubnetsClient) {
-				id, name := "sub-new", "my-subnet"
-				m.createFn = func(_ context.Context, _, _ string, _ types.SubnetRequest, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-					return &types.Response[types.SubnetResponse]{
-						StatusCode: 200,
-						Data:       &types.SubnetResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "sub-new") {
+				if !strings.Contains(out, "sub-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
@@ -217,12 +184,10 @@ func TestSubnetCreateCmd(t *testing.T) {
 			errContains: "region",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"network", "subnet", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-subnet", "--region", "IT-BG"},
-			setupMock: func(m *mockSubnetsClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.SubnetRequest, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -230,13 +195,8 @@ func TestSubnetCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"network", "subnet", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-subnet", "--region", "IT-BG"},
-			setupMock: func(m *mockSubnetsClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.SubnetRequest, _ *types.RequestParameters) (*types.Response[types.SubnetResponse], error) {
-					return &types.Response[types.SubnetResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -244,11 +204,86 @@ func TestSubnetCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSubnetsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestSubnetUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "subnet", "update", "vpc-001", "sub-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "sub-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no flags error",
+			args:        []string{"network", "subnet", "update", "vpc-001", "sub-001", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "pre-Get server error",
+			args: []string{"network", "subnet", "update", "vpc-001", "sub-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "update server error",
+			args: []string{"network", "subnet", "update", "vpc-001", "sub-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -260,17 +295,17 @@ func TestSubnetCreateCmd(t *testing.T) {
 func TestSubnetDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSubnetsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockSubnetsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sub-001") {
@@ -280,11 +315,12 @@ func TestSubnetDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockSubnetsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			args: []string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "sub-001") {
@@ -293,24 +329,19 @@ func TestSubnetDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSubnetsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSubnetsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -318,15 +349,11 @@ func TestSubnetDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSubnetsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "subnet", "delete", "vpc-001", "sub-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{subnetsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -43,11 +44,22 @@ func init() {
 	vpcDeleteCmd.ValidArgsFunction = completeVPCID
 }
 
+// vpcRef builds the combined project+VPC Ref used by Get/Delete/Update; also
+// used as the parent Ref for VPC-scoped resources (subnet, securitygroup, vpcpeering).
+func vpcRef(projectID, vpcID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID)
+}
+
+func vpcListPayload(l *aruba.List[*aruba.VPC]) any {
+	if r, ok := l.Raw().(*types.Response[types.VPCList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
 // Completion functions for network resources
 
 func completeVPCID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -59,20 +71,21 @@ func completeVPCID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	}
 
 	ctx := context.Background()
-	response, err := client.FromNetwork().VPCs().List(ctx, projectID, nil)
+	list, err := client.FromNetwork().VPCs().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, vpc := range response.Data.Values {
-			if vpc.Metadata.ID != nil && vpc.Metadata.Name != nil {
-				id := *vpc.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *vpc.Metadata.Name))
-				}
+	if list != nil {
+		for _, vpc := range list.Items() {
+			id := vpc.VPCID()
+			name := vpc.Name()
+			if id == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
@@ -98,67 +111,49 @@ network resources are created within a VPC.`,
   acloud network vpc create --name prod-vpc --region IT-BG --tags env=prod,team=infra`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request (default and preset are always false)
-		setDefault := false
-		setPreset := false
-		createRequest := types.VPCRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.VPCPropertiesRequest{
-				Properties: &types.VPCProperties{
-					Default: &setDefault,
-					Preset:  &setPreset,
-				},
-			},
+		vpc := aruba.NewVPC().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			NotDefault().
+			WithPreset(false)
+		if len(tags) > 0 {
+			vpc.ReplaceTags(tags...)
 		}
 
-		// Create the VPC using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().VPCs().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromNetwork().VPCs().Create(ctx, vpc)
 		if err != nil {
-			return fmt.Errorf("creating VPC: %w", err)
+			return fmt.Errorf("creating VPC: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		r := created.Raw()
+		if r != nil {
 			fmt.Printf("\n%s\n", msgCreated("VPC", name))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *response.Data.Metadata.ID)
+			if r.Metadata.ID != nil {
+				fmt.Printf("ID:      %s\n", *r.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *response.Data.Metadata.Name)
+			if r.Metadata.Name != nil {
+				fmt.Printf("Name:    %s\n", *r.Metadata.Name)
 			}
-			fmt.Printf("Default: %t\n", response.Data.Properties.Default)
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", response.Data.Metadata.Tags)
+			fmt.Printf("Default: %t\n", r.Properties.Default)
+			if len(r.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:    %v\n", r.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("VPC", name))
@@ -174,34 +169,25 @@ var vpcGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get VPC details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
+		got, err := client.FromNetwork().VPCs().Get(ctx, vpcRef(projectID, vpcID))
 		if err != nil {
-			return fmt.Errorf("getting VPC details: %w", err)
+			return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
-			vpc := response.Data
-
-			// Display VPC details
+		vpc := got.Raw()
+		if vpc != nil {
 			fmt.Println("\nVPC Details:")
 			fmt.Println("============")
 
@@ -250,95 +236,66 @@ var vpcUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one update flag must be provided
 		if name == "" && len(tags) == 0 {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current VPC to preserve existing properties
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
+		cur, err := client.FromNetwork().VPCs().Get(ctx, vpcRef(projectID, vpcID))
 		if err != nil {
-			return fmt.Errorf("getting VPC details: %w", err)
+			return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
+		r := cur.Raw()
+		if r == nil {
 			return fmt.Errorf("VPC not found")
 		}
 
-		// Check if VPC is in InCreation state
-		if getResponse.Data.Status.State != nil && *getResponse.Data.Status.State == StateInCreation {
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update VPC while it is in 'InCreation' state. Please wait until the VPC is fully created")
 		}
 
-		// Get region value
-		regionValue := ""
-		if getResponse.Data.Metadata.LocationResponse != nil {
-			regionValue = getResponse.Data.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
+		if cur.Region() == "" {
 			return fmt.Errorf("unable to determine region value for VPC")
 		}
 
-		// Build the update request, preserving existing values
-		updateRequest := types.VPCRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *getResponse.Data.Metadata.Name,
-					Tags: getResponse.Data.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.VPCPropertiesRequest{
-				Properties: &types.VPCProperties{
-					Default: &getResponse.Data.Properties.Default,
-				},
-			},
-		}
-
-		// Apply updates
 		if name != "" {
-			updateRequest.Metadata.Name = name
+			cur.Named(name)
 		}
-		if len(tags) > 0 {
-			updateRequest.Metadata.Tags = tags
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
 		}
 
-		// Update the VPC using the SDK
-		response, err := client.FromNetwork().VPCs().Update(ctx, projectID, vpcID, updateRequest, nil)
+		updated, err := client.FromNetwork().VPCs().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating VPC: %w", err)
+			return fmt.Errorf("updating VPC: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
+		ur := updated.Raw()
+		if ur != nil {
 			fmt.Printf("\n%s\n", msgUpdated("VPC", vpcID))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *response.Data.Metadata.ID)
+			if ur.Metadata.ID != nil {
+				fmt.Printf("ID:      %s\n", *ur.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *response.Data.Metadata.Name)
+			if ur.Metadata.Name != nil {
+				fmt.Printf("Name:    %s\n", *ur.Metadata.Name)
 			}
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", response.Data.Metadata.Tags)
+			if len(ur.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:    %v\n", ur.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("VPC", vpcID))
@@ -354,10 +311,8 @@ var vpcDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpcID := args[0]
 
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("VPC", vpcID)
 			if err != nil {
@@ -368,13 +323,11 @@ var vpcDeleteCmd = &cobra.Command{
 			}
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -385,21 +338,16 @@ var vpcDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
+			_, err = client.FromNetwork().VPCs().Get(ctx, vpcRef(projectID, vpcID))
 			if err != nil {
-				return fmt.Errorf("dry-run: VPC not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: VPC not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("VPC", vpcID))
 			return nil
 		}
 
-		// Delete the VPC using the SDK
-		deleteResp, err := client.FromNetwork().VPCs().Delete(ctx, projectID, vpcID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting VPC: %w", err)
-		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+		if err := client.FromNetwork().VPCs().Delete(ctx, vpcRef(projectID, vpcID)); err != nil {
+			return fmt.Errorf("deleting VPC: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("VPC", vpcID))
@@ -412,31 +360,24 @@ var vpcListCmd = &cobra.Command{
 	Short: "List all VPCs",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get projectID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// List VPCs using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().VPCs().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromNetwork().VPCs().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing VPCs: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing VPCs: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
-			// Define table columns
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 40},
 				{Header: "ID", Width: 25},
@@ -445,36 +386,29 @@ var vpcListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 
-			// Build rows
 			var rows [][]string
-			for _, vpc := range response.Data.Values {
-				name := ""
-				if vpc.Metadata.Name != nil && *vpc.Metadata.Name != "" {
-					name = *vpc.Metadata.Name
-				}
-
-				id := ""
-				if vpc.Metadata.ID != nil {
-					id = *vpc.Metadata.ID
-				}
+			for _, vpc := range list.Items() {
+				r := vpc.Raw()
+				name := vpc.Name()
+				id := vpc.VPCID()
 
 				region := ""
-				if vpc.Metadata.LocationResponse != nil {
-					region = vpc.Metadata.LocationResponse.Value
-				}
-
-				subnets := fmt.Sprintf("%d", len(vpc.Properties.LinkedResources))
-
+				subnets := "0"
 				status := ""
-				if vpc.Status.State != nil {
-					status = *vpc.Status.State
+				if r != nil {
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					subnets = fmt.Sprintf("%d", len(r.Properties.LinkedResources))
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 
 				rows = append(rows, []string{name, id, region, subnets, status})
 			}
 
-			// Print the table
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(vpcListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No VPCs found")
 		}

--- a/cmd/network.vpc_test.go
+++ b/cmd/network.vpc_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -11,29 +9,24 @@ import (
 )
 
 func TestVPCListCmd(t *testing.T) {
-	vpcID := "vpc-001"
-	vpcName := "my-vpc"
-
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockVPCsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
-					return &types.Response[types.VPCList]{
-						StatusCode: 200,
-						Data: &types.VPCList{
-							Values: []types.VPCResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
-							},
-						},
-					}, nil
-				}
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+					Values: []types.VPCResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vpc-001") {
@@ -42,26 +35,22 @@ func TestVPCListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "success with no results",
-			setupMock: func(m *mockVPCsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
-					return &types.Response[types.VPCList]{StatusCode: 200, Data: &types.VPCList{}}, nil
-				}
+			name: "success empty",
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockVPCsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
-					return &types.Response[types.VPCList]{
-						StatusCode: 200,
-						Data: &types.VPCList{
-							Values: []types.VPCResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
-							},
-						},
-					}, nil
-				}
+			name: "--output json emits valid JSON",
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+					Values: []types.VPCResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -71,51 +60,32 @@ func TestVPCListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
-			errContains: "listing VPCs",
+			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockVPCsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPCList], error) {
-					return &types.Response[types.VPCList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpc", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetwork(m)), args)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
-				}
-			} else if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
 			}
@@ -124,25 +94,20 @@ func TestVPCListCmd(t *testing.T) {
 }
 
 func TestVPCGetCmd(t *testing.T) {
-	vpcID := "vpc-001"
-	vpcName := "my-vpc"
-
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockVPCsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return &types.Response[types.VPCResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCResponse{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vpc-001") {
@@ -151,55 +116,30 @@ func TestVPCGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
-			errContains: "getting VPC details",
+			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockVPCsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return &types.Response[types.VPCResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
-		{
-			name: "nil data — not found message",
-			setupMock: func(m *mockVPCsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return &types.Response[types.VPCResponse]{StatusCode: 200}, nil
-				}
-			},
-		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetwork(m)), []string{"network", "vpc", "get", "vpc-001", "--project-id", "proj-123"})
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
-				}
-			} else if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			out, err := runCmdCapture(srv.Client(), []string{"network", "vpc", "get", "vpc-001", "--project-id", "proj-123"})
+			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
 			}
@@ -208,13 +148,10 @@ func TestVPCGetCmd(t *testing.T) {
 }
 
 func TestVPCCreateCmd(t *testing.T) {
-	vpcID := "vpc-new"
-	vpcName := "new-vpc"
-
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVPCsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -222,16 +159,14 @@ func TestVPCCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"network", "vpc", "create", "--project-id", "proj-123", "--name", "new-vpc", "--region", "IT-BG"},
-			setupMock: func(m *mockVPCsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.VPCRequest, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return &types.Response[types.VPCResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCResponse{Metadata: types.ResourceMetadataResponse{ID: &vpcID, Name: &vpcName}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "new-vpc"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "vpc-new") {
+				if !strings.Contains(out, "vpc-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
@@ -249,49 +184,107 @@ func TestVPCCreateCmd(t *testing.T) {
 			errContains: "region",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"network", "vpc", "create", "--project-id", "proj-123", "--name", "new-vpc", "--region", "IT-BG"},
-			setupMock: func(m *mockVPCsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.VPCRequest, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
-			errContains: "creating VPC",
+			errContains: "creating",
 		},
 		{
 			name: "API error propagates",
 			args: []string{"network", "vpc", "create", "--project-id", "proj-123", "--name", "new-vpc", "--region", "IT-BG"},
-			setupMock: func(m *mockVPCsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.VPCRequest, _ *types.RequestParameters) (*types.Response[types.VPCResponse], error) {
-					return &types.Response[types.VPCResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetwork(m)), tc.args)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
-				}
-			} else if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
 			}
+		})
+	}
+}
+
+func TestVPCUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "vpc", "update", "vpc-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpc-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no flags error",
+			args:        []string{"network", "vpc", "update", "vpc-001", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "pre-Get server error",
+			args: []string{"network", "vpc", "update", "vpc-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "update server error",
+			args: []string{"network", "vpc", "update", "vpc-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				state := "Active"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Status:   types.ResourceStatus{State: &state},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
 			}
@@ -302,17 +295,17 @@ func TestVPCCreateCmd(t *testing.T) {
 func TestVPCDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
-			name: "success with --yes flag",
-			setupMock: func(m *mockVPCsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			name: "success with --yes",
+			args: []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vpc-001") {
@@ -322,11 +315,12 @@ func TestVPCDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockVPCsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			args: []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vpc-001") {
@@ -335,52 +329,32 @@ func TestVPCDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
-			errContains: "deleting VPC",
+			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockVPCsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			// --yes skips the interactive confirmation prompt
-			args := []string{"network", "vpc", "delete", "vpc-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetwork(m)), args)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
-				}
-			} else if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
 			}

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -3,9 +3,22 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+// vpcPeeringRef is shared with vpcpeeringroute.go.
+func vpcPeeringRef(projectID, vpcID, peeringID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID + "/vpcPeerings/" + peeringID)
+}
+
+func vpcPeeringListPayload(l *aruba.List[*aruba.VPCPeering]) any {
+	if r, ok := l.Raw().(*types.Response[types.VPCPeeringList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
 
 func init() {
 	// Peering
@@ -76,26 +89,23 @@ peering is established.`,
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		req := types.VPCPeeringRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{Value: region},
-			},
-			Properties: types.VPCPeeringPropertiesRequest{
-				RemoteVPC: &types.ReferenceResource{URI: peerVPCID},
-			},
+
+		peering := aruba.NewVPCPeering().
+			IntoVPC(vpcRef(projectID, vpcID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			WithRemoteVPC(aruba.URI(peerVPCID))
+		if len(tags) > 0 {
+			peering.ReplaceTags(tags...)
 		}
-		resp, err := client.FromNetwork().VPCPeerings().Create(ctx, projectID, vpcID, req, nil)
+
+		created, err := client.FromNetwork().VPCPeerings().Create(ctx, peering)
 		if err != nil {
-			return fmt.Errorf("creating VPC peering: %w", err)
+			return fmt.Errorf("creating VPC peering: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
+
+		r := created.Raw()
+		if r != nil && r.Metadata.ID != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -103,30 +113,19 @@ peering is established.`,
 				{Header: "REGION", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				name,
-				*resp.Data.Metadata.ID,
-				func() string {
-					if resp.Data.Properties.RemoteVPC != nil {
-						return resp.Data.Properties.RemoteVPC.URI
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.LocationResponse != nil {
-						return resp.Data.Metadata.LocationResponse.Value
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					} else {
-						return ""
-					}
-				}(),
+			peerVPC := ""
+			if r.Properties.RemoteVPC != nil {
+				peerVPC = r.Properties.RemoteVPC.URI
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			regionVal := ""
+			if r.Metadata.LocationResponse != nil {
+				regionVal = string(r.Metadata.LocationResponse.Value)
+			}
+			status := ""
+			if r.Status.State != nil {
+				status = *r.Status.State
+			}
+			PrintOutput(r, headers, [][]string{{name, *r.Metadata.ID, peerVPC, regionVal, status}})
 		} else {
 			fmt.Println(msgCreatedAsync("VPC peering", name))
 		}
@@ -151,15 +150,13 @@ var vpcpeeringGetCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
+		got, err := client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(projectID, vpcID, peeringID))
 		if err != nil {
-			return fmt.Errorf("getting VPC peering: %w", err)
+			return fmt.Errorf("getting VPC peering: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil {
-			peering := resp.Data
+
+		peering := got.Raw()
+		if peering != nil {
 			fmt.Println("\nVPC Peering Details:")
 			fmt.Println("====================")
 			if peering.Metadata.ID != nil {
@@ -172,9 +169,7 @@ var vpcpeeringGetCmd = &cobra.Command{
 				fmt.Printf("Peer VPC:        %s\n", peering.Properties.RemoteVPC.URI)
 			}
 			if peering.Metadata.LocationResponse != nil {
-				if peering.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", peering.Metadata.LocationResponse.Value)
-				}
+				fmt.Printf("Region:          %s\n", peering.Metadata.LocationResponse.Value)
 			}
 			if peering.Metadata.CreationDate != nil {
 				fmt.Printf("Creation Date:   %s\n", peering.Metadata.CreationDate.Format(DateLayout))
@@ -213,14 +208,12 @@ var vpcpeeringListCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPCPeerings().List(ctx, projectID, vpcID, listParams(cmd))
+		list, err := client.FromNetwork().VPCPeerings().List(ctx, vpcRef(projectID, vpcID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing VPC peerings: %w", err)
+			return fmt.Errorf("listing VPC peerings: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -229,30 +222,27 @@ var vpcpeeringListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 			var rows [][]string
-			for _, peering := range resp.Data.Values {
-				name := ""
-				if peering.Metadata.Name != nil {
-					name = *peering.Metadata.Name
-				}
-				id := ""
-				if peering.Metadata.ID != nil {
-					id = *peering.Metadata.ID
-				}
+			for _, p := range list.Items() {
+				r := p.Raw()
+				name := p.Name()
+				id := p.VPCPeeringID()
 				peerVPC := ""
-				if peering.Properties.RemoteVPC != nil {
-					peerVPC = peering.Properties.RemoteVPC.URI
-				}
 				region := ""
-				if peering.Metadata.LocationResponse != nil {
-					region = peering.Metadata.LocationResponse.Value
-				}
 				status := ""
-				if peering.Status.State != nil {
-					status = *peering.Status.State
+				if r != nil {
+					if r.Properties.RemoteVPC != nil {
+						peerVPC = r.Properties.RemoteVPC.URI
+					}
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 				rows = append(rows, []string{name, id, peerVPC, region, status})
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(vpcPeeringListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No VPC peerings found.")
 		}
@@ -282,60 +272,33 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 		}
 		ctx, cancel := newCtx()
 		defer cancel()
-		// Fetch current peering details
-		getResp, err := client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-		if err != nil || getResp == nil || getResp.Data == nil {
-			return fmt.Errorf("fetching current VPC peering: %w", err)
+
+		cur, err := client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(projectID, vpcID, peeringID))
+		if err != nil {
+			return fmt.Errorf("fetching current VPC peering: %w", apiErrFromV2(err))
 		}
-		current := getResp.Data
-		// Block update if peering is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == StateInCreation {
+		r := cur.Raw()
+		if r == nil {
+			return fmt.Errorf("VPC peering not found")
+		}
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update VPC peering while it is in 'InCreation' state. Please wait until the VPC peering is fully created")
 		}
-		// Build update request by merging user input with all current valid fields
-		req := types.VPCPeeringRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: func() string {
-						if name != "" {
-							return name
-						}
-						if current.Metadata.Name != nil {
-							return *current.Metadata.Name
-						}
-						return ""
-					}(),
-					Tags: func() []string {
-						if cmd.Flags().Changed("tags") {
-							return tags
-						}
-						if current.Metadata.Tags != nil {
-							return current.Metadata.Tags
-						}
-						return []string{}
-					}(),
-				},
-				Location: types.LocationRequest{
-					Value: func() string {
-						if current.Metadata.LocationResponse != nil {
-							return current.Metadata.LocationResponse.Value
-						}
-						return ""
-					}(),
-				},
-			},
-			Properties: types.VPCPeeringPropertiesRequest{
-				RemoteVPC: current.Properties.RemoteVPC,
-			},
+
+		if name != "" {
+			cur.Named(name)
 		}
-		resp, err := client.FromNetwork().VPCPeerings().Update(ctx, projectID, vpcID, peeringID, req, nil)
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
+		}
+
+		updated, err := client.FromNetwork().VPCPeerings().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating VPC peering: %w", err)
+			return fmt.Errorf("updating VPC peering: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-		if resp != nil && resp.Data != nil {
+
+		ur := updated.Raw()
+		if ur != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -343,39 +306,27 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 				{Header: "REGION", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				func() string {
-					if resp.Data.Metadata.Name != nil {
-						return *resp.Data.Metadata.Name
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.ID != nil {
-						return *resp.Data.Metadata.ID
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Properties.RemoteVPC != nil {
-						return resp.Data.Properties.RemoteVPC.URI
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.LocationResponse != nil {
-						return resp.Data.Metadata.LocationResponse.Value
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			updName := ""
+			if ur.Metadata.Name != nil {
+				updName = *ur.Metadata.Name
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			updID := ""
+			if ur.Metadata.ID != nil {
+				updID = *ur.Metadata.ID
+			}
+			peerVPC := ""
+			if ur.Properties.RemoteVPC != nil {
+				peerVPC = ur.Properties.RemoteVPC.URI
+			}
+			regionVal := ""
+			if ur.Metadata.LocationResponse != nil {
+				regionVal = string(ur.Metadata.LocationResponse.Value)
+			}
+			updStatus := ""
+			if ur.Status.State != nil {
+				updStatus = *ur.Status.State
+			}
+			PrintOutput(ur, headers, [][]string{{updName, updID, peerVPC, regionVal, updStatus}})
 		} else {
 			fmt.Println(msgUpdatedAsync("VPC peering", peeringID))
 		}
@@ -391,10 +342,7 @@ var vpcpeeringDeleteCmd = &cobra.Command{
 		vpcID := args[0]
 		peeringID := args[1]
 
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("VPC peering", peeringID)
 			if err != nil {
@@ -418,21 +366,18 @@ var vpcpeeringDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
+			_, err = client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(projectID, vpcID, peeringID))
 			if err != nil {
-				return fmt.Errorf("dry-run: VPC peering not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: VPC peering not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("VPC peering", peeringID))
 			return nil
 		}
 
-		resp, err := client.FromNetwork().VPCPeerings().Delete(ctx, projectID, vpcID, peeringID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting VPC peering: %w", err)
+		if err := client.FromNetwork().VPCPeerings().Delete(ctx, vpcPeeringRef(projectID, vpcID, peeringID)); err != nil {
+			return fmt.Errorf("deleting VPC peering: %w", apiErrFromV2(err))
 		}
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
+
 		headers := []TableColumn{
 			{Header: "ID", Width: 26},
 			{Header: "STATUS", Width: 15},

--- a/cmd/network.vpcpeering_test.go
+++ b/cmd/network.vpcpeering_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,23 @@ import (
 func TestVPCPeeringListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCPeeringsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockVPCPeeringsClient) {
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "peer-001", "my-peering"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
-					return &types.Response[types.VPCPeeringList]{
-						StatusCode: 200,
-						Data: &types.VPCPeeringList{
-							Values: []types.VPCPeeringResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringList{
+						Values: []types.VPCPeeringResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "peer-001") {
@@ -41,26 +37,23 @@ func TestVPCPeeringListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
-					return &types.Response[types.VPCPeeringList]{StatusCode: 200, Data: &types.VPCPeeringList{}}, nil
-				}
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockVPCPeeringsClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "peer-001", "my-peering"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
-					return &types.Response[types.VPCPeeringList]{
-						StatusCode: 200,
-						Data: &types.VPCPeeringList{
-							Values: []types.VPCPeeringResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringList{
+						Values: []types.VPCPeeringResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +63,21 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
-					return &types.Response[types.VPCPeeringList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +85,11 @@ func TestVPCPeeringListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +101,21 @@ func TestVPCPeeringListCmd(t *testing.T) {
 func TestVPCPeeringGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCPeeringsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockVPCPeeringsClient) {
+			args: []string{"network", "vpcpeering", "get", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "peer-001", "my-peering"
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-					return &types.Response[types.VPCPeeringResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					jsonResponse(200, types.VPCPeeringResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "peer-001") {
@@ -138,24 +124,21 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpcpeering", "get", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-					return &types.Response[types.VPCPeeringResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpcpeering", "get", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +146,11 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})),
-				[]string{"network", "vpcpeering", "get", "vpc-001", "peer-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -178,25 +160,30 @@ func TestVPCPeeringGetCmd(t *testing.T) {
 }
 
 func TestVPCPeeringCreateCmd(t *testing.T) {
+	baseArgs := []string{
+		"network", "vpcpeering", "create", "vpc-001",
+		"--project-id", "proj-123",
+		"--name", "my-peering",
+		"--region", "IT-BG",
+		"--peer-vpc-id", "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002",
+	}
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVPCPeeringsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			args: []string{"network", "vpcpeering", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-peering", "--peer-vpc-id", "vpc-002", "--region", "IT-BG"},
-			setupMock: func(m *mockVPCPeeringsClient) {
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "peer-new", "my-peering"
-				m.createFn = func(_ context.Context, _, _ string, _ types.VPCPeeringRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-					return &types.Response[types.VPCPeeringResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "peer-new") {
@@ -206,31 +193,32 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 		},
 		{
 			name:        "missing required flag --name",
-			args:        []string{"network", "vpcpeering", "create", "vpc-001", "--project-id", "proj-123", "--peer-vpc-id", "vpc-002", "--region", "IT-BG"},
+			args:        removeFlag(baseArgs, "--name", "my-peering"),
 			wantErr:     true,
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
-			args: []string{"network", "vpcpeering", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-peering", "--peer-vpc-id", "vpc-002", "--region", "IT-BG"},
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.VPCPeeringRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			name:        "missing required flag --peer-vpc-id",
+			args:        removeFlag(baseArgs, "--peer-vpc-id", "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002"),
+			wantErr:     true,
+			errContains: "peer-vpc-id",
+		},
+		{
+			name: "server error propagates",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "creating",
 		},
 		{
-			name: "API error propagates",
-			args: []string{"network", "vpcpeering", "create", "vpc-001", "--project-id", "proj-123", "--name", "my-peering", "--peer-vpc-id", "vpc-002", "--region", "IT-BG"},
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.VPCPeeringRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error) {
-					return &types.Response[types.VPCPeeringResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -238,11 +226,91 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestVPCPeeringUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "vpcpeering", "update", "vpc-001", "peer-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "peer-001", "my-peering"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					jsonResponse(200, types.VPCPeeringResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				updID, updName := "peer-001", "new-name"
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					jsonResponse(200, types.VPCPeeringResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "peer-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no fields provided returns error",
+			args:        []string{"network", "vpcpeering", "update", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv:    nil,
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "server error on update propagates",
+			args: []string{"network", "vpcpeering", "update", "vpc-001", "peer-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "peer-001", "my-peering"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					jsonResponse(200, types.VPCPeeringResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+		{
+			name: "API 404 on get propagates",
+			args: []string{"network", "vpcpeering", "update", "vpc-001", "peer-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -254,17 +322,18 @@ func TestVPCPeeringCreateCmd(t *testing.T) {
 func TestVPCPeeringDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCPeeringsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "peer-001") {
@@ -273,12 +342,14 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name: "--dry-run registers only GET",
+			args: []string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "peer-001", "my-peering"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					jsonResponse(200, types.VPCPeeringResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "peer-001") {
@@ -287,24 +358,21 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPCPeeringsClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -312,15 +380,11 @@ func TestVPCPeeringDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpcpeering", "delete", "vpc-001", "peer-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -3,10 +3,23 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+func vpcPeeringRouteRef(projectID, vpcID, peeringID, routeID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID + "/vpcPeerings/" + peeringID + "/vpcPeeringRoutes/" + routeID)
+}
+
+func vpcPeeringRouteListPayload(l *aruba.List[*aruba.VPCPeeringRoute]) any {
+	if r, ok := l.Raw().(*types.Response[types.VPCPeeringRouteList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
 
 func init() {
 
@@ -55,7 +68,6 @@ func init() {
 	vpcpeeringrouteDeleteCmd.ValidArgsFunction = completeVPCPeeringRouteID
 }
 
-// Completion functions for network resources
 func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) < 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -75,18 +87,23 @@ func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete str
 	vpcPeeringID := args[1]
 
 	ctx := context.Background()
-	response, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, projectID, vpcID, vpcPeeringID, nil)
+	list, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, vpcPeeringRef(projectID, vpcID, vpcPeeringID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	// Note: VPCPeeringRouteResponse.Metadata doesn't have ID field
-	// We can't provide completion without ID, so return empty
-	// The user will need to type the route ID manually
 	var completions []string
-	if response != nil && response.Data != nil {
-		// Completion not available for VPC peering routes due to missing ID in metadata
-		_ = response.Data.Values
+	if list != nil {
+		for _, route := range list.Items() {
+			id := route.VPCPeeringRouteID()
+			name := route.Name()
+			if id == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
+			}
+		}
 	}
 
 	return completions, cobra.ShellCompDirectiveNoFileComp
@@ -135,25 +152,6 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		req := types.VPCPeeringRouteRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{Value: region},
-			},
-			Properties: types.VPCPeeringRoutePropertiesRequest{
-				LocalNetworkAddress:  localNetwork,
-				RemoteNetworkAddress: remoteNetwork,
-				BillingPlan: types.BillingPeriodResource{
-					BillingPeriod: billingPeriod,
-				},
-			},
-		}
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("Creating VPC peering route with the following parameters:")
 			fmt.Printf("  Name:            %s\n", name)
@@ -166,18 +164,26 @@ Billing period: Hour (default), Month, or Year.`,
 			fmt.Println()
 		}
 
+		route := aruba.NewVPCPeeringRoute().
+			IntoVPCPeering(vpcPeeringRef(projectID, vpcID, peeringID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			WithLocalCIDR(localNetwork).
+			WithRemoteCIDR(remoteNetwork).
+			WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+		if len(tags) > 0 {
+			route.ReplaceTags(tags...)
+		}
+
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPCPeeringRoutes().Create(ctx, projectID, vpcID, peeringID, req, nil)
+		created, err := client.FromNetwork().VPCPeeringRoutes().Create(ctx, route)
 		if err != nil {
-			return fmt.Errorf("creating VPC peering route: %w", err)
+			return fmt.Errorf("creating VPC peering route: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
+		r := created.Raw()
+		if r != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -185,29 +191,19 @@ Billing period: Hour (default), Month, or Year.`,
 				{Header: "REMOTE NETWORK", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				func() string {
-					if resp.Data.Metadata.Name != nil {
-						return *resp.Data.Metadata.Name
-					}
-					return name
-				}(),
-				func() string {
-					if resp.Data.Metadata.ID != nil {
-						return *resp.Data.Metadata.ID
-					}
-					return ""
-				}(),
-				localNetwork,
-				remoteNetwork,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			id := ""
+			if r.Metadata.ID != nil {
+				id = *r.Metadata.ID
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			createdName := name
+			if r.Metadata.Name != nil {
+				createdName = *r.Metadata.Name
+			}
+			status := ""
+			if r.Status.State != nil {
+				status = *r.Status.State
+			}
+			PrintOutput(r, headers, [][]string{{createdName, id, localNetwork, remoteNetwork, status}})
 		} else {
 			fmt.Println(msgCreatedAsync("VPC peering route", name))
 		}
@@ -236,17 +232,13 @@ var vpcpeeringrouteGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
+		got, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, vpcPeeringRouteRef(projectID, vpcID, peeringID, routeID))
 		if err != nil {
-			return fmt.Errorf("getting VPC peering route: %w", err)
+			return fmt.Errorf("getting VPC peering route: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			route := resp.Data
+		route := got.Raw()
+		if route != nil {
 			fmt.Println("\nVPC Peering Route Details:")
 			fmt.Println("==========================")
 			fmt.Printf("ID:              %s\n", routeID)
@@ -255,8 +247,8 @@ var vpcpeeringrouteGetCmd = &cobra.Command{
 			}
 			fmt.Printf("Local Network:    %s\n", route.Properties.LocalNetworkAddress)
 			fmt.Printf("Remote Network:   %s\n", route.Properties.RemoteNetworkAddress)
-			if route.Properties.BillingPlan.BillingPeriod != "" {
-				fmt.Printf("Billing Period:  %s\n", route.Properties.BillingPlan.BillingPeriod)
+			if route.Properties.BillingPeriod != nil {
+				fmt.Printf("Billing Period:  %s\n", string(*route.Properties.BillingPeriod))
 			}
 			if len(route.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", route.Metadata.Tags)
@@ -293,16 +285,12 @@ var vpcpeeringrouteListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, projectID, vpcID, peeringID, listParams(cmd))
+		list, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, vpcPeeringRef(projectID, vpcID, peeringID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing VPC peering routes: %w", err)
+			return fmt.Errorf("listing VPC peering routes: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -311,24 +299,23 @@ var vpcpeeringrouteListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 			var rows [][]string
-			for _, route := range resp.Data.Values {
-				name := ""
-				if route.Metadata.Name != nil {
-					name = *route.Metadata.Name
-				}
-				id := ""
-				if route.Metadata.ID != nil {
-					id = *route.Metadata.ID
-				}
-				localNetwork := route.Properties.LocalNetworkAddress
-				remoteNetwork := route.Properties.RemoteNetworkAddress
+			for _, route := range list.Items() {
+				r := route.Raw()
+				name := route.Name()
+				id := route.VPCPeeringRouteID()
+				localNetwork := ""
+				remoteNetwork := ""
 				status := ""
-				if route.Status.State != nil {
-					status = *route.Status.State
+				if r != nil {
+					localNetwork = r.Properties.LocalNetworkAddress
+					remoteNetwork = r.Properties.RemoteNetworkAddress
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 				rows = append(rows, []string{name, id, localNetwork, remoteNetwork, status})
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(vpcPeeringRouteListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No VPC peering routes found.")
 		}
@@ -351,7 +338,6 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 		remoteNetwork, _ := cmd.Flags().GetString("remote-network")
 		billingPeriod, _ := cmd.Flags().GetString("billing-period")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") && localNetwork == "" && remoteNetwork == "" && billingPeriod == "" {
 			return fmt.Errorf("at least one field must be provided for update")
 		}
@@ -369,84 +355,41 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 		ctx, cancel := newCtx()
 		defer cancel()
 
-		// Fetch current VPC peering route details
-		getResp, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-		if err != nil || getResp == nil || getResp.Data == nil {
-			return fmt.Errorf("fetching current VPC peering route: %w", err)
+		cur, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, vpcPeeringRouteRef(projectID, vpcID, peeringID, routeID))
+		if err != nil {
+			return fmt.Errorf("fetching current VPC peering route: %w", apiErrFromV2(err))
 		}
-
-		current := getResp.Data
-
-		// Block update if VPC peering route is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == StateInCreation {
+		r := cur.Raw()
+		if r == nil {
+			return fmt.Errorf("VPC peering route not found")
+		}
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update VPC peering route while it is in 'InCreation' state. Please wait until the VPC peering route is fully created")
 		}
 
-		// Preserve the region from the current resource for the update request.
-		var regionValue string
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
+		if name != "" {
+			cur.Named(name)
+		}
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
+		}
+		if localNetwork != "" {
+			cur.WithLocalCIDR(localNetwork)
+		}
+		if remoteNetwork != "" {
+			cur.WithRemoteCIDR(remoteNetwork)
+		}
+		if billingPeriod != "" {
+			cur.WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
 		}
 
-		// Build update request by merging user input with current values
-		req := types.VPCPeeringRouteRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: func() string {
-						if name != "" {
-							return name
-						}
-						if current.Metadata.Name != nil {
-							return *current.Metadata.Name
-						}
-						return ""
-					}(),
-					Tags: func() []string {
-						if cmd.Flags().Changed("tags") {
-							return tags
-						}
-						if current.Metadata.Tags != nil {
-							return current.Metadata.Tags
-						}
-						return []string{}
-					}(),
-				},
-				Location: types.LocationRequest{Value: regionValue},
-			},
-			Properties: types.VPCPeeringRoutePropertiesRequest{
-				LocalNetworkAddress: func() string {
-					if localNetwork != "" {
-						return localNetwork
-					}
-					return current.Properties.LocalNetworkAddress
-				}(),
-				RemoteNetworkAddress: func() string {
-					if remoteNetwork != "" {
-						return remoteNetwork
-					}
-					return current.Properties.RemoteNetworkAddress
-				}(),
-				BillingPlan: types.BillingPeriodResource{
-					BillingPeriod: func() string {
-						if billingPeriod != "" {
-							return billingPeriod
-						}
-						return current.Properties.BillingPlan.BillingPeriod
-					}(),
-				},
-			},
-		}
-
-		resp, err := client.FromNetwork().VPCPeeringRoutes().Update(ctx, projectID, vpcID, peeringID, routeID, req, nil)
+		updated, err := client.FromNetwork().VPCPeeringRoutes().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating VPC peering route: %w", err)
+			return fmt.Errorf("updating VPC peering route: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
+		ur := updated.Raw()
+		if ur != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -454,29 +397,19 @@ var vpcpeeringrouteUpdateCmd = &cobra.Command{
 				{Header: "REMOTE NETWORK", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				func() string {
-					if resp.Data.Metadata.Name != nil {
-						return *resp.Data.Metadata.Name
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.ID != nil {
-						return *resp.Data.Metadata.ID
-					}
-					return routeID
-				}(),
-				resp.Data.Properties.LocalNetworkAddress,
-				resp.Data.Properties.RemoteNetworkAddress,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			updName := ""
+			if ur.Metadata.Name != nil {
+				updName = *ur.Metadata.Name
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			updID := routeID
+			if ur.Metadata.ID != nil {
+				updID = *ur.Metadata.ID
+			}
+			updStatus := ""
+			if ur.Status.State != nil {
+				updStatus = *ur.Status.State
+			}
+			PrintOutput(ur, headers, [][]string{{updName, updID, ur.Properties.LocalNetworkAddress, ur.Properties.RemoteNetworkAddress, updStatus}})
 		} else {
 			fmt.Println(msgUpdatedAsync("VPC peering route", routeID))
 		}
@@ -493,15 +426,7 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 		peeringID := args[1]
 		routeID := args[2]
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("VPC peering route", routeID)
 			if err != nil {
@@ -510,6 +435,11 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 			if !ok {
 				return nil
 			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
@@ -522,21 +452,16 @@ var vpcpeeringrouteDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
+			_, err = client.FromNetwork().VPCPeeringRoutes().Get(ctx, vpcPeeringRouteRef(projectID, vpcID, peeringID, routeID))
 			if err != nil {
-				return fmt.Errorf("dry-run: VPC peering route not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: VPC peering route not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("VPC peering route", routeID))
 			return nil
 		}
 
-		resp, err := client.FromNetwork().VPCPeeringRoutes().Delete(ctx, projectID, vpcID, peeringID, routeID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting VPC peering route: %w", err)
-		}
-
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
+		if err := client.FromNetwork().VPCPeeringRoutes().Delete(ctx, vpcPeeringRouteRef(projectID, vpcID, peeringID, routeID)); err != nil {
+			return fmt.Errorf("deleting VPC peering route: %w", apiErrFromV2(err))
 		}
 
 		headers := []TableColumn{

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,60 +11,49 @@ import (
 func TestVPCPeeringRouteListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCPeeringRoutesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-					return &types.Response[types.VPCPeeringRouteList]{
-						StatusCode: 200,
-						Data: &types.VPCPeeringRouteList{
-							Values: []types.VPCPeeringRouteResponse{{}},
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteList{
+						Values: []types.VPCPeeringRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
-		},
-		{
-			name: "success with non-nil name and id",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-					name := "my-route"
-					id := "route-abc"
-					return &types.Response[types.VPCPeeringRouteList]{
-						StatusCode: 200,
-						Data: &types.VPCPeeringRouteList{
-							Values: []types.VPCPeeringRouteResponse{{
-								Metadata: types.ResourceMetadataResponse{Name: &name, ID: &id},
-							}},
-						},
-					}, nil
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-					return &types.Response[types.VPCPeeringRouteList]{StatusCode: 200, Data: &types.VPCPeeringRouteList{}}, nil
-				}
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-					return &types.Response[types.VPCPeeringRouteList]{
-						StatusCode: 200,
-						Data: &types.VPCPeeringRouteList{
-							Values: []types.VPCPeeringRouteResponse{{}},
+			name: "--output json emits valid JSON",
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteList{
+						Values: []types.VPCPeeringRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -76,24 +63,21 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.listFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
-					return &types.Response[types.VPCPeeringRouteList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -101,15 +85,11 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -121,53 +101,44 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 func TestVPCPeeringRouteGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCPeeringRoutesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{},
-					}, nil
+			args: []string{"network", "vpcpeeringroute", "get", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					jsonResponse(200, types.VPCPeeringRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "success with non-nil name",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					name := "my-route"
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{Metadata: types.ResourceMetadataResponse{Name: &name}},
-					}, nil
-				}
-			},
-		},
-		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpcpeeringroute", "get", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpcpeeringroute", "get", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -175,12 +146,11 @@ func TestVPCPeeringRouteGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})),
-				[]string{"network", "vpcpeeringroute", "get", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -190,94 +160,73 @@ func TestVPCPeeringRouteGetCmd(t *testing.T) {
 }
 
 func TestVPCPeeringRouteCreateCmd(t *testing.T) {
+	baseArgs := []string{
+		"network", "vpcpeeringroute", "create", "vpc-001", "peer-001",
+		"--project-id", "proj-123",
+		"--name", "my-route",
+		"--region", "IT-BG",
+		"--local-network", "10.0.0.0/24",
+		"--remote-network", "192.168.0.0/24",
+		"--billing-period", "monthly",
+	}
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVPCPeeringRoutesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			args: []string{
-				"network", "vpcpeeringroute", "create", "vpc-001", "peer-001",
-				"--project-id", "proj-123",
-				"--name", "my-route",
-				"--region", "ITBG-Bergamo",
-				"--local-network", "10.0.0.0/24",
-				"--remote-network", "10.1.0.0/24",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-new", "my-route"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{},
-					}, nil
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-new") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "success with non-nil metadata in response",
-			args: []string{
-				"network", "vpcpeeringroute", "create", "vpc-001", "peer-001",
-				"--project-id", "proj-123",
-				"--name", "my-route",
-				"--region", "ITBG-Bergamo",
-				"--local-network", "10.0.0.0/24",
-				"--remote-network", "10.1.0.0/24",
-			},
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					name := "my-route"
-					id := "route-abc"
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{Metadata: types.ResourceMetadataResponse{Name: &name, ID: &id}},
-					}, nil
-				}
-			},
+			name:        "missing required flag --name",
+			args:        removeFlag(baseArgs, "--name", "my-route"),
+			wantErr:     true,
+			errContains: "name",
 		},
 		{
-			name:    "missing required flag --name",
-			args:    []string{"network", "vpcpeeringroute", "create", "vpc-001", "peer-001", "--project-id", "proj-123", "--region", "ITBG-Bergamo", "--local-network", "10.0.0.0/24", "--remote-network", "10.1.0.0/24"},
-			wantErr: true, errContains: "name",
+			name:        "missing required flag --local-network",
+			args:        removeFlag(baseArgs, "--local-network", "10.0.0.0/24"),
+			wantErr:     true,
+			errContains: "local-network",
 		},
 		{
-			name: "SDK error propagates",
-			args: []string{
-				"network", "vpcpeeringroute", "create", "vpc-001", "peer-001",
-				"--project-id", "proj-123",
-				"--name", "my-route",
-				"--region", "ITBG-Bergamo",
-				"--local-network", "10.0.0.0/24",
-				"--remote-network", "10.1.0.0/24",
-			},
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			name:        "missing required flag --remote-network",
+			args:        removeFlag(baseArgs, "--remote-network", "192.168.0.0/24"),
+			wantErr:     true,
+			errContains: "remote-network",
+		},
+		{
+			name: "server error propagates",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "creating",
 		},
 		{
-			name: "API error propagates",
-			args: []string{
-				"network", "vpcpeeringroute", "create", "vpc-001", "peer-001",
-				"--project-id", "proj-123",
-				"--name", "my-route",
-				"--region", "ITBG-Bergamo",
-				"--local-network", "10.0.0.0/24",
-				"--remote-network", "10.1.0.0/24",
-			},
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.createFn = func(_ context.Context, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -285,11 +234,11 @@ func TestVPCPeeringRouteCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -299,129 +248,77 @@ func TestVPCPeeringRouteCreateCmd(t *testing.T) {
 }
 
 func TestVPCPeeringRouteUpdateCmd(t *testing.T) {
-	baseArgs := []string{
-		"network", "vpcpeeringroute", "update", "vpc-001", "peer-001", "route-001",
-		"--project-id", "proj-123",
-	}
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVPCPeeringRoutesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			args: append(baseArgs, "--name", "updated-route"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.updateFn = func(_ context.Context, _, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{},
-					}, nil
+			args: []string{"network", "vpcpeeringroute", "update", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					jsonResponse(200, types.VPCPeeringRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				updID, updName := "route-001", "new-name"
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					jsonResponse(200, types.VPCPeeringRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-001") {
+					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "success with non-nil metadata in response",
-			args: append(baseArgs, "--name", "updated-route"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					currentName := "old-route"
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{Metadata: types.ResourceMetadataResponse{Name: &currentName}},
-					}, nil
-				}
-				m.updateFn = func(_ context.Context, _, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					name := "updated-route"
-					id := "route-001"
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{Metadata: types.ResourceMetadataResponse{Name: &name, ID: &id}},
-					}, nil
-				}
-			},
-		},
-		{
-			name: "name falls back to current when not provided",
-			args: append(baseArgs, "--tags", "t1"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					currentName := "existing-name"
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{Metadata: types.ResourceMetadataResponse{Name: &currentName}},
-					}, nil
-				}
-			},
-		},
-		{
-			name:        "no fields provided",
-			args:        baseArgs,
+			name:        "no fields provided returns error",
+			args:        []string{"network", "vpcpeeringroute", "update", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"},
+			setupSrv:    nil,
 			wantErr:     true,
-			errContains: "at least one field",
+			errContains: "at least one",
 		},
 		{
-			name: "InCreation blocks update",
-			args: append(baseArgs, "--name", "new-name"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					state := StateInCreation
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPCPeeringRouteResponse{Status: types.ResourceStatus{State: &state}},
-					}, nil
-				}
-			},
-			wantErr:     true,
-			errContains: "InCreation",
-		},
-		{
-			name: "SDK error on get",
-			args: append(baseArgs, "--name", "new-name"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
-			},
-			wantErr:     true,
-			errContains: "fetching current",
-		},
-		{
-			name: "SDK error on update",
-			args: append(baseArgs, "--name", "new-name"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.updateFn = func(_ context.Context, _, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return nil, fmt.Errorf("timeout")
-				}
+			name: "server error on update propagates",
+			args: []string{"network", "vpcpeeringroute", "update", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					jsonResponse(200, types.VPCPeeringRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "updating",
 		},
 		{
-			name: "API error on update",
-			args: append(baseArgs, "--name", "new-name"),
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.updateFn = func(_ context.Context, _, _, _, _ string, _ types.VPCPeeringRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error) {
-					return &types.Response[types.VPCPeeringRouteResponse]{
-						StatusCode: 422,
-						Error:      &types.ErrorResponse{Title: strPtr("Unprocessable"), Detail: strPtr("invalid CIDR")},
-					}, nil
-				}
+			name: "API 404 on get propagates",
+			args: []string{"network", "vpcpeeringroute", "update", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
-			errContains: "API error (status 422): Unprocessable",
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -433,17 +330,18 @@ func TestVPCPeeringRouteUpdateCmd(t *testing.T) {
 func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPCPeeringRoutesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "route-001") {
@@ -452,12 +350,14 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name: "--dry-run registers only GET",
+			args: []string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					jsonResponse(200, types.VPCPeeringRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "route-001") {
@@ -466,24 +366,21 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPCPeeringRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -491,15 +388,11 @@ func TestVPCPeeringRouteDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPCPeeringRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpcpeeringroute", "delete", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpcPeeringRoutesMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -1,16 +1,26 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func vpnRouteRef(projectID, tunnelID, routeID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpnTunnels/" + tunnelID + "/vpnRoutes/" + routeID)
+}
 
+func vpnRouteListPayload(l *aruba.List[*aruba.VPNRoute]) any {
+	if r, ok := l.Raw().(*types.Response[types.VPNRouteList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
+func init() {
 	networkCmd.AddCommand(vpnrouteCmd)
 
 	vpnrouteCmd.AddCommand(vpnrouteCreateCmd)
@@ -48,49 +58,41 @@ func init() {
 	vpnrouteListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	vpnrouteListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
-	// Set up auto-completion for resource IDs
 	vpnrouteGetCmd.ValidArgsFunction = completeVPNRouteID
 	vpnrouteUpdateCmd.ValidArgsFunction = completeVPNRouteID
 	vpnrouteDeleteCmd.ValidArgsFunction = completeVPNRouteID
 }
 
-// Completion functions for network resources
 func completeVPNRouteID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) < 1 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	vpnTunnelID := args[0]
-
-	ctx := context.Background()
-	response, err := client.FromNetwork().VPNRoutes().List(ctx, projectID, vpnTunnelID, nil)
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().VPNRoutes().List(ctx, vpnTunnelRef(projectID, vpnTunnelID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, route := range response.Data.Values {
-			if route.Metadata.ID != nil && route.Metadata.Name != nil {
-				id := *route.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *route.Metadata.Name))
-				}
-			}
+	for _, route := range list.Items() {
+		id := route.VPNRouteID()
+		name := route.Name()
+		if id == "" {
+			continue
+		}
+		if toComplete == "" || strings.HasPrefix(id, toComplete) {
+			completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 		}
 	}
-
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -114,7 +116,6 @@ with --onprem-subnet. Both values should be valid CIDR blocks.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
-
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		cloudSubnet, _ := cmd.Flags().GetString("cloud-subnet")
@@ -126,30 +127,11 @@ with --onprem-subnet. Both values should be valid CIDR blocks.`,
 		if err != nil {
 			return err
 		}
-
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		req := types.VPNRouteRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.VPNRoutePropertiesRequest{
-				CloudSubnet:  cloudSubnet,
-				OnPremSubnet: onPremSubnet,
-			},
-		}
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("Creating VPN route with the following parameters:")
 			fmt.Printf("  Name:          %s\n", name)
@@ -164,16 +146,24 @@ with --onprem-subnet. Both values should be valid CIDR blocks.`,
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPNRoutes().Create(ctx, projectID, vpnTunnelID, req, nil)
+
+		route := aruba.NewVPNRoute().
+			IntoVPNTunnel(vpnTunnelRef(projectID, vpnTunnelID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			WithCloudSubnet(cloudSubnet).
+			WithOnPremSubnet(onPremSubnet)
+		if len(tags) > 0 {
+			route.ReplaceTags(tags...)
+		}
+
+		created, err := client.FromNetwork().VPNRoutes().Create(ctx, route)
 		if err != nil {
-			return fmt.Errorf("creating VPN route: %w", err)
+			return fmt.Errorf("creating VPN route: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && resp.Data.Metadata.ID != nil {
+		r := created.Raw()
+		if r != nil && r.Metadata.ID != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -181,19 +171,11 @@ with --onprem-subnet. Both values should be valid CIDR blocks.`,
 				{Header: "ONPREM SUBNET", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				name,
-				*resp.Data.Metadata.ID,
-				cloudSubnet,
-				onPremSubnet,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			status := ""
+			if r.Status.State != nil {
+				status = *r.Status.State
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			PrintOutput(r, headers, [][]string{{name, *r.Metadata.ID, cloudSubnet, onPremSubnet, status}})
 		} else {
 			fmt.Println(msgCreatedAsync("VPN route", name))
 		}
@@ -208,30 +190,23 @@ var vpnrouteGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 		routeID := args[1]
-
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
-
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
-
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
+		got, err := client.FromNetwork().VPNRoutes().Get(ctx, vpnRouteRef(projectID, vpnTunnelID, routeID))
 		if err != nil {
-			return fmt.Errorf("getting VPN route: %w", err)
+			return fmt.Errorf("getting VPN route: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			route := resp.Data
+		route := got.Raw()
+		if route != nil {
 			fmt.Println("\nVPN Route Details:")
 			fmt.Println("==================")
 			if route.Metadata.ID != nil {
@@ -244,9 +219,7 @@ var vpnrouteGetCmd = &cobra.Command{
 				fmt.Printf("Name:            %s\n", *route.Metadata.Name)
 			}
 			if route.Metadata.LocationResponse != nil {
-				if route.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", route.Metadata.LocationResponse.Value)
-				}
+				fmt.Printf("Region:          %s\n", route.Metadata.LocationResponse.Value)
 			}
 			fmt.Printf("Cloud Subnet:    %s\n", route.Properties.CloudSubnet)
 			fmt.Printf("OnPrem Subnet:   %s\n", route.Properties.OnPremSubnet)
@@ -277,29 +250,22 @@ var vpnrouteListCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
-
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
-
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
-
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromNetwork().VPNRoutes().List(ctx, projectID, vpnTunnelID, listParams(cmd))
+		list, err := client.FromNetwork().VPNRoutes().List(ctx, vpnTunnelRef(projectID, vpnTunnelID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing VPN routes: %w", err)
+			return fmt.Errorf("listing VPN routes: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -308,24 +274,23 @@ var vpnrouteListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 			var rows [][]string
-			for _, route := range resp.Data.Values {
-				name := ""
-				if route.Metadata.Name != nil {
-					name = *route.Metadata.Name
-				}
-				id := ""
-				if route.Metadata.ID != nil {
-					id = *route.Metadata.ID
-				}
-				cloudSubnet := route.Properties.CloudSubnet
-				onPremSubnet := route.Properties.OnPremSubnet
+			for _, route := range list.Items() {
+				r := route.Raw()
+				name := route.Name()
+				id := route.VPNRouteID()
+				cloudSubnet := ""
+				onPremSubnet := ""
 				status := ""
-				if route.Status.State != nil {
-					status = *route.Status.State
+				if r != nil {
+					cloudSubnet = r.Properties.CloudSubnet
+					onPremSubnet = r.Properties.OnPremSubnet
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
 				rows = append(rows, []string{name, id, cloudSubnet, onPremSubnet, status})
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(vpnRouteListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No VPN routes found.")
 		}
@@ -340,13 +305,11 @@ var vpnrouteUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 		routeID := args[1]
-
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		cloudSubnet, _ := cmd.Flags().GetString("cloud-subnet")
 		onPremSubnet, _ := cmd.Flags().GetString("onprem-subnet")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") && cloudSubnet == "" && onPremSubnet == "" {
 			return fmt.Errorf("at least one field must be provided for update")
 		}
@@ -355,90 +318,45 @@ var vpnrouteUpdateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
-
 		ctx, cancel := newCtx()
 		defer cancel()
 
-		// Fetch current VPN route details
-		getResp, err := client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-		if err != nil || getResp == nil || getResp.Data == nil {
-			return fmt.Errorf("fetching current VPN route: %w", err)
+		cur, err := client.FromNetwork().VPNRoutes().Get(ctx, vpnRouteRef(projectID, vpnTunnelID, routeID))
+		if err != nil {
+			return fmt.Errorf("fetching current VPN route: %w", apiErrFromV2(err))
 		}
-
-		current := getResp.Data
-
-		// Block update if VPN route is in 'InCreation' state
-		if current.Status.State != nil && *current.Status.State == StateInCreation {
+		r := cur.Raw()
+		if r == nil {
+			return fmt.Errorf("VPN route not found")
+		}
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update VPN route while it is in 'InCreation' state. Please wait until the VPN route is fully created")
 		}
 
-		// Normalize region code if needed
-		regionValue := ""
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
+		if name != "" {
+			cur.Named(name)
 		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for VPN route")
+		if cmd.Flags().Changed("tags") {
+			cur.ReplaceTags(tags...)
 		}
-
-		// Build update request by merging user input with current values
-		req := types.VPNRouteRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: func() string {
-						if name != "" {
-							return name
-						}
-						if current.Metadata.Name != nil {
-							return *current.Metadata.Name
-						}
-						return ""
-					}(),
-					Tags: func() []string {
-						if cmd.Flags().Changed("tags") {
-							return tags
-						}
-						if current.Metadata.Tags != nil {
-							return current.Metadata.Tags
-						}
-						return []string{}
-					}(),
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.VPNRoutePropertiesRequest{
-				CloudSubnet: func() string {
-					if cloudSubnet != "" {
-						return cloudSubnet
-					}
-					return current.Properties.CloudSubnet
-				}(),
-				OnPremSubnet: func() string {
-					if onPremSubnet != "" {
-						return onPremSubnet
-					}
-					return current.Properties.OnPremSubnet
-				}(),
-			},
+		if cloudSubnet != "" {
+			cur.WithCloudSubnet(cloudSubnet)
+		}
+		if onPremSubnet != "" {
+			cur.WithOnPremSubnet(onPremSubnet)
 		}
 
-		resp, err := client.FromNetwork().VPNRoutes().Update(ctx, projectID, vpnTunnelID, routeID, req, nil)
+		updated, err := client.FromNetwork().VPNRoutes().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating VPN route: %w", err)
+			return fmt.Errorf("updating VPN route: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
+		ur := updated.Raw()
+		if ur != nil {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -446,29 +364,19 @@ var vpnrouteUpdateCmd = &cobra.Command{
 				{Header: "ONPREM SUBNET", Width: 18},
 				{Header: "STATUS", Width: 15},
 			}
-			row := []string{
-				func() string {
-					if resp.Data.Metadata.Name != nil {
-						return *resp.Data.Metadata.Name
-					}
-					return ""
-				}(),
-				func() string {
-					if resp.Data.Metadata.ID != nil {
-						return *resp.Data.Metadata.ID
-					}
-					return ""
-				}(),
-				resp.Data.Properties.CloudSubnet,
-				resp.Data.Properties.OnPremSubnet,
-				func() string {
-					if resp.Data.Status.State != nil {
-						return *resp.Data.Status.State
-					}
-					return ""
-				}(),
+			updName := ""
+			if ur.Metadata.Name != nil {
+				updName = *ur.Metadata.Name
 			}
-			PrintOutput(resp.Data, headers, [][]string{row})
+			updID := ""
+			if ur.Metadata.ID != nil {
+				updID = *ur.Metadata.ID
+			}
+			updStatus := ""
+			if ur.Status.State != nil {
+				updStatus = *ur.Status.State
+			}
+			PrintOutput(ur, headers, [][]string{{updName, updID, ur.Properties.CloudSubnet, ur.Properties.OnPremSubnet, updStatus}})
 		} else {
 			fmt.Println(msgUpdatedAsync("VPN route", routeID))
 		}
@@ -484,15 +392,7 @@ var vpnrouteDeleteCmd = &cobra.Command{
 		vpnTunnelID := args[0]
 		routeID := args[1]
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("VPN route", routeID)
 			if err != nil {
@@ -503,31 +403,29 @@ var vpnrouteDeleteCmd = &cobra.Command{
 			}
 		}
 
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
-
 		ctx, cancel := newCtx()
 		defer cancel()
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
+			_, err = client.FromNetwork().VPNRoutes().Get(ctx, vpnRouteRef(projectID, vpnTunnelID, routeID))
 			if err != nil {
-				return fmt.Errorf("dry-run: VPN route not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: VPN route not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("VPN route", routeID))
 			return nil
 		}
 
-		resp, err := client.FromNetwork().VPNRoutes().Delete(ctx, projectID, vpnTunnelID, routeID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting VPN route: %w", err)
-		}
-
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
+		if err := client.FromNetwork().VPNRoutes().Delete(ctx, vpnRouteRef(projectID, vpnTunnelID, routeID)); err != nil {
+			return fmt.Errorf("deleting VPN route: %w", apiErrFromV2(err))
 		}
 
 		headers := []TableColumn{

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,54 +11,49 @@ import (
 func TestVPNRouteListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPNRoutesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockVPNRoutesClient) {
-				id, name := "vpnr-001", "my-vpnroute"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
-					return &types.Response[types.VPNRouteList]{
-						StatusCode: 200,
-						Data: &types.VPNRouteList{
-							Values: []types.VPNRouteResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteList{
+						Values: []types.VPNRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "vpnr-001") {
+				if !strings.Contains(out, "route-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
-					return &types.Response[types.VPNRouteList]{StatusCode: 200, Data: &types.VPNRouteList{}}, nil
-				}
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockVPNRoutesClient) {
-				id, name := "vpnr-001", "my-vpnroute"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
-					return &types.Response[types.VPNRouteList]{
-						StatusCode: 200,
-						Data: &types.VPNRouteList{
-							Values: []types.VPNRouteResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+			name: "--output json emits valid JSON",
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteList{
+						Values: []types.VPNRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +63,21 @@ func TestVPNRouteListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
-					return &types.Response[types.VPNRouteList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +85,11 @@ func TestVPNRouteListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpnroute", "list", "tun-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,47 +101,44 @@ func TestVPNRouteListCmd(t *testing.T) {
 func TestVPNRouteGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPNRoutesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockVPNRoutesClient) {
-				id, name := "vpnr-001", "my-vpnroute"
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-					return &types.Response[types.VPNRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPNRouteResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			args: []string{"network", "vpnroute", "get", "vpn-001", "route-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					jsonResponse(200, types.VPNRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "vpnr-001") {
+				if !strings.Contains(out, "route-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpnroute", "get", "vpn-001", "route-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-					return &types.Response[types.VPNRouteResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpnroute", "get", "vpn-001", "route-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +146,11 @@ func TestVPNRouteGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})),
-				[]string{"network", "vpnroute", "get", "tun-001", "vpnr-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -179,7 +161,7 @@ func TestVPNRouteGetCmd(t *testing.T) {
 
 func TestVPNRouteCreateCmd(t *testing.T) {
 	baseArgs := []string{
-		"network", "vpnroute", "create", "tun-001",
+		"network", "vpnroute", "create", "vpn-001",
 		"--project-id", "proj-123",
 		"--name", "my-route",
 		"--region", "IT-BG",
@@ -189,7 +171,7 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVPNRoutesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -197,17 +179,15 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: baseArgs,
-			setupMock: func(m *mockVPNRoutesClient) {
-				id, name := "vpnr-new", "my-route"
-				m.createFn = func(_ context.Context, _, _ string, _ types.VPNRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-					return &types.Response[types.VPNRouteResponse]{
-						StatusCode: 200,
-						Data:       &types.VPNRouteResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-new", "my-route"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "vpnr-new") {
+				if !strings.Contains(out, "route-new") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
@@ -219,26 +199,33 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
+			name:        "missing required flag --cloud-subnet",
+			args:        removeFlag(baseArgs, "--cloud-subnet", "10.0.0.0/24"),
+			wantErr:     true,
+			errContains: "cloud-subnet",
+		},
+		{
+			name:        "missing required flag --onprem-subnet",
+			args:        removeFlag(baseArgs, "--onprem-subnet", "192.168.1.0/24"),
+			wantErr:     true,
+			errContains: "onprem-subnet",
+		},
+		{
+			name: "server error propagates",
 			args: baseArgs,
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.VPNRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "creating",
 		},
 		{
-			name: "API error propagates",
+			name: "API 404 propagates",
 			args: baseArgs,
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.VPNRouteRequest, _ *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error) {
-					return &types.Response[types.VPNRouteResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -246,11 +233,91 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestVPNRouteUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "vpnroute", "update", "vpn-001", "route-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					jsonResponse(200, types.VPNRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				updID, updName := "route-001", "new-name"
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					jsonResponse(200, types.VPNRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "route-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no fields provided returns error",
+			args:        []string{"network", "vpnroute", "update", "vpn-001", "route-001", "--project-id", "proj-123"},
+			setupSrv:    nil,
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "server error on update propagates",
+			args: []string{"network", "vpnroute", "update", "vpn-001", "route-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					jsonResponse(200, types.VPNRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+		{
+			name: "API 404 on get propagates",
+			args: []string{"network", "vpnroute", "update", "vpn-001", "route-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -262,57 +329,57 @@ func TestVPNRouteCreateCmd(t *testing.T) {
 func TestVPNRouteDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPNRoutesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"network", "vpnroute", "delete", "vpn-001", "route-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "vpnr-001") {
+				if !strings.Contains(out, "route-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name: "--dry-run registers only GET",
+			args: []string{"network", "vpnroute", "delete", "vpn-001", "route-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					jsonResponse(200, types.VPNRouteResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "vpnr-001") {
+				if !strings.Contains(out, "route-001") {
 					t.Errorf("expected ID in dry-run output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpnroute", "delete", "vpn-001", "route-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPNRoutesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpnroute", "delete", "vpn-001", "route-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -320,15 +387,11 @@ func TestVPNRouteDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNRoutesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpnroute", "delete", "tun-001", "vpnr-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnRoutesMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -5,61 +5,183 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
-var vpnEncryptionAlgorithms = []string{
-	types.VPNEncryptionAES128, types.VPNEncryptionAES192, types.VPNEncryptionAES256,
-	types.VPNEncryptionAES128CTR, types.VPNEncryptionAES192CTR, types.VPNEncryptionAES256CTR,
-	types.VPNEncryptionAES128CCM64, types.VPNEncryptionAES128CCM96, types.VPNEncryptionAES128CCM128,
-	types.VPNEncryptionAES192CCM64, types.VPNEncryptionAES192CCM96, types.VPNEncryptionAES192CCM128,
-	types.VPNEncryptionAES256CCM64, types.VPNEncryptionAES256CCM96, types.VPNEncryptionAES256CCM128,
-	types.VPNEncryptionAES128GCM64, types.VPNEncryptionAES128GCM96, types.VPNEncryptionAES128GCM128,
-	types.VPNEncryptionAES192GCM64, types.VPNEncryptionAES192GCM96, types.VPNEncryptionAES192GCM128,
-	types.VPNEncryptionAES256GCM64, types.VPNEncryptionAES256GCM96, types.VPNEncryptionAES256GCM128,
-	types.VPNEncryptionAES128GMAC, types.VPNEncryptionAES192GMAC, types.VPNEncryptionAES256GMAC,
-	types.VPNEncryption3DES,
-	types.VPNEncryptionBlowfish128, types.VPNEncryptionBlowfish192, types.VPNEncryptionBlowfish256,
-	types.VPNEncryptionCamellia128, types.VPNEncryptionCamellia192, types.VPNEncryptionCamellia256,
-	types.VPNEncryptionCamellia128CTR, types.VPNEncryptionCamellia192CTR, types.VPNEncryptionCamellia256CTR,
-	types.VPNEncryptionCamellia128CCM64, types.VPNEncryptionCamellia128CCM96, types.VPNEncryptionCamellia128CCM128,
-	types.VPNEncryptionCamellia192CCM64, types.VPNEncryptionCamellia192CCM96, types.VPNEncryptionCamellia192CCM128,
-	types.VPNEncryptionCamellia256CCM64, types.VPNEncryptionCamellia256CCM96, types.VPNEncryptionCamellia256CCM128,
-	types.VPNEncryptionSerpent128, types.VPNEncryptionSerpent192, types.VPNEncryptionSerpent256,
-	types.VPNEncryptionTwofish128, types.VPNEncryptionTwofish192, types.VPNEncryptionTwofish256,
-	types.VPNEncryptionCAST128, types.VPNEncryptionChaCha20Poly1305,
+// vpnTunnelRef is shared with vpnroute.go.
+func vpnTunnelRef(projectID, tunnelID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpnTunnels/" + tunnelID)
 }
 
-var vpnHashAlgorithms = []string{
-	types.VPNHashMD5, types.VPNHashMD5128,
-	types.VPNHashSHA1, types.VPNHashSHA1160,
-	types.VPNHashSHA256, types.VPNHashSHA25696,
-	types.VPNHashSHA384, types.VPNHashSHA512,
-	types.VPNHashAESXCBC, types.VPNHashAESCMAC,
-	types.VPNHashAES128GMAC, types.VPNHashAES192GMAC, types.VPNHashAES256GMAC,
+func vpnTunnelListPayload(l *aruba.List[*aruba.VPNTunnel]) any {
+	if r, ok := l.Raw().(*types.Response[types.VPNTunnelList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
 }
 
-var vpnDHGroups = []string{
-	types.VPNDHGroup1, types.VPNDHGroup2, types.VPNDHGroup5,
-	types.VPNDHGroup14, types.VPNDHGroup15, types.VPNDHGroup16, types.VPNDHGroup17, types.VPNDHGroup18,
-	types.VPNDHGroup19, types.VPNDHGroup20, types.VPNDHGroup21,
-	types.VPNDHGroup22, types.VPNDHGroup23, types.VPNDHGroup24,
-	types.VPNDHGroup25, types.VPNDHGroup26, types.VPNDHGroup27, types.VPNDHGroup28, types.VPNDHGroup29, types.VPNDHGroup30,
-	types.VPNDHGroup31, types.VPNDHGroup32,
+// vpnTunnelReattachSettings reconstructs IKE/ESP/PSK/IPConfig sub-builders from
+// the raw response and re-attaches them to the wrapper before Update. The wrapper's
+// fromResponse does not rehydrate sub-builders, so a naive Update would drop them.
+func vpnTunnelReattachSettings(cur *aruba.VPNTunnel) {
+	r := cur.Raw()
+	if r == nil {
+		return
+	}
+	if cfg := r.Properties.IPConfigurations; cfg != nil {
+		ipc := aruba.NewVPNIPConfig()
+		if cfg.VPC != nil {
+			ipc.WithVPC(aruba.URI(cfg.VPC.URI))
+		}
+		if cfg.PublicIP != nil {
+			ipc.WithElasticIP(aruba.URI(cfg.PublicIP.URI))
+		}
+		if cfg.Subnet != nil {
+			ipc.WithSubnet(cfg.Subnet.Name, cfg.Subnet.CIDR)
+		}
+		cur.WithIPConfig(ipc)
+	}
+	if cs := r.Properties.VPNClientSettings; cs != nil {
+		if ike := cs.IKE; ike != nil {
+			k := aruba.NewVPNIKE().
+				WithLifetimeSeconds(int(ike.Lifetime)).
+				WithDPDIntervalSeconds(int(ike.DPDInterval)).
+				WithDPDTimeoutSeconds(int(ike.DPDTimeout))
+			if ike.Encryption != nil {
+				k.WithEncryption(*ike.Encryption)
+			}
+			if ike.Hash != nil {
+				k.WithHash(*ike.Hash)
+			}
+			if ike.DHGroup != nil {
+				k.WithDHGroup(*ike.DHGroup)
+			}
+			if ike.DPDAction != nil {
+				k.WithDPDAction(*ike.DPDAction)
+			}
+			cur.WithIKESettings(k)
+		}
+		if esp := cs.ESP; esp != nil {
+			e := aruba.NewVPNESP().WithLifetimeSeconds(int(esp.Lifetime))
+			if esp.Encryption != nil {
+				e.WithEncryption(*esp.Encryption)
+			}
+			if esp.Hash != nil {
+				e.WithHash(*esp.Hash)
+			}
+			if esp.PFS != nil {
+				e.WithPFS(*esp.PFS)
+			}
+			cur.WithESPSettings(e)
+		}
+		if psk := cs.PSK; psk != nil {
+			p := aruba.NewVPNPSK()
+			if psk.Secret != nil {
+				p.WithKey(*psk.Secret)
+			}
+			if psk.CloudSite != nil {
+				p.WithCloudSite(*psk.CloudSite)
+			}
+			if psk.OnPremSite != nil {
+				p.WithOnPremSite(*psk.OnPremSite)
+			}
+			cur.WithPSKSettings(p)
+		}
+	}
 }
 
-var vpnDPDActions = []string{types.VPNDPDActionTrap, types.VPNDPDActionClear, types.VPNDPDActionRestart}
+// IKE-specific enum slices
+var vpnIKEEncryptionAlgorithms = []string{
+	string(aruba.IKEEncryptionAES128), string(aruba.IKEEncryptionAES192), string(aruba.IKEEncryptionAES256),
+	string(aruba.IKEEncryptionAES128CTR), string(aruba.IKEEncryptionAES192CTR), string(aruba.IKEEncryptionAES256CTR),
+	string(aruba.IKEEncryptionAES128CCM64), string(aruba.IKEEncryptionAES128CCM96), string(aruba.IKEEncryptionAES128CCM128),
+	string(aruba.IKEEncryptionAES192CCM64), string(aruba.IKEEncryptionAES192CCM96), string(aruba.IKEEncryptionAES192CCM128),
+	string(aruba.IKEEncryptionAES256CCM64), string(aruba.IKEEncryptionAES256CCM96), string(aruba.IKEEncryptionAES256CCM128),
+	string(aruba.IKEEncryptionAES128GCM64), string(aruba.IKEEncryptionAES128GCM96), string(aruba.IKEEncryptionAES128GCM128),
+	string(aruba.IKEEncryptionAES192GCM64), string(aruba.IKEEncryptionAES192GCM96), string(aruba.IKEEncryptionAES192GCM128),
+	string(aruba.IKEEncryptionAES256GCM64), string(aruba.IKEEncryptionAES256GCM96), string(aruba.IKEEncryptionAES256GCM128),
+	string(aruba.IKEEncryptionAES128GMAC), string(aruba.IKEEncryptionAES192GMAC), string(aruba.IKEEncryptionAES256GMAC),
+	string(aruba.IKEEncryption3DES),
+	string(aruba.IKEEncryptionBlowfish128), string(aruba.IKEEncryptionBlowfish192), string(aruba.IKEEncryptionBlowfish256),
+	string(aruba.IKEEncryptionCamellia128), string(aruba.IKEEncryptionCamellia192), string(aruba.IKEEncryptionCamellia256),
+	string(aruba.IKEEncryptionCamellia128CTR), string(aruba.IKEEncryptionCamellia192CTR), string(aruba.IKEEncryptionCamellia256CTR),
+	string(aruba.IKEEncryptionCamellia128CCM64), string(aruba.IKEEncryptionCamellia128CCM96), string(aruba.IKEEncryptionCamellia128CCM128),
+	string(aruba.IKEEncryptionCamellia192CCM64), string(aruba.IKEEncryptionCamellia192CCM96), string(aruba.IKEEncryptionCamellia192CCM128),
+	string(aruba.IKEEncryptionCamellia256CCM64), string(aruba.IKEEncryptionCamellia256CCM96), string(aruba.IKEEncryptionCamellia256CCM128),
+	string(aruba.IKEEncryptionSerpent128), string(aruba.IKEEncryptionSerpent192), string(aruba.IKEEncryptionSerpent256),
+	string(aruba.IKEEncryptionTwofish128), string(aruba.IKEEncryptionTwofish192), string(aruba.IKEEncryptionTwofish256),
+	string(aruba.IKEEncryptionCAST128), string(aruba.IKEEncryptionChaCha20Poly1305),
+}
 
-var vpnPFSGroups = []string{
-	types.VPNPFSEnable,
-	types.VPNPFSDHGroup1, types.VPNPFSDHGroup2, types.VPNPFSDHGroup5,
-	types.VPNPFSDHGroup14, types.VPNPFSDHGroup15, types.VPNPFSDHGroup16, types.VPNPFSDHGroup17, types.VPNPFSDHGroup18,
-	types.VPNPFSDHGroup19, types.VPNPFSDHGroup20, types.VPNPFSDHGroup21,
-	types.VPNPFSDHGroup22, types.VPNPFSDHGroup23, types.VPNPFSDHGroup24,
-	types.VPNPFSDHGroup25, types.VPNPFSDHGroup26, types.VPNPFSDHGroup27, types.VPNPFSDHGroup28, types.VPNPFSDHGroup29, types.VPNPFSDHGroup30,
-	types.VPNPFSDHGroup31, types.VPNPFSDHGroup32,
-	types.VPNPFSDisable,
+// ESP-specific encryption slice (same algorithms, separate type)
+var vpnESPEncryptionAlgorithms = []string{
+	string(aruba.ESPEncryptionAES128), string(aruba.ESPEncryptionAES192), string(aruba.ESPEncryptionAES256),
+	string(aruba.ESPEncryptionAES128CTR), string(aruba.ESPEncryptionAES192CTR), string(aruba.ESPEncryptionAES256CTR),
+	string(aruba.ESPEncryptionAES128CCM64), string(aruba.ESPEncryptionAES128CCM96), string(aruba.ESPEncryptionAES128CCM128),
+	string(aruba.ESPEncryptionAES192CCM64), string(aruba.ESPEncryptionAES192CCM96), string(aruba.ESPEncryptionAES192CCM128),
+	string(aruba.ESPEncryptionAES256CCM64), string(aruba.ESPEncryptionAES256CCM96), string(aruba.ESPEncryptionAES256CCM128),
+	string(aruba.ESPEncryptionAES128GCM64), string(aruba.ESPEncryptionAES128GCM96), string(aruba.ESPEncryptionAES128GCM128),
+	string(aruba.ESPEncryptionAES192GCM64), string(aruba.ESPEncryptionAES192GCM96), string(aruba.ESPEncryptionAES192GCM128),
+	string(aruba.ESPEncryptionAES256GCM64), string(aruba.ESPEncryptionAES256GCM96), string(aruba.ESPEncryptionAES256GCM128),
+	string(aruba.ESPEncryptionAES128GMAC), string(aruba.ESPEncryptionAES192GMAC), string(aruba.ESPEncryptionAES256GMAC),
+	string(aruba.ESPEncryption3DES),
+	string(aruba.ESPEncryptionBlowfish128), string(aruba.ESPEncryptionBlowfish192), string(aruba.ESPEncryptionBlowfish256),
+	string(aruba.ESPEncryptionCamellia128), string(aruba.ESPEncryptionCamellia192), string(aruba.ESPEncryptionCamellia256),
+	string(aruba.ESPEncryptionCamellia128CTR), string(aruba.ESPEncryptionCamellia192CTR), string(aruba.ESPEncryptionCamellia256CTR),
+	string(aruba.ESPEncryptionCamellia128CCM64), string(aruba.ESPEncryptionCamellia128CCM96), string(aruba.ESPEncryptionCamellia128CCM128),
+	string(aruba.ESPEncryptionCamellia192CCM64), string(aruba.ESPEncryptionCamellia192CCM96), string(aruba.ESPEncryptionCamellia192CCM128),
+	string(aruba.ESPEncryptionCamellia256CCM64), string(aruba.ESPEncryptionCamellia256CCM96), string(aruba.ESPEncryptionCamellia256CCM128),
+	string(aruba.ESPEncryptionSerpent128), string(aruba.ESPEncryptionSerpent192), string(aruba.ESPEncryptionSerpent256),
+	string(aruba.ESPEncryptionTwofish128), string(aruba.ESPEncryptionTwofish192), string(aruba.ESPEncryptionTwofish256),
+	string(aruba.ESPEncryptionCAST128), string(aruba.ESPEncryptionChaCha20Poly1305),
+}
+
+var vpnIKEHashAlgorithms = []string{
+	string(aruba.IKEHashMD5), string(aruba.IKEHashMD5128),
+	string(aruba.IKEHashSHA1), string(aruba.IKEHashSHA1160),
+	string(aruba.IKEHashSHA256), string(aruba.IKEHashSHA25696),
+	string(aruba.IKEHashSHA384), string(aruba.IKEHashSHA512),
+	string(aruba.IKEHashAESXCBC), string(aruba.IKEHashAESCMAC),
+	string(aruba.IKEHashAES128GMAC), string(aruba.IKEHashAES192GMAC), string(aruba.IKEHashAES256GMAC),
+}
+
+var vpnESPHashAlgorithms = []string{
+	string(aruba.ESPHashMD5), string(aruba.ESPHashMD5128),
+	string(aruba.ESPHashSHA1), string(aruba.ESPHashSHA1160),
+	string(aruba.ESPHashSHA256), string(aruba.ESPHashSHA25696),
+	string(aruba.ESPHashSHA384), string(aruba.ESPHashSHA512),
+	string(aruba.ESPHashAESXCBC), string(aruba.ESPHashAESCMAC),
+	string(aruba.ESPHashAES128GMAC), string(aruba.ESPHashAES192GMAC), string(aruba.ESPHashAES256GMAC),
+}
+
+var vpnIKEDHGroups = []string{
+	string(aruba.IKEDHGroup1), string(aruba.IKEDHGroup2), string(aruba.IKEDHGroup5),
+	string(aruba.IKEDHGroup14), string(aruba.IKEDHGroup15), string(aruba.IKEDHGroup16),
+	string(aruba.IKEDHGroup17), string(aruba.IKEDHGroup18),
+	string(aruba.IKEDHGroup19), string(aruba.IKEDHGroup20), string(aruba.IKEDHGroup21),
+	string(aruba.IKEDHGroup22), string(aruba.IKEDHGroup23), string(aruba.IKEDHGroup24),
+	string(aruba.IKEDHGroup25), string(aruba.IKEDHGroup26), string(aruba.IKEDHGroup27),
+	string(aruba.IKEDHGroup28), string(aruba.IKEDHGroup29), string(aruba.IKEDHGroup30),
+	string(aruba.IKEDHGroup31), string(aruba.IKEDHGroup32),
+}
+
+var vpnIKEDPDActions = []string{
+	string(aruba.IKEDPDActionTrap), string(aruba.IKEDPDActionClear), string(aruba.IKEDPDActionRestart),
+}
+
+var vpnESPPFSGroups = []string{
+	string(aruba.ESPPFSGroupEnable),
+	string(aruba.ESPPFSGroupDHGroup1), string(aruba.ESPPFSGroupDHGroup2), string(aruba.ESPPFSGroupDHGroup5),
+	string(aruba.ESPPFSGroupDHGroup14), string(aruba.ESPPFSGroupDHGroup15), string(aruba.ESPPFSGroupDHGroup16),
+	string(aruba.ESPPFSGroupDHGroup17), string(aruba.ESPPFSGroupDHGroup18),
+	string(aruba.ESPPFSGroupDHGroup19), string(aruba.ESPPFSGroupDHGroup20), string(aruba.ESPPFSGroupDHGroup21),
+	string(aruba.ESPPFSGroupDHGroup22), string(aruba.ESPPFSGroupDHGroup23), string(aruba.ESPPFSGroupDHGroup24),
+	string(aruba.ESPPFSGroupDHGroup25), string(aruba.ESPPFSGroupDHGroup26), string(aruba.ESPPFSGroupDHGroup27),
+	string(aruba.ESPPFSGroupDHGroup28), string(aruba.ESPPFSGroupDHGroup29), string(aruba.ESPPFSGroupDHGroup30),
+	string(aruba.ESPPFSGroupDHGroup31), string(aruba.ESPPFSGroupDHGroup32),
+	string(aruba.ESPPFSGroupDisable),
 }
 
 func vpnValidateEnum(value, flag string, valid []string) error {
@@ -149,11 +271,7 @@ func redactVPNTunnelSecrets(tunnels []types.VPNTunnelResponse) {
 	}
 }
 
-// Completion functions for network resources
-
 func completeVPNTunnelID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -165,20 +283,21 @@ func completeVPNTunnelID(cmd *cobra.Command, args []string, toComplete string) (
 	}
 
 	ctx := context.Background()
-	response, err := client.FromNetwork().VPNTunnels().List(ctx, projectID, nil)
+	list, err := client.FromNetwork().VPNTunnels().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, vpn := range response.Data.Values {
-			if vpn.Metadata.ID != nil && vpn.Metadata.Name != nil {
-				id := *vpn.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *vpn.Metadata.Name))
-				}
+	if list != nil {
+		for _, vpn := range list.Items() {
+			id := vpn.VPNTunnelID()
+			name := vpn.Name()
+			if id == "" {
+				continue
+			}
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
@@ -198,31 +317,24 @@ var vpntunnelListCmd = &cobra.Command{
 	Short: "List all VPN tunnels",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get projectID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// List VPN tunnels using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().VPNTunnels().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromNetwork().VPNTunnels().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing VPN tunnels: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing VPN tunnels: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
-			// Define table columns
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 40},
 				{Header: "ID", Width: 25},
@@ -230,39 +342,33 @@ var vpntunnelListCmd = &cobra.Command{
 				{Header: "TYPE", Width: 15},
 				{Header: "STATUS", Width: 15},
 			}
-			// Build rows
 			var rows [][]string
-			for _, vpn := range response.Data.Values {
-				name := ""
-				if vpn.Metadata.Name != nil && *vpn.Metadata.Name != "" {
-					name = *vpn.Metadata.Name
-				}
-
-				id := ""
-				if vpn.Metadata.ID != nil {
-					id = *vpn.Metadata.ID
-				}
-
+			for _, vpn := range list.Items() {
+				r := vpn.Raw()
+				name := vpn.Name()
+				id := vpn.VPNTunnelID()
 				region := ""
-				if vpn.Metadata.LocationResponse != nil {
-					region = vpn.Metadata.LocationResponse.Value
-				}
-
 				vpnType := ""
-				if vpn.Properties.VPNType != nil {
-					vpnType = *vpn.Properties.VPNType
-				}
-
 				status := ""
-				if vpn.Status.State != nil {
-					status = *vpn.Status.State
+				if r != nil {
+					if r.Metadata.LocationResponse != nil {
+						region = string(r.Metadata.LocationResponse.Value)
+					}
+					if r.Properties.VPNType != nil {
+						vpnType = string(*r.Properties.VPNType)
+					}
+					if r.Status.State != nil {
+						status = *r.Status.State
+					}
 				}
-
 				rows = append(rows, []string{name, id, region, vpnType, status})
 			}
 
-			redactVPNTunnelSecrets(response.Data.Values)
-			PrintOutput(response.Data, headers, rows)
+			payload := vpnTunnelListPayload(list)
+			if pl, ok := payload.(types.VPNTunnelList); ok {
+				redactVPNTunnelSecrets(pl.Values)
+			}
+			PrintOutput(payload, headers, rows)
 		} else {
 			fmt.Println("No VPN tunnels found")
 		}
@@ -277,33 +383,25 @@ var vpntunnelGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get VPN tunnel details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().VPNTunnels().Get(ctx, projectID, vpnID, nil)
+		got, err := client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(projectID, vpnID))
 		if err != nil {
-			return fmt.Errorf("getting VPN tunnel details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting VPN tunnel details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			vpn := response.Data
-
-			// Display VPN tunnel details
+		vpn := got.Raw()
+		if vpn != nil {
 			fmt.Println("\nVPN Tunnel Details:")
 			fmt.Println("===================")
 
@@ -321,10 +419,10 @@ var vpntunnelGetCmd = &cobra.Command{
 			}
 
 			if vpn.Properties.VPNType != nil {
-				fmt.Printf("VPN Type:        %s\n", *vpn.Properties.VPNType)
+				fmt.Printf("VPN Type:        %s\n", string(*vpn.Properties.VPNType))
 			}
 			if vpn.Properties.VPNClientProtocol != nil {
-				fmt.Printf("Protocol:        %s\n", *vpn.Properties.VPNClientProtocol)
+				fmt.Printf("Protocol:        %s\n", string(*vpn.Properties.VPNClientProtocol))
 			}
 			if vpn.Properties.VPNClientSettings != nil && vpn.Properties.VPNClientSettings.PeerClientPublicIP != nil {
 				fmt.Printf("Peer IP:         %s\n", *vpn.Properties.VPNClientSettings.PeerClientPublicIP)
@@ -346,8 +444,8 @@ var vpntunnelGetCmd = &cobra.Command{
 				}
 			}
 
-			if vpn.Properties.BillingPlan != nil {
-				fmt.Printf("\nBilling Period:  %s\n", vpn.Properties.BillingPlan.BillingPeriod)
+			if vpn.Properties.BillingPeriod != nil {
+				fmt.Printf("\nBilling Period:  %s\n", string(*vpn.Properties.BillingPeriod))
 			}
 
 			if vpn.Metadata.CreationDate != nil {
@@ -392,7 +490,6 @@ IKE and ESP settings are optional; the platform uses secure defaults when omitte
     --psk my-pre-shared-key`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
@@ -404,7 +501,7 @@ IKE and ESP settings are optional; the platform uses secure defaults when omitte
 		subnetName, _ := cmd.Flags().GetString("subnet-name")
 		publicIPURI, _ := cmd.Flags().GetString("elastic-ip-uri")
 		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		psk, _ := cmd.Flags().GetString("psk")
+		pskSecret, _ := cmd.Flags().GetString("psk")
 
 		// IKE settings
 		ikeLifetime, _ := cmd.Flags().GetInt32("ike-lifetime")
@@ -426,176 +523,126 @@ IKE and ESP settings are optional; the platform uses secure defaults when omitte
 		pskCloudSite, _ := cmd.Flags().GetString("psk-cloud-site")
 		pskOnpremSite, _ := cmd.Flags().GetString("psk-onprem-site")
 
-		// Validate mutual-exclusive subnet flags
 		if subnetCIDR == "" && subnetName == "" {
 			return fmt.Errorf("--subnet-cidr or --subnet-name is required")
 		}
 
-		// Validate enum fields client-side to surface typos before the API call.
 		for _, check := range []struct {
 			val   string
 			flag  string
 			valid []string
 		}{
-			{ikeEncryption, "ike-encryption", vpnEncryptionAlgorithms},
-			{ikeHash, "ike-hash", vpnHashAlgorithms},
-			{ikeDHGroup, "ike-dh-group", vpnDHGroups},
-			{ikeDPDAction, "ike-dpd-action", vpnDPDActions},
-			{espEncryption, "esp-encryption", vpnEncryptionAlgorithms},
-			{espHash, "esp-hash", vpnHashAlgorithms},
-			{espPFS, "esp-pfs", vpnPFSGroups},
+			{ikeEncryption, "ike-encryption", vpnIKEEncryptionAlgorithms},
+			{ikeHash, "ike-hash", vpnIKEHashAlgorithms},
+			{ikeDHGroup, "ike-dh-group", vpnIKEDHGroups},
+			{ikeDPDAction, "ike-dpd-action", vpnIKEDPDActions},
+			{espEncryption, "esp-encryption", vpnESPEncryptionAlgorithms},
+			{espHash, "esp-hash", vpnESPHashAlgorithms},
+			{espPFS, "esp-pfs", vpnESPPFSGroups},
 		} {
 			if err := vpnValidateEnum(check.val, check.flag, check.valid); err != nil {
 				return err
 			}
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build subnet object with both CIDR and Name fields
-		subnetRef := &types.SubnetInfo{}
-		if subnetCIDR != "" {
-			subnetRef.CIDR = subnetCIDR
-		}
-		if subnetName != "" {
-			subnetRef.Name = subnetName
-		}
-
-		// Build IP configurations
-		ipConfig := types.IPConfigurations{
-			VPC: &types.ReferenceResource{
-				URI: vpcURI,
-			},
-			Subnet: subnetRef,
-			PublicIP: &types.ReferenceResource{
-				URI: publicIPURI,
-			},
+		t := aruba.NewVPNTunnel().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			OfType(aruba.VPNType(vpnType)).
+			WithVPNClientProtocol(aruba.VPNClientProtocol(protocol)).
+			WithBillingPeriod(aruba.BillingPeriod(billingPeriod)).
+			WithPeerClientPublicIP(peerIP)
+		if len(tags) > 0 {
+			t.ReplaceTags(tags...)
 		}
 
-		// Build IKE settings
-		ikeSettings := &types.IKESettings{
-			Lifetime:    ikeLifetime,
-			Encryption:  nil,
-			Hash:        nil,
-			DHGroup:     nil,
-			DPDAction:   nil,
-			DPDInterval: ikeDPDInterval,
-			DPDTimeout:  ikeDPDTimeout,
+		ipc := aruba.NewVPNIPConfig().
+			WithVPC(aruba.URI(vpcURI)).
+			WithElasticIP(aruba.URI(publicIPURI))
+		if subnetCIDR != "" || subnetName != "" {
+			ipc.WithSubnet(subnetName, subnetCIDR)
 		}
+		t.WithIPConfig(ipc)
+
+		ike := aruba.NewVPNIKE().
+			WithLifetimeSeconds(int(ikeLifetime)).
+			WithDPDIntervalSeconds(int(ikeDPDInterval)).
+			WithDPDTimeoutSeconds(int(ikeDPDTimeout))
 		if ikeEncryption != "" {
-			ikeSettings.Encryption = &ikeEncryption
+			ike.WithEncryption(aruba.IKEEncryption(ikeEncryption))
 		}
 		if ikeHash != "" {
-			ikeSettings.Hash = &ikeHash
+			ike.WithHash(aruba.IKEHash(ikeHash))
 		}
 		if ikeDHGroup != "" {
-			ikeSettings.DHGroup = &ikeDHGroup
+			ike.WithDHGroup(aruba.IKEDHGroup(ikeDHGroup))
 		}
 		if ikeDPDAction != "" {
-			ikeSettings.DPDAction = &ikeDPDAction
+			ike.WithDPDAction(aruba.IKEDPDAction(ikeDPDAction))
 		}
+		t.WithIKESettings(ike)
 
-		// Build ESP settings
-		espSettings := &types.ESPSettings{
-			Lifetime:   espLifetime,
-			Encryption: &espEncryption, // always include, default to aes256
-			Hash:       nil,
-			PFS:        nil,
-		}
+		esp := aruba.NewVPNESP().
+			WithLifetimeSeconds(int(espLifetime)).
+			WithEncryption(aruba.ESPEncryption(espEncryption))
 		if espHash != "" {
-			espSettings.Hash = &espHash
+			esp.WithHash(aruba.ESPHash(espHash))
 		}
 		if espPFS != "" {
-			espSettings.PFS = &espPFS
+			esp.WithPFS(aruba.ESPPFSGroup(espPFS))
 		}
+		t.WithESPSettings(esp)
 
-		// Build PSK settings
-		pskSettings := &types.PSKSettings{
-			Secret:     nil,
-			CloudSite:  nil,
-			OnPremSite: nil,
-		}
-		if psk != "" {
-			pskSettings.Secret = &psk
+		pskB := aruba.NewVPNPSK()
+		if pskSecret != "" {
+			pskB.WithKey(pskSecret)
 		}
 		if pskCloudSite != "" {
-			pskSettings.CloudSite = &pskCloudSite
+			pskB.WithCloudSite(pskCloudSite)
 		}
 		if pskOnpremSite != "" {
-			pskSettings.OnPremSite = &pskOnpremSite
+			pskB.WithOnPremSite(pskOnpremSite)
 		}
+		t.WithPSKSettings(pskB)
 
-		// Build VPN client settings
-		vpnClientSettings := &types.VPNClientSettings{
-			IKE:                ikeSettings,
-			ESP:                espSettings,
-			PSK:                pskSettings,
-			PeerClientPublicIP: &peerIP,
-		}
-
-		// Build the create request using custom types that match the API
-		createRequest := types.VPNTunnelRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.VPNTunnelPropertiesRequest{
-				VPNType:           &vpnType,
-				VPNClientProtocol: &protocol,
-				IPConfigurations:  &ipConfig,
-				VPNClientSettings: vpnClientSettings,
-				BillingPlan: &types.BillingPeriodResource{
-					BillingPeriod: billingPeriod,
-				},
-			},
-		}
-
-		// Create the VPN tunnel using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromNetwork().VPNTunnels().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromNetwork().VPNTunnels().Create(ctx, t)
 		if err != nil {
-			return fmt.Errorf("creating VPN tunnel: %w", err)
+			return fmt.Errorf("creating VPN tunnel: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		r := created.Raw()
+		if r != nil {
 			fmt.Printf("\n%s\n", msgCreated("VPN Tunnel", name))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:       %s\n", *response.Data.Metadata.ID)
+			if r.Metadata.ID != nil {
+				fmt.Printf("ID:       %s\n", *r.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:     %s\n", *response.Data.Metadata.Name)
+			if r.Metadata.Name != nil {
+				fmt.Printf("Name:     %s\n", *r.Metadata.Name)
 			}
-			if response.Data.Metadata.URI != nil {
-				fmt.Printf("URI:      %s\n", *response.Data.Metadata.URI)
+			if r.Metadata.URI != nil {
+				fmt.Printf("URI:      %s\n", *r.Metadata.URI)
 			}
-			if response.Data.Properties.VPNType != nil {
-				fmt.Printf("Type:     %s\n", *response.Data.Properties.VPNType)
+			if r.Properties.VPNType != nil {
+				fmt.Printf("Type:     %s\n", string(*r.Properties.VPNType))
 			}
-			if response.Data.Properties.VPNClientProtocol != nil {
-				fmt.Printf("Protocol: %s\n", *response.Data.Properties.VPNClientProtocol)
+			if r.Properties.VPNClientProtocol != nil {
+				fmt.Printf("Protocol: %s\n", string(*r.Properties.VPNClientProtocol))
 			}
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:     %v\n", response.Data.Metadata.Tags)
+			if len(r.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:     %v\n", r.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("VPN Tunnel", name))
@@ -611,106 +658,65 @@ var vpntunnelUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one update flag must be provided
 		if name == "" && len(tags) == 0 {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
-		// Get project ID
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get Aruba Cloud client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get current VPN tunnel configuration
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResp, err := client.FromNetwork().VPNTunnels().Get(ctx, projectID, vpnTunnelID, nil)
+		cur, err := client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(projectID, vpnTunnelID))
 		if err != nil {
-			return fmt.Errorf("getting VPN tunnel: %w", err)
+			return fmt.Errorf("getting VPN tunnel: %w", apiErrFromV2(err))
 		}
 
-		if getResp != nil && getResp.IsError() {
-			return apiErrFromResp(getResp.StatusCode, getResp.Error)
-		}
-
-		if getResp.Data == nil {
+		r := cur.Raw()
+		if r == nil {
 			return fmt.Errorf("VPN tunnel not found")
 		}
-
-		// Check if VPN tunnel is in "InCreation" state
-		if getResp.Data.Status.State != nil && *getResp.Data.Status.State == StateInCreation {
+		if r.Status.State != nil && *r.Status.State == StateInCreation {
 			return fmt.Errorf("cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created")
 		}
 
-		// Get region value
-		regionValue := ""
-		if getResp.Data.Metadata.LocationResponse != nil {
-			regionValue = getResp.Data.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for VPN tunnel")
-		}
+		// Reattach IKE/ESP/PSK/IPConfig sub-builders before Update — fromResponse does
+		// not rehydrate sub-builders, so omitting this would drop them from the PUT body.
+		vpnTunnelReattachSettings(cur)
 
-		// Build update request, preserving current values
-		updateReq := types.VPNTunnelRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *getResp.Data.Metadata.Name,
-					Tags: getResp.Data.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.VPNTunnelPropertiesRequest{
-				VPNType:           getResp.Data.Properties.VPNType,
-				VPNClientProtocol: getResp.Data.Properties.VPNClientProtocol,
-				IPConfigurations:  getResp.Data.Properties.IPConfigurations,
-				VPNClientSettings: getResp.Data.Properties.VPNClientSettings,
-				// PeerClientPublicIP is now set via VPNClientSettings only
-				BillingPlan: getResp.Data.Properties.BillingPlan,
-			},
-		}
-
-		// Apply updates
 		if name != "" {
-			updateReq.Metadata.Name = name
+			cur.Named(name)
 		}
 		if len(tags) > 0 {
-			updateReq.Metadata.Tags = tags
+			cur.ReplaceTags(tags...)
 		}
 
-		// Update VPN tunnel
-		resp, err := client.FromNetwork().VPNTunnels().Update(ctx, projectID, vpnTunnelID, updateReq, nil)
+		updated, err := client.FromNetwork().VPNTunnels().Update(ctx, cur)
 		if err != nil {
-			return fmt.Errorf("updating VPN tunnel: %w", err)
+			return fmt.Errorf("updating VPN tunnel: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp.Data != nil {
+		ur := updated.Raw()
+		if ur != nil {
 			fmt.Printf("\n%s\n", msgUpdated("VPN Tunnel", vpnTunnelID))
-			if resp.Data.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *resp.Data.Metadata.ID)
+			if ur.Metadata.ID != nil {
+				fmt.Printf("ID:      %s\n", *ur.Metadata.ID)
 			}
-			if resp.Data.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *resp.Data.Metadata.Name)
+			if ur.Metadata.Name != nil {
+				fmt.Printf("Name:    %s\n", *ur.Metadata.Name)
 			}
-			if len(resp.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", resp.Data.Metadata.Tags)
+			if len(ur.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:    %v\n", ur.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("VPN Tunnel", vpnTunnelID))
@@ -726,10 +732,7 @@ var vpntunnelDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vpnTunnelID := args[0]
 
-		// Get skip confirmation flag
 		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		// Prompt for confirmation unless --yes flag is used
 		if !skipConfirm {
 			ok, err := confirmDelete("VPN tunnel", vpnTunnelID)
 			if err != nil {
@@ -740,13 +743,11 @@ var vpntunnelDeleteCmd = &cobra.Command{
 			}
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -757,22 +758,16 @@ var vpntunnelDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromNetwork().VPNTunnels().Get(ctx, projectID, vpnTunnelID, nil)
+			_, err = client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(projectID, vpnTunnelID))
 			if err != nil {
-				return fmt.Errorf("dry-run: VPN tunnel not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: VPN tunnel not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("VPN tunnel", vpnTunnelID))
 			return nil
 		}
 
-		// Delete the VPN tunnel using the SDK
-		response, err := client.FromNetwork().VPNTunnels().Delete(ctx, projectID, vpnTunnelID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting VPN tunnel: %w", err)
-		}
-
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		if err := client.FromNetwork().VPNTunnels().Delete(ctx, vpnTunnelRef(projectID, vpnTunnelID)); err != nil {
+			return fmt.Errorf("deleting VPN tunnel: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("VPN tunnel", vpnTunnelID))

--- a/cmd/network.vpntunnel_test.go
+++ b/cmd/network.vpntunnel_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,54 +11,49 @@ import (
 func TestVPNTunnelListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPNTunnelsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				id, name := "tun-001", "my-tunnel"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-					return &types.Response[types.VPNTunnelList]{
-						StatusCode: 200,
-						Data: &types.VPNTunnelList{
-							Values: []types.VPNTunnelResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelList{
+						Values: []types.VPNTunnelResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "tun-001") {
+				if !strings.Contains(out, "vpn-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-					return &types.Response[types.VPNTunnelList]{StatusCode: 200, Data: &types.VPNTunnelList{}}, nil
-				}
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				id, name := "tun-001", "my-tunnel"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-					return &types.Response[types.VPNTunnelList]{
-						StatusCode: 200,
-						Data: &types.VPNTunnelList{
-							Values: []types.VPNTunnelResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
+			name: "--output json emits valid JSON",
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelList{
+						Values: []types.VPNTunnelResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
-					}, nil
-				}
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +63,21 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-					return &types.Response[types.VPNTunnelList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +85,11 @@ func TestVPNTunnelListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNTunnelsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"network", "vpntunnel", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -114,13 +100,14 @@ func TestVPNTunnelListCmd(t *testing.T) {
 
 func TestVPNTunnelListCmd_RedactsPSKSecret(t *testing.T) {
 	const secret = "super-secret-psk-value"
-	id, name := "tun-001", "my-tunnel"
+	id, name := "vpn-001", "my-tunnel"
 	s := secret
-	m := &mockVPNTunnelsClient{
-		listFn: func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
-			return &types.Response[types.VPNTunnelList]{
-				StatusCode: 200,
-				Data: &types.VPNTunnelList{
+
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+				jsonResponse(200, types.VPNTunnelList{
 					Values: []types.VPNTunnelResponse{{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
 						Properties: types.VPNTunnelPropertiesResponse{
@@ -129,17 +116,10 @@ func TestVPNTunnelListCmd_RedactsPSKSecret(t *testing.T) {
 							},
 						},
 					}},
-				},
-			}, nil
-		},
-	}
-
-	for _, format := range []string{"json", "yaml"} {
-		t.Run(format, func(t *testing.T) {
+				}))
 			out := captureStdout(func() {
 				rootCmd.PersistentFlags().Set("output", format)
-				_ = runCmd(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})),
-					[]string{"network", "vpntunnel", "list", "--project-id", "proj-123"})
+				_ = runCmd(srv.Client(), []string{"network", "vpntunnel", "list", "--project-id", "proj-123"})
 				rootCmd.PersistentFlags().Set("output", "table")
 			})
 			if strings.Contains(out, secret) {
@@ -152,47 +132,44 @@ func TestVPNTunnelListCmd_RedactsPSKSecret(t *testing.T) {
 func TestVPNTunnelGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVPNTunnelsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				id, name := "tun-001", "my-tunnel"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return &types.Response[types.VPNTunnelResponse]{
-						StatusCode: 200,
-						Data:       &types.VPNTunnelResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			args: []string{"network", "vpntunnel", "get", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "tun-001") {
+				if !strings.Contains(out, "vpn-001") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"network", "vpntunnel", "get", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return &types.Response[types.VPNTunnelResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "API 404 propagates",
+			args: []string{"network", "vpntunnel", "get", "vpn-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -200,12 +177,11 @@ func TestVPNTunnelGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNTunnelsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})),
-				[]string{"network", "vpntunnel", "get", "tun-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -228,7 +204,7 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVPNTunnelsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -236,17 +212,15 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: baseArgs,
-			setupMock: func(m *mockVPNTunnelsClient) {
-				id, name := "tun-new", "my-tunnel"
-				m.createFn = func(_ context.Context, _ string, _ types.VPNTunnelRequest, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return &types.Response[types.VPNTunnelResponse]{
-						StatusCode: 200,
-						Data:       &types.VPNTunnelResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-new", "my-tunnel"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "tun-new") {
+				if !strings.Contains(out, "vpn-new") {
 					t.Errorf("expected ID in output, got: %s", out)
 				}
 			},
@@ -258,69 +232,228 @@ func TestVPNTunnelCreateCmd(t *testing.T) {
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
-			args: baseArgs,
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.VPNTunnelRequest, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
-			},
+			name:        "missing required flag --peer-ip",
+			args:        removeFlag(baseArgs, "--peer-ip", "1.2.3.4"),
 			wantErr:     true,
-			errContains: "creating",
+			errContains: "peer-ip",
 		},
 		{
-			name: "API error propagates",
-			args: baseArgs,
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.VPNTunnelRequest, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return &types.Response[types.VPNTunnelResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
-			},
+			name:        "missing required flag --vpc-uri",
+			args:        removeFlag(baseArgs, "--vpc-uri", "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"),
 			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			errContains: "vpc-uri",
 		},
 		{
 			name:        "rejects invalid --ike-encryption before API call",
-			args:        append(baseArgs, "--ike-encryption", "rot13"),
+			args:        append(append([]string(nil), baseArgs...), "--ike-encryption", "rot13"),
 			wantErr:     true,
 			errContains: `"rot13" is not a valid value`,
 		},
 		{
 			name:        "rejects invalid --ike-dpd-action before API call",
-			args:        append(baseArgs, "--ike-dpd-action", "explode"),
+			args:        append(append([]string(nil), baseArgs...), "--ike-dpd-action", "explode"),
 			wantErr:     true,
 			errContains: "is not a valid value",
 		},
 		{
 			name:        "rejects invalid --esp-pfs before API call",
-			args:        append(baseArgs, "--esp-pfs", "group99"),
+			args:        append(append([]string(nil), baseArgs...), "--esp-pfs", "group99"),
 			wantErr:     true,
 			errContains: "is not a valid value",
 		},
 		{
 			name: "accepts valid --ike-encryption without API error",
-			args: append(baseArgs, "--ike-encryption", types.VPNEncryptionAES256),
-			setupMock: func(m *mockVPNTunnelsClient) {
-				id, name := "tun-new", "my-tunnel"
-				m.createFn = func(_ context.Context, _ string, _ types.VPNTunnelRequest, _ *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error) {
-					return &types.Response[types.VPNTunnelResponse]{
-						StatusCode: 200,
-						Data:       &types.VPNTunnelResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+			args: append(append([]string(nil), baseArgs...), "--ike-encryption", "aes256"),
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-new", "my-tunnel"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
 			},
+		},
+		{
+			name: "server error propagates",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "creating",
+		},
+		{
+			name: "API 404 propagates",
+			args: baseArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNTunnelsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestVPNTunnelUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"network", "vpntunnel", "update", "vpn-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				updID, updName := "vpn-001", "new-name"
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpn-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "no fields provided returns error",
+			args:        []string{"network", "vpntunnel", "update", "vpn-001", "--project-id", "proj-123"},
+			setupSrv:    nil,
+			wantErr:     true,
+			errContains: "at least one",
+		},
+		{
+			name: "server error on update propagates",
+			args: []string{"network", "vpntunnel", "update", "vpn-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+						Status:   types.ResourceStatus{State: strPtr("Active")},
+					}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+		{
+			name: "API 404 on get propagates",
+			args: []string{"network", "vpntunnel", "update", "vpn-001", "--project-id", "proj-123", "--name", "new-name"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestVPNTunnelDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success with --yes",
+			args: []string{"network", "vpntunnel", "delete", "vpn-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					jsonResponse(200, nil))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpn-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run registers only GET",
+			args: []string{"network", "vpntunnel", "delete", "vpn-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					jsonResponse(200, types.VPNTunnelResponse{
+						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "vpn-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "server error propagates",
+			args: []string{"network", "vpntunnel", "delete", "vpn-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "deleting",
+		},
+		{
+			name: "API 404 propagates",
+			args: []string{"network", "vpntunnel", "delete", "vpn-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
+					errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -338,30 +471,28 @@ func TestVPNValidateEnum(t *testing.T) {
 		wantErr bool
 		errMsg  string
 	}{
-		{name: "empty value passes", value: "", flag: "ike-encryption", valid: vpnEncryptionAlgorithms},
-		{name: "valid encryption", value: types.VPNEncryptionAES256, flag: "ike-encryption", valid: vpnEncryptionAlgorithms},
-		{name: "valid hash", value: types.VPNHashSHA256, flag: "ike-hash", valid: vpnHashAlgorithms},
-		{name: "valid dh-group", value: types.VPNDHGroup14, flag: "ike-dh-group", valid: vpnDHGroups},
-		{name: "valid dpd-action", value: types.VPNDPDActionTrap, flag: "ike-dpd-action", valid: vpnDPDActions},
-		{name: "valid pfs-group", value: types.VPNPFSDHGroup14, flag: "esp-pfs", valid: vpnPFSGroups},
+		{name: "empty value passes", value: "", flag: "ike-encryption", valid: vpnIKEEncryptionAlgorithms},
+		{name: "valid IKE encryption", value: "aes256", flag: "ike-encryption", valid: vpnIKEEncryptionAlgorithms},
+		{name: "valid IKE hash", value: "sha256", flag: "ike-hash", valid: vpnIKEHashAlgorithms},
+		{name: "valid IKE dh-group", value: "14", flag: "ike-dh-group", valid: vpnIKEDHGroups},
+		{name: "valid IKE dpd-action", value: "trap", flag: "ike-dpd-action", valid: vpnIKEDPDActions},
+		{name: "valid ESP pfs", value: "enable", flag: "esp-pfs", valid: vpnESPPFSGroups},
+		{name: "valid ESP encryption", value: "aes256", flag: "esp-encryption", valid: vpnESPEncryptionAlgorithms},
+		{name: "valid ESP hash", value: "sha256", flag: "esp-hash", valid: vpnESPHashAlgorithms},
 		{
-			name: "invalid encryption rejected", value: "rot13", flag: "ike-encryption", valid: vpnEncryptionAlgorithms,
+			name: "invalid IKE encryption rejected", value: "rot13", flag: "ike-encryption", valid: vpnIKEEncryptionAlgorithms,
 			wantErr: true, errMsg: `--ike-encryption "rot13" is not a valid value`,
 		},
 		{
-			name: "invalid hash rejected", value: "crc32", flag: "ike-hash", valid: vpnHashAlgorithms,
+			name: "invalid IKE hash rejected", value: "crc32", flag: "ike-hash", valid: vpnIKEHashAlgorithms,
 			wantErr: true, errMsg: "--ike-hash",
 		},
 		{
-			name: "invalid dh-group rejected", value: "42", flag: "ike-dh-group", valid: vpnDHGroups,
-			wantErr: true, errMsg: "--ike-dh-group",
-		},
-		{
-			name: "invalid dpd-action rejected", value: "explode", flag: "ike-dpd-action", valid: vpnDPDActions,
+			name: "invalid dpd-action rejected", value: "explode", flag: "ike-dpd-action", valid: vpnIKEDPDActions,
 			wantErr: true, errMsg: "--ike-dpd-action",
 		},
 		{
-			name: "invalid pfs-group rejected", value: "group99", flag: "esp-pfs", valid: vpnPFSGroups,
+			name: "invalid esp-pfs rejected", value: "group99", flag: "esp-pfs", valid: vpnESPPFSGroups,
 			wantErr: true, errMsg: "--esp-pfs",
 		},
 	}
@@ -379,84 +510,6 @@ func TestVPNValidateEnum(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-			}
-		})
-	}
-}
-
-func TestVPNTunnelDeleteCmd(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupMock   func(*mockVPNTunnelsClient)
-		wantErr     bool
-		errContains string
-		assertOut   func(*testing.T, string)
-	}{
-		{
-			name: "success with --yes",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
-			},
-			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "tun-001") {
-					t.Errorf("expected ID in output, got: %s", out)
-				}
-			},
-		},
-		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
-			},
-			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "tun-001") {
-					t.Errorf("expected ID in dry-run output, got: %s", out)
-				}
-			},
-		},
-		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
-			},
-			wantErr:     true,
-			errContains: "deleting",
-		},
-		{
-			name: "API error propagates",
-			setupMock: func(m *mockVPNTunnelsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
-			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVPNTunnelsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
-			}
-			args := []string{"network", "vpntunnel", "delete", "tun-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withNetworkMock(&mockNetworkClient{vpnTunnelsMock: m})), args)
-			checkErr(t, err, tc.wantErr, tc.errContains)
-			if tc.assertOut != nil {
-				tc.assertOut(t, out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Migrates all 10 network command files (~73 SDK call sites) from the v0.1.x positional-ID API to the v0.2.0 fluent wrapper API (`pkg/aruba`)
- Rewrites all 10 `network.*_test.go` files onto the `arubaTestServer` httptest harness
- Updates `ai/ARCHITECTURE.md`, `ai/CONVENTIONS.md`, `ai/TECH_DEBT.md`

## Resources migrated

`vpc`, `subnet`, `securitygroup`, `securityrule`, `vpcpeering`, `vpcpeeringroute`, `elasticip`, `loadbalancer`, `vpntunnel`, `vpnroute`

## Key changes

- **Multi-level nested Refs**: file-local `<resource>Ref(...)` helpers hand-build full ancestry URIs; shared parent helpers (`vpcRef`, `securityGroupRef`, `vpcPeeringRef`, `vpnTunnelRef`) defined once and reused
- **Read-only `LoadBalancer`**: only `list`/`get` — no Create/Update/Delete, no builder
- **SecurityGroup create**: no `.InRegion()` (builder has no region setter); `--region` flag kept declared+required for CLI parity; dead region-guard in `update` dropped (behaviour-preserving)
- **`securityrule` update cross-resource VPC fallback**: when rule has no `LocationResponse`, falls back to fetching parent VPC's region
- **VPN crypto enums split IKE/ESP**: five unified slices replaced with seven per-direction slices (`vpnIKEEncryptionAlgorithms`, `vpnESPEncryptionAlgorithms`, etc.) built from `aruba.IKE*`/`aruba.ESP*` constants; accepted string values unchanged → CLI byte-identical
- **`vpnTunnelReattachSettings`**: reconstructs sub-builders from `cur.Raw().Properties.*` before `Update` because `VPNTunnel.fromResponse()` does not rehydrate IKE/ESP/PSK/IPConfig (highest-risk change — flagged for review)
- **`redactVPNTunnelSecrets`** preserved in `vpntunnel list`
- **`completeVPCPeeringRouteID`** made functional (v0.1.x route responses had no ID field; v0.2.0 wrapper exposes `.VPCPeeringRouteID()`)
- **`listParams`** → `listOpts(cmd)...` at all 10 list sites
- Unified `fmt.Errorf("<verb> <resource>: %w", apiErrFromV2(err))` at all error sites; no `response.IsError()` / `apiErrFromResp`

## Verification

- `gofmt -l cmd/network.*.go cmd/network.*_test.go` → empty (clean)
- `go vet ./cmd/` → no `network.*` diagnostics
- `go build ./cmd/` → no `network.*` errors
- `go build ./cmd` / `go test ./cmd` / `make test` remain red overall by design (families #105–#110 not yet migrated) — same posture as #102/#103
- `make e2e-network` requires live credentials; to be validated once the integration branch is complete

## Manual checklist

- [x] All ~73 network call sites on v0.2.0 wrapper API; `listOpts(cmd)...` everywhere
- [x] All 10 `<resource>Ref` + 10 `<resource>ListPayload` helpers; shared Ref helpers defined exactly once
- [x] Unified `apiErrFromV2` error wrapping; no `response.IsError()` / `apiErrFromResp`
- [x] `LoadBalancer` has no Create/Update/Delete; `SecurityGroup` create has no `.InRegion`
- [x] `securityrule` update cross-resource VPC `Get` via `vpcRef`
- [x] VPN enum slices rebuilt from `aruba.IKE*`/`aruba.ESP*`; `vpnTunnelReattachSettings` used in `vpntunnel update`; `redactVPNTunnelSecrets` preserved
- [x] `completeVPCPeeringRouteID` made functional
- [x] Tests on `arubaTestServer` harness; `checkErr`/`removeFlag` reused not redefined; `TestSplitRouteString`/`TestVPNValidateEnum` kept

Closes #104