### PR TITLE
feat(sdk): migrate storage family to SDK v0.2.0 wrapper API (#105)

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -57,7 +57,7 @@ client.FromProject().Delete(ctx, projectRef(id))   // → error
 
 // Project-scoped resources — wrapper built with IntoProject(projectRef):
 client.FromCompute().CloudServers().Get(ctx, ref)  // → (*aruba.CloudServer, error)
-client.FromStorage().BlockStorages().List(ctx, ...)// → (*aruba.List[*aruba.BlockStorage], error)
+client.FromStorage().Volumes().List(ctx, ...)      // → (*aruba.List[*aruba.BlockStorage], error)
 
 // Regional resources carry .InRegion(region) on the wrapper builder.
 // Zonal resources additionally carry .InZone(zone).
@@ -80,6 +80,46 @@ func cloudServerRef(projectID, serverID string) aruba.Ref {
         "/providers/Aruba.Compute/cloudServers/" + serverID)
 }
 ```
+
+**Storage family sub-clients and Refs** — The four storage sub-clients are
+`Volumes()`, `Snapshots()`, `Backups()`, `Restores()`. There is no `BlockStorages()`
+alias. Each file declares a file-local Ref helper:
+
+| Helper | Defined in | URI template |
+|---|---|---|
+| `volumeRef(pid, vid)` | `storage.blockstorage.go` | `/projects/<pid>/providers/Aruba.Storage/blockstorages/<vid>` |
+| `snapshotRef(pid, sid)` | `storage.snapshot.go` | `/projects/<pid>/providers/Aruba.Storage/snapshots/<sid>` |
+| `backupRef(pid, bid)` | `storage.backup.go` | `/projects/<pid>/providers/Aruba.Storage/backups/<bid>` |
+| `restoreRef(pid, bid, rid)` | `storage.restore.go` | `/projects/<pid>/providers/Aruba.Storage/backups/<bid>/restores/<rid>` |
+
+Note: path segments use **all-lowercase** (`blockstorages`, `snapshots`, `backups`,
+`restores`) matching `internal/clients/storage/path.go`.
+
+**Cross-family pre-validation** — `StorageBackup` Create fetches the source volume
+(`Volumes().Get(ctx, volumeRef(...))`) before building the backup wrapper. `StorageRestore`
+Create fetches both the parent backup (`Backups().Get`) **and** the target volume
+(`Volumes().Get`) before building the restore wrapper.
+
+**`StorageRestore` diverges from the project-scoped pattern** in two ways:
+- Builder uses `IntoBackup(bk)` (not `IntoProject`) — the backup Ref carries the project ID implicitly.
+- `Restores().List(ctx, backup Ref, ...)` is **backup-scoped**, not project-scoped.
+
+```go
+// Backup Create — cross-family pre-validation then builder:
+vol, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
+bk := aruba.NewStorageBackup().IntoProject(projectRef(projectID)).Named(name).
+    InRegion(aruba.Region(region)).OfType(aruba.StorageBackupType(t)).FromVolume(vol)
+
+// Restore Create — dual cross-family pre-validation:
+bk, err  := client.FromStorage().Backups().Get(ctx, backupRef(projectID, backupID))
+target, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
+rs := aruba.NewStorageRestore().IntoBackup(bk).Named(name).InRegion(aruba.Region(region)).ToVolume(target)
+
+// Restore List — backup-scoped:
+list, err := client.FromStorage().Restores().List(ctx, backupRef(projectID, backupID), listOpts(cmd)...)
+```
+
+All four storage wrappers' `Raw()` returns the **full** typed response (e.g. `*types.StorageBackupResponse`). No `RawHTTP()` re-parse is needed, unlike `*aruba.Project`.
 
 **Multi-level nested Refs (network family)** — VPC-scoped resources (Subnet,
 SecurityGroup, VPCPeering) require 3-segment Refs; deeper resources (SecurityRule,
@@ -352,13 +392,16 @@ func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string
     if err != nil { return nil, cobra.ShellCompDirectiveNoFileComp }
 
     ctx := context.Background()
-    response, err := client.FromStorage().Volumes().List(ctx, projectID, nil)
+    list, err := client.FromStorage().Volumes().List(ctx, projectRef(projectID))
     if err != nil { return nil, cobra.ShellCompDirectiveNoFileComp }
 
     var completions []string
-    for _, v := range response.Data.Values {
-        if v.Metadata.ID != nil && strings.HasPrefix(*v.Metadata.ID, toComplete) {
-            completions = append(completions, fmt.Sprintf("%s\t%s", *v.Metadata.ID, *v.Metadata.Name))
+    if list != nil {
+        for _, v := range list.Items() {
+            id := v.ID()
+            if toComplete == "" || strings.HasPrefix(id, toComplete) {
+                completions = append(completions, fmt.Sprintf("%s\t%s", id, v.Name()))
+            }
         }
     }
     return completions, cobra.ShellCompDirectiveNoFileComp

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -365,3 +365,70 @@ func TestMyCommand(t *testing.T) {
 - Unregistered routes cause `t.Errorf` (not a silent 404) — mis-keyed paths fail loudly.
 - `runCmd`/`runCmdCapture`/`resetCmdFlags`/`strPtr` helpers are unchanged; pass `srv.Client()` where the old code passed a `newMockClient(...)`.
 - Clear the client cache after each test (handled automatically by `runCmd` via `defer resetClientState()`).
+
+---
+
+## Storage-Specific Patterns
+
+The storage family has three patterns that diverge from the canonical command bodies above.
+
+### Cross-family pre-validation in Backup Create
+
+`StorageBackup.Create` requires a source volume. The file validates the volume exists
+before building the backup wrapper. The volume GET response **must** include a URI
+field so the SDK can carry it through the builder chain.
+
+```go
+// Pre-validate source volume (cross-family Get)
+vol, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
+if err != nil { return fmt.Errorf("getting volume: %w", apiErrFromV2(err)) }
+
+bk := aruba.NewStorageBackup().
+    IntoProject(projectRef(projectID)).
+    Named(name).
+    InRegion(aruba.Region(region)).
+    WithBillingPeriod(aruba.BillingPeriod(billingPeriod)).
+    FromVolume(vol)
+if retentionDays > 0 { bk.WithRetentionDays(int(retentionDays)) }
+
+created, err := client.FromStorage().Backups().Create(ctx, bk)
+if err != nil { return fmt.Errorf("creating backup: %w", apiErrFromV2(err)) }
+```
+
+### Restore Create: dual cross-family Gets + IntoBackup/ToVolume
+
+`StorageRestore` is parented on a Backup (not a project). Use `IntoBackup(bk)` (not
+`IntoProject`) — it extracts projectID and backupID from the backup's URI. Both the
+backup GET and volume GET responses **must** include a URI field. `ToVolume(target)`
+extracts the URI from the volume wrapper.
+
+```go
+// Pre-validate parent backup AND target volume
+bk, err := client.FromStorage().Backups().Get(ctx, backupRef(projectID, backupID))
+if err != nil { return fmt.Errorf("getting backup: %w", apiErrFromV2(err)) }
+target, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
+if err != nil { return fmt.Errorf("getting volume: %w", apiErrFromV2(err)) }
+
+rs := aruba.NewStorageRestore().
+    IntoBackup(bk).       // parents on backup, NOT IntoProject(...)
+    Named(name).
+    InRegion(aruba.Region(region)).
+    ToVolume(target)
+
+created, err := client.FromStorage().Restores().Create(ctx, rs)
+if err != nil { return fmt.Errorf("creating restore: %w", apiErrFromV2(err)) }
+```
+
+### Restore List: backup-scoped (not project-scoped)
+
+Unlike all other storage resources, `StorageRestoreClient.List` takes a **backup Ref**
+as its first argument, not a project Ref.
+
+```go
+// Use backupRef(projectID, backupID), NOT projectRef(projectID)
+list, err := client.FromStorage().Restores().List(ctx, backupRef(projectID, backupID), listOpts(cmd)...)
+if err != nil { return fmt.Errorf("listing restores: %w", apiErrFromV2(err)) }
+```
+
+In tests, register the list route under the backup-scoped path:
+`/projects/{p}/providers/Aruba.Storage/backups/{bid}/restores`

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -44,11 +44,12 @@ Issues are grouped by severity. Address Critical items before new features ship;
 ### TD-022 · Pre-release SDK version (v0.1.x → v0.2.0 migration in progress)
 `go.mod` now depends on `github.com/Arubacloud/sdk-go v0.2.0`. Migration status:
 - #100 (shared helpers), #101 (`arubaTestServer` harness), #102 (`management.project`), #103 (`compute`: cloudserver + keypair), #104 (`network` family: 10 resources) — all merged onto `feat/sdk-v0.2.0-upgrade`.
-- #105–#110 (storage, database, container, kms, other families) — still open.
+- #105 (storage family: blockstorage, snapshot, backup, restore) — merged onto `feat/sdk-v0.2.0-upgrade`.
+- #106–#110, #111 (database, container, kms, other families) — still open.
 
-`go build ./cmd` remains red until #105–#110 land. `make e2e-network` requires live credentials (validated after integration branch complete).
+`go build ./cmd` remains red until #106–#110 land. `make e2e-network` requires live credentials (validated after integration branch complete).
 
-**Fix:** Close out #99's exit criteria (#105–#110 + #111), then mark TD-022 resolved.
+**Fix:** Close out #99's exit criteria (#106–#110 + #111), then mark TD-022 resolved.
 
 ---
 

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -2,16 +2,33 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func backupRef(projectID, backupID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/backups/" + backupID)
+}
 
+func backupFromRaw(b *aruba.StorageBackup) *types.StorageBackupResponse {
+	if b == nil {
+		return nil
+	}
+	return b.Raw()
+}
+
+func backupListPayload(l *aruba.List[*aruba.StorageBackup]) any {
+	if r, ok := l.Raw().(*types.Response[types.StorageBackupList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
+func init() {
 	// Backup commands
 	storageCmd.AddCommand(storageBackupCmd)
 	storageBackupCmd.AddCommand(storageBackupListCmd)
@@ -46,11 +63,7 @@ func init() {
 	storageBackupDeleteCmd.ValidArgsFunction = completeBackupID
 }
 
-// Completion functions for storage resources
-
 func completeBackupID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -62,20 +75,17 @@ func completeBackupID(cmd *cobra.Command, args []string, toComplete string) ([]s
 	}
 
 	ctx := context.Background()
-	response, err := client.FromStorage().Backups().List(ctx, projectID, nil)
+	list, err := client.FromStorage().Backups().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, backup := range response.Data.Values {
-			if backup.Metadata.ID != nil && backup.Metadata.Name != nil {
-				id := *backup.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *backup.Metadata.Name))
-				}
+	if list != nil {
+		for _, b := range list.Items() {
+			id := b.ID()
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, b.Name()))
 			}
 		}
 	}
@@ -83,7 +93,6 @@ func completeBackupID(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
-// Backup command - creates an Aruba.Storage/backup resource
 var storageBackupCmd = &cobra.Command{
 	Use:   "backup [volume-id]",
 	Short: "Create a storage backup of a block storage volume",
@@ -99,78 +108,38 @@ Billing period: Hour (default), Month, or Year.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		backupType, _ := cmd.Flags().GetString("type")
 		retentionDays, _ := cmd.Flags().GetInt("retention-days")
 		billingPeriod, _ := cmd.Flags().GetString("billing-period")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
+		verbose, _ := cmd.Flags().GetBool("verbose")
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the volume details to get the full URI
 		ctx, cancel := newCtx()
 		defer cancel()
-		volumeResponse, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
+
+		vol, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
 		if err != nil {
-			return fmt.Errorf("getting volume details: %w", err)
+			return fmt.Errorf("getting volume details: %w", apiErrFromV2(err))
 		}
 
-		if volumeResponse == nil || volumeResponse.Data == nil {
-			return fmt.Errorf("volume not found")
-		}
-
-		volumeURI := *volumeResponse.Data.Metadata.URI
-
-		// Build the backup create request
-		createRequest := types.StorageBackupRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.StorageBackupPropertiesRequest{
-				StorageBackupType: types.StorageBackupType(backupType),
-				Origin: types.ReferenceResource{
-					URI: volumeURI,
-				},
-			},
-		}
-
-		// Add optional fields
-		if retentionDays > 0 {
-			createRequest.Properties.RetentionDays = &retentionDays
-		}
-		if billingPeriod != "" {
-			createRequest.Properties.BillingPeriod = &billingPeriod
-		}
-
-		// Get verbose flag
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("Creating storage backup with the following parameters:")
 			fmt.Printf("  Name:           %s\n", name)
 			fmt.Printf("  Type:           %s\n", backupType)
 			fmt.Printf("  Region:         %s\n", region)
 			fmt.Printf("  Volume ID:      %s\n", volumeID)
-			fmt.Printf("  Volume URI:     %s\n", volumeURI)
 			if retentionDays > 0 {
 				fmt.Printf("  Retention Days: %d\n", retentionDays)
 			}
@@ -183,34 +152,47 @@ Billing period: Hour (default), Month, or Year.`,
 			fmt.Println()
 		}
 
-		// Create the backup using the SDK
-		response, err := client.FromStorage().Backups().Create(ctx, projectID, createRequest, nil)
+		bk := aruba.NewStorageBackup().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			OfType(aruba.StorageBackupType(backupType)).
+			FromVolume(vol)
+		if retentionDays > 0 {
+			bk.WithRetentionDays(retentionDays)
+		}
+		if billingPeriod != "" {
+			bk.WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+		}
+		if len(tags) > 0 {
+			bk.ReplaceTags(tags...)
+		}
+
+		created, err := client.FromStorage().Backups().Create(ctx, bk)
 		if err != nil {
-			return fmt.Errorf("creating backup: %w", err)
+			return fmt.Errorf("creating backup: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			if verbose {
-				jsonData, _ := json.MarshalIndent(response.Error, "", "  ")
-				fmt.Printf("Full Error Response:\n%s\n", string(jsonData))
-			}
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response.Data != nil {
+		resource := backupFromRaw(created)
+		if resource != nil {
 			fmt.Println(msgCreated("Storage backup", name))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			fmt.Printf("Type:            %s\n", response.Data.Properties.Type)
-			if response.Data.Metadata.CreationDate != nil && !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
+			}
+			fmt.Printf("Type:            %s\n", resource.Properties.Type)
+			if resource.Metadata.CreationDate != nil && !resource.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", resource.Metadata.CreationDate.Format(DateLayout))
+			}
+		} else {
+			fmt.Println(msgCreatedAsync("Storage backup", name))
 		}
 		return nil
 	},
 }
 
-// Backup List command
 var storageBackupListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List storage backups",
@@ -228,15 +210,12 @@ var storageBackupListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Backups().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromStorage().Backups().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing backups: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -245,28 +224,12 @@ var storageBackupListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, backup := range response.Data.Values {
-				name := ""
-				if backup.Metadata.Name != nil {
-					name = *backup.Metadata.Name
-				}
-
-				id := ""
-				if backup.Metadata.ID != nil {
-					id = *backup.Metadata.ID
-				}
-
-				backupType := string(backup.Properties.Type)
-
-				status := ""
-				if backup.Status.State != nil {
-					status = *backup.Status.State
-				}
-
-				rows = append(rows, []string{name, id, backupType, status})
+			for _, b := range list.Items() {
+				backupTypeStr := string(b.Type())
+				rows = append(rows, []string{b.Name(), b.ID(), backupTypeStr, b.State()})
 			}
 
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(backupListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No backups found")
 		}
@@ -274,7 +237,6 @@ var storageBackupListCmd = &cobra.Command{
 	},
 }
 
-// Backup Get command
 var storageBackupGetCmd = &cobra.Command{
 	Use:   "get [backup-id]",
 	Short: "Get storage backup details",
@@ -294,16 +256,18 @@ var storageBackupGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
+		got, err := client.FromStorage().Backups().Get(ctx, backupRef(projectID, backupID))
 		if err != nil {
-			return fmt.Errorf("getting backup details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting backup details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			backup := response.Data
+		backup := backupFromRaw(got)
+		if backup != nil {
+			format := resolveOutputFormat()
+			if format == OutputFormatJSON || format == OutputFormatYAML {
+				PrintOutput(backup, nil, nil)
+				return nil
+			}
 
 			fmt.Println("\nStorage Backup Details:")
 			fmt.Println("=======================")
@@ -317,37 +281,28 @@ var storageBackupGetCmd = &cobra.Command{
 			if backup.Metadata.Name != nil {
 				fmt.Printf("Name:            %s\n", *backup.Metadata.Name)
 			}
-
 			fmt.Printf("Type:            %s\n", backup.Properties.Type)
-
 			if backup.Properties.Origin.URI != "" {
 				fmt.Printf("Source Volume:   %s\n", backup.Properties.Origin.URI)
 			}
-
 			if backup.Properties.RetentionDays != nil {
 				fmt.Printf("Retention Days:  %d\n", *backup.Properties.RetentionDays)
 			}
-
 			if backup.Properties.BillingPeriod != nil {
 				fmt.Printf("Billing Period:  %s\n", *backup.Properties.BillingPeriod)
 			}
-
 			if backup.Metadata.LocationResponse != nil {
 				fmt.Printf("Region:          %s\n", backup.Metadata.LocationResponse.Value)
 			}
-
 			if backup.Status.State != nil {
 				fmt.Printf("Status:          %s\n", *backup.Status.State)
 			}
-
 			if backup.Metadata.CreationDate != nil && !backup.Metadata.CreationDate.IsZero() {
 				fmt.Printf("Creation Date:   %s\n", backup.Metadata.CreationDate.Format(DateLayout))
 			}
-
 			if backup.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *backup.Metadata.CreatedBy)
 			}
-
 			if len(backup.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", backup.Metadata.Tags)
 			} else {
@@ -360,7 +315,6 @@ var storageBackupGetCmd = &cobra.Command{
 	},
 }
 
-// Backup Update command
 var storageBackupUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id]",
 	Short: "Update a storage backup (name and/or tags)",
@@ -373,11 +327,9 @@ var storageBackupUpdateCmd = &cobra.Command{
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
@@ -387,81 +339,40 @@ var storageBackupUpdateCmd = &cobra.Command{
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current backup details
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
+		current, err := client.FromStorage().Backups().Get(ctx, backupRef(projectID, backupID))
 		if err != nil {
-			return fmt.Errorf("getting backup details: %w", err)
+			return fmt.Errorf("getting backup details: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
+		if current.Raw() == nil {
 			return fmt.Errorf("backup not found")
 		}
 
-		currentBackup := getResponse.Data
-
-		// Get region value
-		regionValue := ""
-		if currentBackup.Metadata.LocationResponse != nil {
-			regionValue = currentBackup.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for backup")
-		}
-
-		// Build the update request with current values as defaults
-		updateRequest := types.StorageBackupRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *currentBackup.Metadata.Name,
-					Tags: currentBackup.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.StorageBackupPropertiesRequest{
-				StorageBackupType: currentBackup.Properties.Type,
-				Origin: types.ReferenceResource{
-					URI: currentBackup.Properties.Origin.URI,
-				},
-			},
-		}
-
-		// Add optional fields if present
-		if currentBackup.Properties.RetentionDays != nil {
-			updateRequest.Properties.RetentionDays = currentBackup.Properties.RetentionDays
-		}
-		if currentBackup.Properties.BillingPeriod != nil {
-			updateRequest.Properties.BillingPeriod = currentBackup.Properties.BillingPeriod
-		}
-
-		// Update only the fields that were provided
 		if name != "" {
-			updateRequest.Metadata.ResourceMetadataRequest.Name = name
+			current.Named(name)
 		}
-
 		if cmd.Flags().Changed("tags") {
-			updateRequest.Metadata.ResourceMetadataRequest.Tags = tags
+			current.ReplaceTags(tags...)
 		}
 
-		// Update the backup using the SDK
-		response, err := client.FromStorage().Backups().Update(ctx, projectID, backupID, updateRequest, nil)
+		updated, err := client.FromStorage().Backups().Update(ctx, current)
 		if err != nil {
-			return fmt.Errorf("updating backup: %w", err)
+			return fmt.Errorf("updating backup: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := backupFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Backup", backupID))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", response.Data.Metadata.Tags)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
+			}
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
+			}
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("Backup", backupID))
@@ -470,7 +381,6 @@ var storageBackupUpdateCmd = &cobra.Command{
 	},
 }
 
-// Backup Delete command
 var storageBackupDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id]",
 	Short: "Delete a storage backup",
@@ -478,13 +388,8 @@ var storageBackupDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if !skipConfirm {
 			ok, err := confirmDelete("backup", backupID)
 			if err != nil {
 				return err
@@ -492,6 +397,11 @@ var storageBackupDeleteCmd = &cobra.Command{
 			if !ok {
 				return nil
 			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
@@ -504,20 +414,16 @@ var storageBackupDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
+			_, err = client.FromStorage().Backups().Get(ctx, backupRef(projectID, backupID))
 			if err != nil {
-				return fmt.Errorf("dry-run: storage backup not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: storage backup not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("storage backup", backupID))
 			return nil
 		}
 
-		deleteResp, err := client.FromStorage().Backups().Delete(ctx, projectID, backupID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting backup: %w", err)
-		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+		if err := client.FromStorage().Backups().Delete(ctx, backupRef(projectID, backupID)); err != nil {
+			return fmt.Errorf("deleting backup: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Backup", backupID))

--- a/cmd/storage.backup_test.go
+++ b/cmd/storage.backup_test.go
@@ -1,40 +1,21 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
-// storage backup create uses storageBackupCmd directly (no separate "create" subcommand).
-// Invocation: storage backup [volume-id] --name <name> ...
-
-// newStorageBackupCreateMock wires a mockStorageClient for the backup create
-// flow, which first fetches the volume (to get its URI) then calls
-// Backups().Create(). Both sub-clients must be set.
-func newStorageBackupCreateMock(backupFn func(context.Context, string, types.StorageBackupRequest, *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)) *mockStorageClient {
-	volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
-	volumes := &mockVolumesClient{
-		getFn: func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-			return &types.Response[types.BlockStorageResponse]{
-				StatusCode: 200,
-				Data:       &types.BlockStorageResponse{Metadata: types.ResourceMetadataResponse{URI: &volURI}},
-			}, nil
-		},
-	}
-	return &mockStorageClient{volumesMock: volumes, backupsMock: &mockStorageBackupsClient{createFn: backupFn}}
-}
-
 func TestStorageBackupCreateCmd(t *testing.T) {
 	createArgs := []string{"storage", "backup", "vol-001", "--project-id", "proj-123", "--name", "my-backup"}
+	volURI := "/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001"
+
 	tests := []struct {
 		name        string
 		args        []string
-		storageMock *mockStorageClient
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -42,13 +23,17 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: createArgs,
-			storageMock: newStorageBackupCreateMock(func(_ context.Context, _ string, _ types.StorageBackupRequest, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-				id, sname := "bkp-new", "my-backup"
-				return &types.Response[types.StorageBackupResponse]{
-					StatusCode: 200,
-					Data:       &types.StorageBackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
-				}, nil
-			}),
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-new", "my-backup"
+				// Pre-validation: GET volume
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &volURI},
+				}))
+				// Create: POST backup
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-new") {
 					t.Errorf("expected ID in output, got: %s", out)
@@ -62,34 +47,43 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
+			name: "volume pre-validation error propagates",
 			args: createArgs,
-			storageMock: newStorageBackupCreateMock(func(_ context.Context, _ string, _ types.StorageBackupRequest, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-				return nil, fmt.Errorf("quota exceeded")
-			}),
-			wantErr:     true,
-			errContains: "creating",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", errorResponse(404, "Not Found", "volume not found"))
+			},
+			wantErr: true, errContains: "getting volume",
 		},
 		{
 			name: "API error propagates",
 			args: createArgs,
-			storageMock: newStorageBackupCreateMock(func(_ context.Context, _ string, _ types.StorageBackupRequest, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-				return &types.Response[types.StorageBackupResponse]{
-					StatusCode: 404,
-					Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-				}, nil
-			}),
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &volURI},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr: true, errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "server error propagates",
+			args: createArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &volURI},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr: true, errContains: "creating",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sm := tc.storageMock
-			if sm == nil {
-				sm = &mockStorageClient{}
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(sm)), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -101,25 +95,22 @@ func TestStorageBackupCreateCmd(t *testing.T) {
 func TestStorageBackupListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockStorageBackupsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockStorageBackupsClient) {
-				id, sname := "bkp-001", "my-backup"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
-					return &types.Response[types.StorageBackupList]{
-						StatusCode: 200,
-						Data: &types.StorageBackupList{
-							Values: []types.StorageBackupResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
-							},
-						},
-					}, nil
-				}
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+					Values: []types.StorageBackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -129,26 +120,21 @@ func TestStorageBackupListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
-					return &types.Response[types.StorageBackupList]{StatusCode: 200, Data: &types.StorageBackupList{}}, nil
-				}
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{}))
 			},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockStorageBackupsClient) {
-				id, sname := "bkp-001", "my-backup"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
-					return &types.Response[types.StorageBackupList]{
-						StatusCode: 200,
-						Data: &types.StorageBackupList{
-							Values: []types.StorageBackupResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
-							},
-						},
-					}, nil
-				}
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+					Values: []types.StorageBackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -158,40 +144,29 @@ func TestStorageBackupListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "listing",
+			wantErr: true, errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
-					return &types.Response[types.StorageBackupList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockStorageBackupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"storage", "backup", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -203,21 +178,18 @@ func TestStorageBackupListCmd(t *testing.T) {
 func TestStorageBackupGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockStorageBackupsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockStorageBackupsClient) {
-				id, sname := "bkp-001", "my-backup"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-					return &types.Response[types.StorageBackupResponse]{
-						StatusCode: 200,
-						Data:       &types.StorageBackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &sname}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -226,36 +198,27 @@ func TestStorageBackupGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "getting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-					return &types.Response[types.StorageBackupResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "getting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockStorageBackupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})),
+			out, err := runCmdCapture(srv.Client(),
 				[]string{"storage", "backup", "get", "bkp-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
@@ -268,17 +231,16 @@ func TestStorageBackupGetCmd(t *testing.T) {
 func TestStorageBackupDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockStorageBackupsClient)
+		setupSrv    func(*arubaTestServer)
+		extraArgs   []string
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -287,12 +249,13 @@ func TestStorageBackupDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name:      "--dry-run: prints intent, does not call Delete",
+			extraArgs: []string{"--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -301,40 +264,29 @@ func TestStorageBackupDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "deleting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockStorageBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "deleting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockStorageBackupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
 			args := []string{"storage", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{backupsMock: m})), args)
+			args = append(args, tc.extraArgs...)
+			out, err := runCmdCapture(srv.Client(), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -5,9 +5,28 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+func volumeRef(projectID, volumeID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/blockstorages/" + volumeID)
+}
+
+func volumeFromRaw(b *aruba.BlockStorage) *types.BlockStorageResponse {
+	if b == nil {
+		return nil
+	}
+	return b.Raw()
+}
+
+func volumeListPayload(l *aruba.List[*aruba.BlockStorage]) any {
+	if r, ok := l.Raw().(*types.Response[types.BlockStorageList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
 
 func init() {
 	blockstorageCreateCmd.Flags().String("snapshot-uri", "", "URI of the snapshot to use (optional)")
@@ -54,14 +73,9 @@ func init() {
 	blockstorageGetCmd.ValidArgsFunction = completeBlockStorageID
 	blockstorageUpdateCmd.ValidArgsFunction = completeBlockStorageID
 	blockstorageDeleteCmd.ValidArgsFunction = completeBlockStorageID
-
 }
 
-// Completion functions for storage resources
-
 func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -73,20 +87,17 @@ func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string
 	}
 
 	ctx := context.Background()
-	response, err := client.FromStorage().Volumes().List(ctx, projectID, nil)
+	list, err := client.FromStorage().Volumes().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, volume := range response.Data.Values {
-			if volume.Metadata.ID != nil && volume.Metadata.Name != nil {
-				id := *volume.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *volume.Metadata.Name))
-				}
+	if list != nil {
+		for _, v := range list.Items() {
+			id := v.ID()
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, v.Name()))
 			}
 		}
 	}
@@ -94,7 +105,6 @@ func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
-// Blockstorage subcommands
 var blockstorageCmd = &cobra.Command{
 	Use:   "blockstorage",
 	Short: "Manage block storage",
@@ -120,13 +130,11 @@ Billing period: Hour (default), Month, or Year.`,
     --snapshot-uri /projects/<proj-id>/providers/Aruba.Storage/blockStorages/<vol-id>/snapshots/<snap-id>`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		zone, _ := cmd.Flags().GetString("zone")
@@ -137,61 +145,17 @@ Billing period: Hour (default), Month, or Year.`,
 		snapshotURI, _ := cmd.Flags().GetString("snapshot-uri")
 		setBootable, _ := cmd.Flags().GetBool("set-bootable")
 		image, _ := cmd.Flags().GetString("image")
+		verbose, _ := cmd.Flags().GetBool("verbose")
 
-		// Validate required fields
 		if size <= 0 {
 			return fmt.Errorf("--size must be greater than 0")
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		createRequest := types.BlockStorageRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.BlockStoragePropertiesRequest{
-				SizeGB:        size,
-				BillingPeriod: billingPeriod,
-				Type:          types.BlockStorageType(volumeType),
-			},
-		}
-
-		// Add zone only if provided
-		if zone != "" {
-			createRequest.Properties.Zone = &zone
-		}
-
-		// Add snapshot if provided
-		if snapshotURI != "" {
-			createRequest.Properties.Snapshot = &types.ReferenceResource{URI: snapshotURI}
-		}
-
-		// Add bootable if --set-bootable is provided (always true)
-		if setBootable {
-			bootable := true
-			createRequest.Properties.Bootable = &bootable
-		}
-
-		// Add image if provided
-		if image != "" {
-			createRequest.Properties.Image = &image
-		}
-
-		// Get verbose flag
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("\nCreating block storage with the following parameters:")
 			fmt.Printf("  Name:           %s\n", name)
@@ -215,36 +179,56 @@ Billing period: Hour (default), Month, or Year.`,
 			fmt.Println()
 		}
 
-		// Create the block storage using the SDK
+		vol := aruba.NewBlockStorage().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			OfType(aruba.BlockStorageType(volumeType)).
+			WithSizeGB(size).
+			WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+		if zone != "" {
+			vol.InZone(aruba.Zone(zone))
+		}
+		if len(tags) > 0 {
+			vol.ReplaceTags(tags...)
+		}
+		if setBootable {
+			vol.SetBootable()
+		}
+		if image != "" {
+			vol.FromImage(image)
+		}
+		if snapshotURI != "" {
+			vol.FromSnapshot(aruba.URI(snapshotURI))
+		}
+
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Volumes().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromStorage().Volumes().Create(ctx, vol)
 		if err != nil {
-			return fmt.Errorf("creating block storage: %w", err)
+			return fmt.Errorf("creating block storage: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			if response.Error != nil {
-				return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
-			}
-			return fmt.Errorf("API error (status %d)", response.StatusCode)
-		}
-
-		if response.Data != nil {
+		resource := volumeFromRaw(created)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgCreated("Block storage", name))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			fmt.Printf("Size (GB):       %d\n", response.Data.Properties.SizeGB)
-			fmt.Printf("Type:            %s\n", response.Data.Properties.Type)
-			fmt.Printf("Zone:            %s\n", response.Data.Properties.Zone)
-			if response.Data.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", response.Data.Metadata.LocationResponse.Value)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			if response.Data.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *response.Data.Status.State)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
-			if response.Data.Metadata.CreationDate != nil && !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
+			fmt.Printf("Size (GB):       %d\n", resource.Properties.SizeGB)
+			fmt.Printf("Type:            %s\n", resource.Properties.Type)
+			fmt.Printf("Zone:            %s\n", resource.Properties.Zone)
+			if resource.Metadata.LocationResponse != nil {
+				fmt.Printf("Region:          %s\n", resource.Metadata.LocationResponse.Value)
+			}
+			if resource.Status.State != nil {
+				fmt.Printf("Status:          %s\n", *resource.Status.State)
+			}
+			if resource.Metadata.CreationDate != nil && !resource.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", resource.Metadata.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("Block storage", name))
@@ -260,78 +244,66 @@ var blockstorageGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get block storage details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
+		got, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
 		if err != nil {
-			return fmt.Errorf("getting block storage details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting block storage details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			volume := response.Data
+		volume := volumeFromRaw(got)
+		if volume != nil {
+			format := resolveOutputFormat()
+			if format == OutputFormatJSON || format == OutputFormatYAML {
+				PrintOutput(volume, nil, nil)
+				return nil
+			}
 
-			// Display volume details
 			fmt.Println("\nBlock Storage Details:")
 			fmt.Println("======================")
 
 			if volume.Metadata.ID != nil {
 				fmt.Printf("ID:              %s\n", *volume.Metadata.ID)
 			}
-
 			if volume.Metadata.URI != nil {
 				fmt.Printf("URI:             %s\n", *volume.Metadata.URI)
 			}
-
 			if volume.Metadata.Name != nil {
 				fmt.Printf("Name:            %s\n", *volume.Metadata.Name)
 			}
-
 			fmt.Printf("Size (GB):       %d\n", volume.Properties.SizeGB)
 			fmt.Printf("Type:            %s\n", volume.Properties.Type)
 			fmt.Printf("Zone:            %s\n", volume.Properties.Zone)
-
 			if volume.Metadata.LocationResponse != nil {
 				fmt.Printf("Region:          %s\n", volume.Metadata.LocationResponse.Value)
 			}
-
 			if volume.Properties.Bootable != nil {
 				fmt.Printf("Bootable:        %t\n", *volume.Properties.Bootable)
 			}
-
 			if volume.Status.State != nil {
 				fmt.Printf("Status:          %s\n", *volume.Status.State)
 			}
-
 			if volume.Metadata.CreationDate != nil && !volume.Metadata.CreationDate.IsZero() {
 				fmt.Printf("Creation Date:   %s\n", volume.Metadata.CreationDate.Format(DateLayout))
 			}
-
 			if volume.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *volume.Metadata.CreatedBy)
 			}
-
 			if len(volume.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", volume.Metadata.Tags)
 			} else {
 				fmt.Printf("Tags:            []\n")
 			}
-
 			fmt.Println()
 		} else {
 			fmt.Println("Block storage not found")
@@ -347,117 +319,67 @@ var blockstorageUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
 			fmt.Println("Error: at least one of --name or --tags must be provided")
 			fmt.Println("Note: Size update is not supported by the API yet")
 			return nil
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current volume details to preserve existing values
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
+		current, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
 		if err != nil {
-			return fmt.Errorf("getting block storage details: %w", err)
+			return fmt.Errorf("getting block storage details: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
+		if current.Raw() == nil {
 			fmt.Println("Block storage not found")
 			return nil
 		}
 
-		currentVolume := getResponse.Data
-
-		// Check if the volume status allows updates
-		if currentVolume.Status.State != nil {
-			status := *currentVolume.Status.State
-			if status != "Used" && status != "NotUsed" {
-				return fmt.Errorf("cannot update block storage with status '%s': block storage can only be updated when status is 'Used' or 'NotUsed'", status)
-			}
+		if state := current.State(); state != "" && state != StateUsed && state != StateNotUsed {
+			return fmt.Errorf("cannot update block storage with status '%s': block storage can only be updated when status is 'Used' or 'NotUsed'", state)
 		}
 
-		// Get region value
-		regionValue := ""
-		if currentVolume.Metadata.LocationResponse != nil {
-			regionValue = currentVolume.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for block storage")
-		}
-
-		// Handle zone - if empty, set to nil
-		var zone *string
-		if currentVolume.Properties.Zone != "" {
-			zone = &currentVolume.Properties.Zone
-		}
-
-		// Build the update request with current values as defaults
-		updateRequest := types.BlockStorageRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *currentVolume.Metadata.Name,
-					Tags: currentVolume.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.BlockStoragePropertiesRequest{
-				SizeGB:        currentVolume.Properties.SizeGB,
-				BillingPeriod: "Hour",
-				Zone:          zone,
-				Type:          currentVolume.Properties.Type,
-			},
-		}
-
-		// Update only the fields that were provided
 		if name != "" {
-			updateRequest.Metadata.ResourceMetadataRequest.Name = name
+			current.Named(name)
 		}
-
 		if cmd.Flags().Changed("tags") {
-			updateRequest.Metadata.ResourceMetadataRequest.Tags = tags
+			current.ReplaceTags(tags...)
 		}
 
-		// Update the block storage using the SDK
-		response, err := client.FromStorage().Volumes().Update(ctx, projectID, volumeID, updateRequest, nil)
+		updated, err := client.FromStorage().Volumes().Update(ctx, current)
 		if err != nil {
-			return fmt.Errorf("updating block storage: %w", err)
+			return fmt.Errorf("updating block storage: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			if response.Error != nil {
-				return fmtAPIError(response.StatusCode, response.Error.Title, response.Error.Detail)
-			}
-			return fmt.Errorf("API error (status %d)", response.StatusCode)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := volumeFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Block storage", volumeID))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", response.Data.Metadata.Tags)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			fmt.Printf("Size (GB):       %d\n", response.Data.Properties.SizeGB)
-			fmt.Printf("Type:            %s\n", response.Data.Properties.Type)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
+			}
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
+			}
+			fmt.Printf("Size (GB):       %d\n", resource.Properties.SizeGB)
+			fmt.Printf("Type:            %s\n", resource.Properties.Type)
 		} else {
 			fmt.Println(msgUpdatedAsync("Block storage", volumeID))
 		}
@@ -472,17 +394,8 @@ var blockstorageDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		volumeID := args[0]
 
-		// Get project ID from flag or context
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		// Get flags
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		// If not confirmed, ask for confirmation
-		if !confirm {
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if !skipConfirm {
 			ok, err := confirmDelete("block storage", volumeID)
 			if err != nil {
 				return err
@@ -492,7 +405,11 @@ var blockstorageDeleteCmd = &cobra.Command{
 			}
 		}
 
-		// Get SDK client
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
+
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -503,21 +420,16 @@ var blockstorageDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
+			_, err = client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
 			if err != nil {
-				return fmt.Errorf("dry-run: block storage not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: block storage not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("block storage", volumeID))
 			return nil
 		}
 
-		// Delete the block storage using the SDK
-		deleteResp, err := client.FromStorage().Volumes().Delete(ctx, projectID, volumeID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting block storage: %w", err)
-		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+		if err := client.FromStorage().Volumes().Delete(ctx, volumeRef(projectID, volumeID)); err != nil {
+			return fmt.Errorf("deleting block storage: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Block storage", volumeID))
@@ -530,67 +442,30 @@ var blockstorageListCmd = &cobra.Command{
 	Short: "List all block storage",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get flags
 		verbose, _ := cmd.Flags().GetBool("verbose")
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// List block storage using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Volumes().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromStorage().Volumes().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing block storage: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing block storage: %w", apiErrFromV2(err))
 		}
 
-		// Debug output
-		if verbose {
-			fmt.Println("\n=== DEBUG: Raw Response ===")
-			fmt.Printf("Status Code: %d\n", response.StatusCode)
-			fmt.Printf("Success: %v\n", response.IsSuccess())
-			if response.Data != nil {
-				fmt.Printf("Number of volumes: %d\n", len(response.Data.Values))
-				if len(response.Data.Values) > 0 {
-					fmt.Println("\n=== Volumes Detail ===")
-					for i, vol := range response.Data.Values {
-						fmt.Printf("\n--- Volume %d ---\n", i+1)
-						if vol.Metadata.ID != nil {
-							fmt.Printf("  ID: %s\n", *vol.Metadata.ID)
-						}
-						if vol.Metadata.Name != nil {
-							fmt.Printf("  Name: %s\n", *vol.Metadata.Name)
-						}
-						fmt.Printf("  Size: %d GB\n", vol.Properties.SizeGB)
-						fmt.Printf("  Type: %v\n", vol.Properties.Type)
-						fmt.Printf("  Zone: %s\n", vol.Properties.Zone)
-						fmt.Printf("  Region: %s\n", vol.Metadata.LocationResponse.Value)
-						if vol.Status.State != nil {
-							fmt.Printf("  Status State: %s\n", *vol.Status.State)
-						} else {
-							fmt.Printf("  Status State: <nil>\n")
-						}
-						fmt.Printf("  Full Status: %+v\n", vol.Status)
-					}
-				}
+		if list != nil && len(list.Items()) > 0 {
+			if verbose {
+				fmt.Printf("\n=== Block Storage (count: %d) ===\n\n", len(list.Items()))
 			}
-			fmt.Println("\n=== End Debug ===")
-		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
-			// Define table columns
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -601,39 +476,20 @@ var blockstorageListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 
-			// Build rows
 			var rows [][]string
-			for _, volume := range response.Data.Values {
-				name := ""
-				if volume.Metadata.Name != nil && *volume.Metadata.Name != "" {
-					name = *volume.Metadata.Name
+			for _, v := range list.Items() {
+				r := volumeFromRaw(v)
+				sizeStr := "0"
+				region := v.Region()
+				zone := string(v.Zone())
+				typeStr := string(v.Type())
+				if r != nil {
+					sizeStr = fmt.Sprintf("%d", r.Properties.SizeGB)
 				}
-
-				id := ""
-				if volume.Metadata.ID != nil {
-					id = *volume.Metadata.ID
-				}
-
-				size := fmt.Sprintf("%d", volume.Properties.SizeGB)
-
-				region := ""
-				if volume.Metadata.LocationResponse != nil {
-					region = volume.Metadata.LocationResponse.Value
-				}
-				zone := volume.Properties.Zone
-
-				volumeType := fmt.Sprintf("%v", volume.Properties.Type)
-
-				status := ""
-				if volume.Status.State != nil {
-					status = *volume.Status.State
-				}
-
-				rows = append(rows, []string{name, id, size, region, zone, volumeType, status})
+				rows = append(rows, []string{v.Name(), v.ID(), sizeStr, region, zone, typeStr, v.State()})
 			}
 
-			// Print the table
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(volumeListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No block storage found")
 		}

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,22 @@ import (
 func TestBlockStorageListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVolumesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockVolumesClient) {
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vol-001", "my-volume"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
-					return &types.Response[types.BlockStorageList]{
-						StatusCode: 200,
-						Data: &types.BlockStorageList{
-							Values: []types.BlockStorageResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages", jsonResponse(200, types.BlockStorageList{
+					Values: []types.BlockStorageResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vol-001") {
@@ -41,26 +36,21 @@ func TestBlockStorageListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockVolumesClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
-					return &types.Response[types.BlockStorageList]{StatusCode: 200, Data: &types.BlockStorageList{}}, nil
-				}
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages", jsonResponse(200, types.BlockStorageList{}))
 			},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockVolumesClient) {
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vol-001", "my-volume"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
-					return &types.Response[types.BlockStorageList]{
-						StatusCode: 200,
-						Data: &types.BlockStorageList{
-							Values: []types.BlockStorageResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages", jsonResponse(200, types.BlockStorageList{
+					Values: []types.BlockStorageResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,40 +60,29 @@ func TestBlockStorageListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVolumesClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "listing",
+			wantErr: true, errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockVolumesClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
-					return &types.Response[types.BlockStorageList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVolumesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"storage", "blockstorage", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withStorage(m)), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +94,18 @@ func TestBlockStorageListCmd(t *testing.T) {
 func TestBlockStorageGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVolumesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockVolumesClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vol-001", "my-volume"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-					return &types.Response[types.BlockStorageResponse]{
-						StatusCode: 200,
-						Data:       &types.BlockStorageResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vol-001") {
@@ -138,36 +114,27 @@ func TestBlockStorageGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVolumesClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "getting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVolumesClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-					return &types.Response[types.BlockStorageResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "getting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVolumesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorage(m)),
+			out, err := runCmdCapture(srv.Client(),
 				[]string{"storage", "blockstorage", "get", "vol-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
@@ -181,7 +148,7 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockVolumesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -189,14 +156,11 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"storage", "blockstorage", "create", "--project-id", "proj-123", "--name", "my-vol", "--region", "ITBG-Bergamo", "--size", "10"},
-			setupMock: func(m *mockVolumesClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vol-new", "my-vol"
-				m.createFn = func(_ context.Context, _ string, _ types.BlockStorageRequest, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-					return &types.Response[types.BlockStorageResponse]{
-						StatusCode: 200,
-						Data:       &types.BlockStorageResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/blockstorages", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vol-new") {
@@ -217,38 +181,29 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 			errContains: "size",
 		},
 		{
-			name: "SDK error propagates",
-			args: []string{"storage", "blockstorage", "create", "--project-id", "proj-123", "--name", "my-vol", "--region", "ITBG-Bergamo", "--size", "10"},
-			setupMock: func(m *mockVolumesClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.BlockStorageRequest, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
-			},
-			wantErr:     true,
-			errContains: "creating",
-		},
-		{
 			name: "API error propagates",
 			args: []string{"storage", "blockstorage", "create", "--project-id", "proj-123", "--name", "my-vol", "--region", "ITBG-Bergamo", "--size", "10"},
-			setupMock: func(m *mockVolumesClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.BlockStorageRequest, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-					return &types.Response[types.BlockStorageResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/blockstorages", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "server error propagates",
+			args: []string{"storage", "blockstorage", "create", "--project-id", "proj-123", "--name", "my-vol", "--region", "ITBG-Bergamo", "--size", "10"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/blockstorages", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr: true, errContains: "creating",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVolumesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorage(m)), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -260,17 +215,16 @@ func TestBlockStorageCreateCmd(t *testing.T) {
 func TestBlockStorageDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockVolumesClient)
+		setupSrv    func(*arubaTestServer)
+		extraArgs   []string
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockVolumesClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vol-001") {
@@ -279,12 +233,13 @@ func TestBlockStorageDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockVolumesClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name:      "--dry-run: prints intent, does not call Delete",
+			extraArgs: []string{"--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vol-001", "my-volume"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "vol-001") {
@@ -293,40 +248,29 @@ func TestBlockStorageDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockVolumesClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "deleting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockVolumesClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "deleting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockVolumesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
 			args := []string{"storage", "blockstorage", "delete", "vol-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withStorage(m)), args)
+			args = append(args, tc.extraArgs...)
+			out, err := runCmdCapture(srv.Client(), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -2,23 +2,39 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
+func restoreRef(projectID, backupID, restoreID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/backups/" + backupID + "/restores/" + restoreID)
+}
+
+func restoreFromRaw(r *aruba.StorageRestore) *types.StorageRestoreResponse {
+	if r == nil {
+		return nil
+	}
+	return r.Raw()
+}
+
+func restoreListPayload(l *aruba.List[*aruba.StorageRestore]) any {
+	if r, ok := l.Raw().(*types.Response[types.StorageRestoreList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
 func init() {
-	// Restore commands
 	storageCmd.AddCommand(storageRestoreCmd)
 	storageRestoreCmd.AddCommand(storageRestoreListCmd)
 	storageRestoreCmd.AddCommand(storageRestoreGetCmd)
 	storageRestoreCmd.AddCommand(storageRestoreUpdateCmd)
 	storageRestoreCmd.AddCommand(storageRestoreDeleteCmd)
 
-	// Add flags for restore command
 	storageRestoreCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	storageRestoreCmd.Flags().String("name", "", "Name for the restore operation (required)")
 	storageRestoreCmd.Flags().String("region", "ITBG-Bergamo", "Region code")
@@ -43,19 +59,14 @@ func init() {
 	storageRestoreListCmd.ValidArgsFunction = completeBackupID
 }
 
-// Completion functions for storage resources
-
 func completeRestoreID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// For restore, we need backup-id as first arg, restore-id as second
 	if len(args) == 0 {
-		// First arg is backup-id, use backup completion
 		return completeBackupID(cmd, args, toComplete)
 	}
 	if len(args) > 1 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	// Second arg is restore-id
 	backupID := args[0]
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
@@ -68,20 +79,17 @@ func completeRestoreID(cmd *cobra.Command, args []string, toComplete string) ([]
 	}
 
 	ctx := context.Background()
-	response, err := client.FromStorage().Restores().List(ctx, projectID, backupID, nil)
+	list, err := client.FromStorage().Restores().List(ctx, backupRef(projectID, backupID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, restore := range response.Data.Values {
-			if restore.Metadata.ID != nil && restore.Metadata.Name != nil {
-				id := *restore.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *restore.Metadata.Name))
-				}
+	if list != nil {
+		for _, r := range list.Items() {
+			id := r.ID()
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, r.Name()))
 			}
 		}
 	}
@@ -89,7 +97,6 @@ func completeRestoreID(cmd *cobra.Command, args []string, toComplete string) ([]
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
-// Restore command - creates an Aruba.Storage/restore resource
 var storageRestoreCmd = &cobra.Command{
 	Use:   "restore [backup-id] [volume-id]",
 	Short: "Restore a block storage volume from a backup",
@@ -104,18 +111,16 @@ idle before starting a restore to avoid data corruption.`,
 		backupID := args[0]
 		volumeID := args[1]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
+		verbose, _ := cmd.Flags().GetBool("verbose")
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -124,96 +129,64 @@ idle before starting a restore to avoid data corruption.`,
 		ctx, cancel := newCtx()
 		defer cancel()
 
-		// Get the backup details
-		backupResponse, err := client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)
+		bk, err := client.FromStorage().Backups().Get(ctx, backupRef(projectID, backupID))
 		if err != nil {
-			return fmt.Errorf("getting backup details: %w", err)
+			return fmt.Errorf("getting backup details: %w", apiErrFromV2(err))
 		}
 
-		if backupResponse == nil || backupResponse.Data == nil {
-			return fmt.Errorf("backup not found")
-		}
-
-		backupURI := *backupResponse.Data.Metadata.URI
-
-		// Get the volume details
-		volumeResponse, err := client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)
+		target, err := client.FromStorage().Volumes().Get(ctx, volumeRef(projectID, volumeID))
 		if err != nil {
-			return fmt.Errorf("getting volume details: %w", err)
+			return fmt.Errorf("getting volume details: %w", apiErrFromV2(err))
 		}
 
-		if volumeResponse == nil || volumeResponse.Data == nil {
-			return fmt.Errorf("volume not found")
-		}
-
-		volumeURI := *volumeResponse.Data.Metadata.URI
-
-		// Build the restore request
-		createRequest := types.RestoreRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.RestorePropertiesRequest{
-				Target: types.ReferenceResource{
-					URI: volumeURI,
-				},
-			},
-		}
-
-		// Get verbose flag
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("Creating restore operation with the following parameters:")
-			fmt.Printf("  Name:       %s\n", name)
-			fmt.Printf("  Region:     %s\n", region)
-			fmt.Printf("  Backup ID:  %s\n", backupID)
-			fmt.Printf("  Backup URI: %s\n", backupURI)
-			fmt.Printf("  Volume ID:  %s\n", volumeID)
-			fmt.Printf("  Volume URI: %s\n", volumeURI)
+			fmt.Printf("  Name:      %s\n", name)
+			fmt.Printf("  Region:    %s\n", region)
+			fmt.Printf("  Backup ID: %s\n", backupID)
+			fmt.Printf("  Volume ID: %s\n", volumeID)
 			if len(tags) > 0 {
-				fmt.Printf("  Tags:       %v\n", tags)
+				fmt.Printf("  Tags:      %v\n", tags)
 			}
 			fmt.Println()
 		}
 
-		// Create the restore using the SDK
-		response, err := client.FromStorage().Restores().Create(ctx, projectID, backupID, createRequest, nil)
+		rs := aruba.NewStorageRestore().
+			IntoBackup(bk).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			ToVolume(target)
+		if len(tags) > 0 {
+			rs.ReplaceTags(tags...)
+		}
+
+		created, err := client.FromStorage().Restores().Create(ctx, rs)
 		if err != nil {
-			return fmt.Errorf("creating restore: %w", err)
+			return fmt.Errorf("creating restore: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() && response.Error != nil {
-			if verbose {
-				jsonData, _ := json.MarshalIndent(response.Error, "", "  ")
-				fmt.Printf("Full Error Response:\n%s\n", string(jsonData))
-			}
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response.Data != nil {
+		resource := restoreFromRaw(created)
+		if resource != nil {
 			fmt.Println(msgCreated("Restore operation", name))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			if response.Data.Metadata.CreationDate != nil && !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			if response.Data.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *response.Data.Status.State)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
+			if resource.Metadata.CreationDate != nil && !resource.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", resource.Metadata.CreationDate.Format(DateLayout))
+			}
+			if resource.Status.State != nil {
+				fmt.Printf("Status:          %s\n", *resource.Status.State)
+			}
+		} else {
+			fmt.Println(msgCreatedAsync("Restore operation", name))
 		}
 		return nil
 	},
 }
 
-// Restore List command
 var storageRestoreListCmd = &cobra.Command{
 	Use:   "list [backup-id]",
 	Short: "List restore operations for a backup",
@@ -233,15 +206,12 @@ var storageRestoreListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Restores().List(ctx, projectID, backupID, listParams(cmd))
+		list, err := client.FromStorage().Restores().List(ctx, backupRef(projectID, backupID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing restores: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing restores: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -249,26 +219,11 @@ var storageRestoreListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, restore := range response.Data.Values {
-				name := ""
-				if restore.Metadata.Name != nil {
-					name = *restore.Metadata.Name
-				}
-
-				id := ""
-				if restore.Metadata.ID != nil {
-					id = *restore.Metadata.ID
-				}
-
-				status := ""
-				if restore.Status.State != nil {
-					status = *restore.Status.State
-				}
-
-				rows = append(rows, []string{name, id, status})
+			for _, r := range list.Items() {
+				rows = append(rows, []string{r.Name(), r.ID(), r.State()})
 			}
 
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(restoreListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No restores found for this backup")
 		}
@@ -276,7 +231,6 @@ var storageRestoreListCmd = &cobra.Command{
 	},
 }
 
-// Restore Get command
 var storageRestoreGetCmd = &cobra.Command{
 	Use:   "get [backup-id] [restore-id]",
 	Short: "Get restore operation details",
@@ -297,16 +251,18 @@ var storageRestoreGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)
+		got, err := client.FromStorage().Restores().Get(ctx, restoreRef(projectID, backupID, restoreID))
 		if err != nil {
-			return fmt.Errorf("getting restore details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting restore details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			restore := response.Data
+		restore := restoreFromRaw(got)
+		if restore != nil {
+			format := resolveOutputFormat()
+			if format == OutputFormatJSON || format == OutputFormatYAML {
+				PrintOutput(restore, nil, nil)
+				return nil
+			}
 
 			fmt.Println("\nRestore Operation Details:")
 			fmt.Println("==========================")
@@ -320,32 +276,27 @@ var storageRestoreGetCmd = &cobra.Command{
 			if restore.Metadata.Name != nil {
 				fmt.Printf("Name:            %s\n", *restore.Metadata.Name)
 			}
-
 			if restore.Properties.Destination.URI != "" {
 				fmt.Printf("Target Volume:   %s\n", restore.Properties.Destination.URI)
 			}
-
 			if restore.Metadata.LocationResponse != nil {
 				fmt.Printf("Region:          %s\n", restore.Metadata.LocationResponse.Value)
 			}
-
 			if restore.Status.State != nil {
 				fmt.Printf("Status:          %s\n", *restore.Status.State)
 			}
-
 			if restore.Metadata.CreationDate != nil && !restore.Metadata.CreationDate.IsZero() {
 				fmt.Printf("Creation Date:   %s\n", restore.Metadata.CreationDate.Format(DateLayout))
 			}
-
 			if restore.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *restore.Metadata.CreatedBy)
 			}
-
 			if len(restore.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", restore.Metadata.Tags)
 			} else {
 				fmt.Printf("Tags:            []\n")
 			}
+			fmt.Println()
 		} else {
 			fmt.Println("Restore operation not found")
 		}
@@ -353,7 +304,6 @@ var storageRestoreGetCmd = &cobra.Command{
 	},
 }
 
-// Restore Update command
 var storageRestoreUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id] [restore-id]",
 	Short: "Update a restore operation (name and/or tags)",
@@ -367,11 +317,9 @@ var storageRestoreUpdateCmd = &cobra.Command{
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
@@ -381,72 +329,40 @@ var storageRestoreUpdateCmd = &cobra.Command{
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current restore details
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)
+		current, err := client.FromStorage().Restores().Get(ctx, restoreRef(projectID, backupID, restoreID))
 		if err != nil {
-			return fmt.Errorf("getting restore details: %w", err)
+			return fmt.Errorf("getting restore details: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
+		if current.Raw() == nil {
 			return fmt.Errorf("restore operation not found")
 		}
 
-		currentRestore := getResponse.Data
-
-		// Get region value
-		regionValue := ""
-		if currentRestore.Metadata.LocationResponse != nil {
-			regionValue = currentRestore.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for restore operation")
-		}
-
-		// Build the update request with current values as defaults
-		updateRequest := types.RestoreRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *currentRestore.Metadata.Name,
-					Tags: currentRestore.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.RestorePropertiesRequest{
-				Target: types.ReferenceResource{
-					URI: currentRestore.Properties.Destination.URI,
-				},
-			},
-		}
-
-		// Update only the fields that were provided
 		if name != "" {
-			updateRequest.Metadata.ResourceMetadataRequest.Name = name
+			current.Named(name)
 		}
-
 		if cmd.Flags().Changed("tags") {
-			updateRequest.Metadata.ResourceMetadataRequest.Tags = tags
+			current.ReplaceTags(tags...)
 		}
 
-		// Update the restore using the SDK
-		response, err := client.FromStorage().Restores().Update(ctx, projectID, backupID, restoreID, updateRequest, nil)
+		updated, err := client.FromStorage().Restores().Update(ctx, current)
 		if err != nil {
-			return fmt.Errorf("updating restore: %w", err)
+			return fmt.Errorf("updating restore: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := restoreFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Restore operation", restoreID))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", response.Data.Metadata.Tags)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
+			}
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
+			}
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("Restore operation", restoreID))
@@ -455,7 +371,6 @@ var storageRestoreUpdateCmd = &cobra.Command{
 	},
 }
 
-// Restore Delete command
 var storageRestoreDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id] [restore-id]",
 	Short: "Delete a restore operation",
@@ -464,13 +379,8 @@ var storageRestoreDeleteCmd = &cobra.Command{
 		backupID := args[0]
 		restoreID := args[1]
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if !skipConfirm {
 			ok, err := confirmDelete("restore operation", restoreID)
 			if err != nil {
 				return err
@@ -478,6 +388,11 @@ var storageRestoreDeleteCmd = &cobra.Command{
 			if !ok {
 				return nil
 			}
+		}
+
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
 		}
 
 		client, err := GetArubaClient()
@@ -490,20 +405,16 @@ var storageRestoreDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)
+			_, err = client.FromStorage().Restores().Get(ctx, restoreRef(projectID, backupID, restoreID))
 			if err != nil {
-				return fmt.Errorf("dry-run: restore operation not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: restore operation not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("restore operation", restoreID))
 			return nil
 		}
 
-		deleteResp, err := client.FromStorage().Restores().Delete(ctx, projectID, backupID, restoreID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting restore: %w", err)
-		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+		if err := client.FromStorage().Restores().Delete(ctx, restoreRef(projectID, backupID, restoreID)); err != nil {
+			return fmt.Errorf("deleting restore: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Restore operation", restoreID))

--- a/cmd/storage.restore_test.go
+++ b/cmd/storage.restore_test.go
@@ -1,49 +1,25 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
-// storage restore create uses storageRestoreCmd directly (no separate "create" subcommand).
-// Invocation: storage restore [backup-id] [volume-id] --name <name> ...
-
-// newStorageRestoreCreateMock wires a mockStorageClient for the restore create
-// flow, which first fetches the backup and volume (to get their URIs) then calls
-// Restores().Create(). All three sub-clients must be set.
-func newStorageRestoreCreateMock(restoreFn func(context.Context, string, string, types.RestoreRequest, *types.RequestParameters) (*types.Response[types.RestoreResponse], error)) *mockStorageClient {
-	bkpURI := "/projects/proj-123/providers/Aruba.Storage/backups/bkp-001"
-	volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
-	backups := &mockStorageBackupsClient{
-		getFn: func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
-			return &types.Response[types.StorageBackupResponse]{
-				StatusCode: 200,
-				Data:       &types.StorageBackupResponse{Metadata: types.ResourceMetadataResponse{URI: &bkpURI}},
-			}, nil
-		},
-	}
-	volumes := &mockVolumesClient{
-		getFn: func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error) {
-			return &types.Response[types.BlockStorageResponse]{
-				StatusCode: 200,
-				Data:       &types.BlockStorageResponse{Metadata: types.ResourceMetadataResponse{URI: &volURI}},
-			}, nil
-		},
-	}
-	return &mockStorageClient{volumesMock: volumes, backupsMock: backups, restoresMock: &mockStorageRestoreClient{createFn: restoreFn}}
-}
+const (
+	restoreBkpURI = "/projects/proj-123/providers/Aruba.Storage/backups/bkp-001"
+	restoreVolURI = "/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001"
+)
 
 func TestStorageRestoreCreateCmd(t *testing.T) {
 	createArgs := []string{"storage", "restore", "bkp-001", "vol-001", "--project-id", "proj-123", "--name", "my-restore"}
+
 	tests := []struct {
 		name        string
 		args        []string
-		storageMock *mockStorageClient
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -51,13 +27,23 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: createArgs,
-			storageMock: newStorageRestoreCreateMock(func(_ context.Context, _, _ string, _ types.RestoreRequest, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-				id, rname := "rst-new", "my-restore"
-				return &types.Response[types.RestoreResponse]{
-					StatusCode: 200,
-					Data:       &types.RestoreResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
-				}, nil
-			}),
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-new", "my-restore"
+				bkpURI := restoreBkpURI
+				volURI := restoreVolURI
+				// Pre-validation: GET backup
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &bkpURI},
+				}))
+				// Pre-validation: GET volume
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &volURI},
+				}))
+				// Create: POST restore (scoped to the backup)
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rst-new") {
 					t.Errorf("expected ID in output, got: %s", out)
@@ -71,34 +57,65 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
+			name: "backup pre-validation error propagates",
 			args: createArgs,
-			storageMock: newStorageRestoreCreateMock(func(_ context.Context, _, _ string, _ types.RestoreRequest, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-				return nil, fmt.Errorf("quota exceeded")
-			}),
-			wantErr:     true,
-			errContains: "creating",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", errorResponse(404, "Not Found", "backup not found"))
+			},
+			wantErr: true, errContains: "getting backup",
+		},
+		{
+			name: "volume pre-validation error propagates",
+			args: createArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				bkpURI := restoreBkpURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &bkpURI},
+				}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", errorResponse(404, "Not Found", "volume not found"))
+			},
+			wantErr: true, errContains: "getting volume",
 		},
 		{
 			name: "API error propagates",
 			args: createArgs,
-			storageMock: newStorageRestoreCreateMock(func(_ context.Context, _, _ string, _ types.RestoreRequest, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-				return &types.Response[types.RestoreResponse]{
-					StatusCode: 404,
-					Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-				}, nil
-			}),
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			setupSrv: func(srv *arubaTestServer) {
+				bkpURI := restoreBkpURI
+				volURI := restoreVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &bkpURI},
+				}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &volURI},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr: true, errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "server error propagates",
+			args: createArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				bkpURI := restoreBkpURI
+				volURI := restoreVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001", jsonResponse(200, types.StorageBackupResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &bkpURI},
+				}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
+					Metadata: types.ResourceMetadataResponse{URI: &volURI},
+				}))
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr: true, errContains: "creating",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sm := tc.storageMock
-			if sm == nil {
-				sm = &mockStorageClient{}
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(sm)), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -110,25 +127,22 @@ func TestStorageRestoreCreateCmd(t *testing.T) {
 func TestStorageRestoreListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockStorageRestoreClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockStorageRestoreClient) {
-				id, rname := "rst-001", "my-restore"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
-					return &types.Response[types.RestoreList]{
-						StatusCode: 200,
-						Data: &types.RestoreList{
-							Values: []types.RestoreResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
-							},
-						},
-					}, nil
-				}
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{
+					Values: []types.StorageRestoreResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rst-001") {
@@ -138,26 +152,21 @@ func TestStorageRestoreListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
-					return &types.Response[types.RestoreList]{StatusCode: 200, Data: &types.RestoreList{}}, nil
-				}
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{}))
 			},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockStorageRestoreClient) {
-				id, rname := "rst-001", "my-restore"
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
-					return &types.Response[types.RestoreList]{
-						StatusCode: 200,
-						Data: &types.RestoreList{
-							Values: []types.RestoreResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
-							},
-						},
-					}, nil
-				}
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{
+					Values: []types.StorageRestoreResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -167,40 +176,29 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "listing",
+			wantErr: true, errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreList], error) {
-					return &types.Response[types.RestoreList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockStorageRestoreClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -212,21 +210,18 @@ func TestStorageRestoreListCmd(t *testing.T) {
 func TestStorageRestoreGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockStorageRestoreClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockStorageRestoreClient) {
-				id, rname := "rst-001", "my-restore"
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-					return &types.Response[types.RestoreResponse]{
-						StatusCode: 200,
-						Data:       &types.RestoreResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &rname}},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", jsonResponse(200, types.StorageRestoreResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rst-001") {
@@ -235,36 +230,27 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "getting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.RestoreResponse], error) {
-					return &types.Response[types.RestoreResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "getting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockStorageRestoreClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})),
+			out, err := runCmdCapture(srv.Client(),
 				[]string{"storage", "restore", "get", "bkp-001", "rst-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
@@ -277,17 +263,16 @@ func TestStorageRestoreGetCmd(t *testing.T) {
 func TestStorageRestoreDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockStorageRestoreClient)
+		setupSrv    func(*arubaTestServer)
+		extraArgs   []string
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rst-001") {
@@ -296,12 +281,13 @@ func TestStorageRestoreDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name:      "--dry-run: prints intent, does not call Delete",
+			extraArgs: []string{"--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", jsonResponse(200, types.StorageRestoreResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "rst-001") {
@@ -310,40 +296,29 @@ func TestStorageRestoreDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "deleting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockStorageRestoreClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores/rst-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "deleting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockStorageRestoreClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
 			args := []string{"storage", "restore", "delete", "bkp-001", "rst-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{restoresMock: m})), args)
+			args = append(args, tc.extraArgs...)
+			out, err := runCmdCapture(srv.Client(), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -5,12 +5,30 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func snapshotRef(projectID, snapshotID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/snapshots/" + snapshotID)
+}
 
+func snapshotFromRaw(s *aruba.Snapshot) *types.SnapshotResponse {
+	if s == nil {
+		return nil
+	}
+	return s.Raw()
+}
+
+func snapshotListPayload(l *aruba.List[*aruba.Snapshot]) any {
+	if r, ok := l.Raw().(*types.Response[types.SnapshotList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
+}
+
+func init() {
 	storageCmd.AddCommand(snapshotCmd)
 	snapshotCmd.AddCommand(snapshotCreateCmd)
 	snapshotCmd.AddCommand(snapshotGetCmd)
@@ -18,7 +36,6 @@ func init() {
 	snapshotCmd.AddCommand(snapshotDeleteCmd)
 	snapshotCmd.AddCommand(snapshotListCmd)
 
-	// Add flags for snapshot commands
 	snapshotCreateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	snapshotCreateCmd.Flags().String("name", "", "Name for the snapshot (required)")
 	snapshotCreateCmd.Flags().String("region", "", "Region code (required)")
@@ -49,14 +66,9 @@ func init() {
 	snapshotGetCmd.ValidArgsFunction = completeSnapshotID
 	snapshotUpdateCmd.ValidArgsFunction = completeSnapshotID
 	snapshotDeleteCmd.ValidArgsFunction = completeSnapshotID
-
 }
 
-// Completion functions for storage resources
-
 func completeSnapshotID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// Allow completion even if args exist - user might be completing a partial ID
-
 	projectID, err := GetProjectID(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -68,20 +80,17 @@ func completeSnapshotID(cmd *cobra.Command, args []string, toComplete string) ([
 	}
 
 	ctx := context.Background()
-	response, err := client.FromStorage().Snapshots().List(ctx, projectID, nil)
+	list, err := client.FromStorage().Snapshots().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, snapshot := range response.Data.Values {
-			if snapshot.Metadata.ID != nil && snapshot.Metadata.Name != nil {
-				id := *snapshot.Metadata.ID
-				// Filter by partial input - use HasPrefix for more reliable matching
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *snapshot.Metadata.Name))
-				}
+	if list != nil {
+		for _, s := range list.Items() {
+			id := s.ID()
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, s.Name()))
 			}
 		}
 	}
@@ -89,7 +98,6 @@ func completeSnapshotID(cmd *cobra.Command, args []string, toComplete string) ([
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
-// Snapshot subcommands
 var snapshotCmd = &cobra.Command{
 	Use:   "snapshot",
 	Short: "Manage snapshots",
@@ -107,46 +115,22 @@ or restore data with 'acloud storage blockstorage create --snapshot-uri'.`,
     --volume-uri /projects/<proj-id>/providers/Aruba.Storage/blockStorages/<vol-id>`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		region, _ := cmd.Flags().GetString("region")
 		volumeURI, _ := cmd.Flags().GetString("volume-uri")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
+		verbose, _ := cmd.Flags().GetBool("verbose")
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		createRequest := types.SnapshotRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.SnapshotPropertiesRequest{
-				Volume: types.ReferenceResource{
-					URI: volumeURI,
-				},
-			},
-		}
-
-		// Get verbose flag
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		// Debug output if verbose
 		if verbose {
 			fmt.Println("Creating snapshot with the following parameters:")
 			fmt.Printf("  Name:       %s\n", name)
@@ -156,28 +140,33 @@ or restore data with 'acloud storage blockstorage create --snapshot-uri'.`,
 			fmt.Println()
 		}
 
-		// Create the snapshot using the SDK
+		snap := aruba.NewSnapshot().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			FromVolume(aruba.URI(volumeURI))
+		if len(tags) > 0 {
+			snap.ReplaceTags(tags...)
+		}
+
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Snapshots().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromStorage().Snapshots().Create(ctx, snap)
 		if err != nil {
-			return fmt.Errorf("creating snapshot: %w", err)
+			return fmt.Errorf("creating snapshot: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := snapshotFromRaw(created)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgCreated("Snapshot", name))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
-			if response.Data.Metadata.CreationDate != nil && !response.Data.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", response.Data.Metadata.CreationDate.Format(DateLayout))
+			if resource.Metadata.CreationDate != nil && !resource.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", resource.Metadata.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("Snapshot", name))
@@ -193,80 +182,68 @@ var snapshotGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		snapshotID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get snapshot details using the SDK
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Snapshots().Get(ctx, projectID, snapshotID, nil)
+		got, err := client.FromStorage().Snapshots().Get(ctx, snapshotRef(projectID, snapshotID))
 		if err != nil {
-			return fmt.Errorf("getting snapshot details: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("getting snapshot details: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
-			snapshot := response.Data
+		snapshot := snapshotFromRaw(got)
+		if snapshot != nil {
+			format := resolveOutputFormat()
+			if format == OutputFormatJSON || format == OutputFormatYAML {
+				PrintOutput(snapshot, nil, nil)
+				return nil
+			}
 
-			// Display snapshot details
 			fmt.Println("\nSnapshot Details:")
 			fmt.Println("=================")
 
 			if snapshot.Metadata.ID != nil {
 				fmt.Printf("ID:              %s\n", *snapshot.Metadata.ID)
 			}
-
 			if snapshot.Metadata.URI != nil {
 				fmt.Printf("URI:             %s\n", *snapshot.Metadata.URI)
 			}
-
 			if snapshot.Metadata.Name != nil {
 				fmt.Printf("Name:            %s\n", *snapshot.Metadata.Name)
 			}
-
-			fmt.Printf("Size (GB):       %d\n", snapshot.Properties.SizeGB)
-
+			if snapshot.Properties.SizeGB != nil {
+				fmt.Printf("Size (GB):       %d\n", *snapshot.Properties.SizeGB)
+			}
 			if snapshot.Properties.Volume != nil && snapshot.Properties.Volume.URI != nil {
 				fmt.Printf("Source Volume:   %s\n", *snapshot.Properties.Volume.URI)
 			}
-
 			if snapshot.Metadata.LocationResponse != nil {
-				if snapshot.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", snapshot.Metadata.LocationResponse.Value)
-				}
+				fmt.Printf("Region:          %s\n", snapshot.Metadata.LocationResponse.Value)
 			}
-
 			status := ""
 			if snapshot.Status.State != nil {
 				status = *snapshot.Status.State
 			}
 			fmt.Printf("Status:          %s\n", status)
-
 			if snapshot.Metadata.CreationDate != nil && !snapshot.Metadata.CreationDate.IsZero() {
 				fmt.Printf("Creation Date:   %s\n", snapshot.Metadata.CreationDate.Format(DateLayout))
 			}
-
 			if snapshot.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *snapshot.Metadata.CreatedBy)
 			}
-
 			if len(snapshot.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", snapshot.Metadata.Tags)
 			} else {
 				fmt.Printf("Tags:            []\n")
 			}
-
 			fmt.Println()
 		} else {
 			fmt.Println("Snapshot not found")
@@ -282,106 +259,57 @@ var snapshotUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		snapshotID := args[0]
 
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get flags
 		name, _ := cmd.Flags().GetString("name")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		// At least one field must be provided
 		if name == "" && !cmd.Flags().Changed("tags") {
 			return fmt.Errorf("at least one of --name or --tags must be provided")
 		}
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// First, get the current snapshot details to preserve existing values
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResponse, err := client.FromStorage().Snapshots().Get(ctx, projectID, snapshotID, nil)
+		current, err := client.FromStorage().Snapshots().Get(ctx, snapshotRef(projectID, snapshotID))
 		if err != nil {
-			return fmt.Errorf("getting snapshot details: %w", err)
+			return fmt.Errorf("getting snapshot details: %w", apiErrFromV2(err))
 		}
 
-		if getResponse == nil || getResponse.Data == nil {
+		if current.Raw() == nil {
 			return fmt.Errorf("snapshot not found")
 		}
 
-		currentSnapshot := getResponse.Data
-
-		// Get region value
-		regionValue := ""
-		if currentSnapshot.Metadata.LocationResponse != nil {
-			regionValue = currentSnapshot.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for snapshot")
-		}
-
-		// Build the update request with current values as defaults
-		volumeURI := ""
-		if currentSnapshot.Properties.Volume != nil && currentSnapshot.Properties.Volume.URI != nil {
-			volumeURI = *currentSnapshot.Properties.Volume.URI
-		}
-
-		currentName := ""
-		if currentSnapshot.Metadata.Name != nil {
-			currentName = *currentSnapshot.Metadata.Name
-		}
-		updateRequest := types.SnapshotRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: currentName,
-					Tags: currentSnapshot.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.SnapshotPropertiesRequest{
-				Volume: types.ReferenceResource{
-					URI: volumeURI,
-				},
-			},
-		}
-
-		// Update only the fields that were provided
 		if name != "" {
-			updateRequest.Metadata.ResourceMetadataRequest.Name = name
+			current.Named(name)
 		}
-
 		if cmd.Flags().Changed("tags") {
-			updateRequest.Metadata.ResourceMetadataRequest.Tags = tags
+			current.ReplaceTags(tags...)
 		}
 
-		// Update the snapshot using the SDK
-		response, err := client.FromStorage().Snapshots().Update(ctx, projectID, snapshotID, updateRequest, nil)
+		updated, err := client.FromStorage().Snapshots().Update(ctx, current)
 		if err != nil {
-			return fmt.Errorf("updating snapshot: %w", err)
+			return fmt.Errorf("updating snapshot: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := snapshotFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Snapshot", snapshotID))
-			if response.Data.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			if response.Data.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", response.Data.Metadata.Tags)
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("Snapshot", snapshotID))
@@ -397,17 +325,8 @@ var snapshotDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		snapshotID := args[0]
 
-		// Get project ID from flag or context
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		// Get flags
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		// If not confirmed, ask for confirmation
-		if !confirm {
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if !skipConfirm {
 			ok, err := confirmDelete("snapshot", snapshotID)
 			if err != nil {
 				return err
@@ -417,7 +336,11 @@ var snapshotDeleteCmd = &cobra.Command{
 			}
 		}
 
-		// Get SDK client
+		projectID, err := GetProjectID(cmd)
+		if err != nil {
+			return err
+		}
+
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -428,21 +351,16 @@ var snapshotDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromStorage().Snapshots().Get(ctx, projectID, snapshotID, nil)
+			_, err = client.FromStorage().Snapshots().Get(ctx, snapshotRef(projectID, snapshotID))
 			if err != nil {
-				return fmt.Errorf("dry-run: snapshot not found or inaccessible: %w", err)
+				return fmt.Errorf("dry-run: snapshot not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("snapshot", snapshotID))
 			return nil
 		}
 
-		// Delete the snapshot using the SDK
-		deleteResp, err := client.FromStorage().Snapshots().Delete(ctx, projectID, snapshotID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting snapshot: %w", err)
-		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+		if err := client.FromStorage().Snapshots().Delete(ctx, snapshotRef(projectID, snapshotID)); err != nil {
+			return fmt.Errorf("deleting snapshot: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Snapshot", snapshotID))
@@ -455,54 +373,38 @@ var snapshotListCmd = &cobra.Command{
 	Short: "List snapshots for a block storage volume",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get project ID from flag or context
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
 			return err
 		}
 
-		// Get block storage URI flag
 		volumeURI, _ := cmd.Flags().GetString("volume-uri")
 
-		// Get SDK client
 		client, err := GetArubaClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// List snapshots using the SDK (filter by volume URI on client side)
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromStorage().Snapshots().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromStorage().Snapshots().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing snapshots: %w", err)
-		}
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+			return fmt.Errorf("listing snapshots: %w", apiErrFromV2(err))
 		}
 
-		// Check verbose flag
-		verbose, _ := cmd.Flags().GetBool("verbose")
-		if verbose {
-			fmt.Println("=== Full API Response ===")
-			fmt.Printf("%+v\n\n", response)
-		}
-
-		if response != nil && response.Data != nil && len(response.Data.Values) > 0 {
-			// Filter snapshots by volume URI
-			var filteredSnapshots []types.SnapshotResponse
-			for _, snapshot := range response.Data.Values {
-				if snapshot.Properties.Volume != nil && snapshot.Properties.Volume.URI != nil && *snapshot.Properties.Volume.URI == volumeURI {
-					filteredSnapshots = append(filteredSnapshots, snapshot)
+		if list != nil && len(list.Items()) > 0 {
+			var filtered []*aruba.Snapshot
+			for _, s := range list.Items() {
+				if s.VolumeURI() == volumeURI {
+					filtered = append(filtered, s)
 				}
 			}
 
-			if len(filteredSnapshots) == 0 {
+			if len(filtered) == 0 {
 				fmt.Printf("No snapshots found for volume: %s\n", volumeURI)
 				return nil
 			}
 
-			// Define table columns
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 26},
@@ -510,31 +412,17 @@ var snapshotListCmd = &cobra.Command{
 				{Header: "STATUS", Width: 15},
 			}
 
-			// Build rows
 			var rows [][]string
-			for _, snapshot := range filteredSnapshots {
-				name := ""
-				if snapshot.Metadata.Name != nil && *snapshot.Metadata.Name != "" {
-					name = *snapshot.Metadata.Name
+			for _, s := range filtered {
+				sizeStr := "0"
+				r := snapshotFromRaw(s)
+				if r != nil && r.Properties.SizeGB != nil {
+					sizeStr = fmt.Sprintf("%d", *r.Properties.SizeGB)
 				}
-
-				id := ""
-				if snapshot.Metadata.ID != nil && *snapshot.Metadata.ID != "" {
-					id = *snapshot.Metadata.ID
-				}
-
-				size := fmt.Sprintf("%d", snapshot.Properties.SizeGB)
-
-				status := ""
-				if snapshot.Status.State != nil {
-					status = *snapshot.Status.State
-				}
-
-				rows = append(rows, []string{name, id, size, status})
+				rows = append(rows, []string{s.Name(), s.ID(), sizeStr, s.State()})
 			}
 
-			// Print the table
-			PrintOutput(response.Data, headers, rows)
+			PrintOutput(snapshotListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No snapshots found")
 		}

--- a/cmd/storage.snapshot_test.go
+++ b/cmd/storage.snapshot_test.go
@@ -1,39 +1,38 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
+const snapshotVolURI = "/projects/proj-123/providers/Aruba.Storage/blockstorages/vol-001"
+
 func TestSnapshotListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSnapshotsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockSnapshotsClient) {
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-uri", snapshotVolURI},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "snap-001", "my-snapshot"
-				volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
-					return &types.Response[types.SnapshotList]{
-						StatusCode: 200,
-						Data: &types.SnapshotList{
-							Values: []types.SnapshotResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-									Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}}},
-							},
+				volURI := snapshotVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{
+					Values: []types.SnapshotResponse{
+						{
+							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}},
 						},
-					}, nil
-				}
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "snap-001") {
@@ -43,28 +42,25 @@ func TestSnapshotListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
-					return &types.Response[types.SnapshotList]{StatusCode: 200, Data: &types.SnapshotList{}}, nil
-				}
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-uri", snapshotVolURI},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{}))
 			},
 		},
 		{
 			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockSnapshotsClient) {
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-uri", snapshotVolURI, "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "snap-001", "my-snapshot"
-				volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
-					return &types.Response[types.SnapshotList]{
-						StatusCode: 200,
-						Data: &types.SnapshotList{
-							Values: []types.SnapshotResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-									Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}}},
-							},
+				volURI := snapshotVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{
+					Values: []types.SnapshotResponse{
+						{
+							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}},
 						},
-					}, nil
-				}
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -74,41 +70,29 @@ func TestSnapshotListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-uri", snapshotVolURI},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "listing",
+			wantErr: true, errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
-					return &types.Response[types.SnapshotList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-uri", snapshotVolURI},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSnapshotsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"storage", "snapshot", "list", "--project-id", "proj-123",
-				"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -120,21 +104,18 @@ func TestSnapshotListCmd(t *testing.T) {
 func TestSnapshotGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSnapshotsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockSnapshotsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "snap-001", "my-snapshot"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-					return &types.Response[types.SnapshotResponse]{
-						StatusCode: 200,
-						Data:       &types.SnapshotResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", jsonResponse(200, types.SnapshotResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "snap-001") {
@@ -143,36 +124,27 @@ func TestSnapshotGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "getting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-					return &types.Response[types.SnapshotResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "getting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSnapshotsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})),
+			out, err := runCmdCapture(srv.Client(),
 				[]string{"storage", "snapshot", "get", "snap-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
@@ -183,31 +155,29 @@ func TestSnapshotGetCmd(t *testing.T) {
 }
 
 func TestSnapshotCreateCmd(t *testing.T) {
+	createArgs := []string{
+		"storage", "snapshot", "create",
+		"--project-id", "proj-123",
+		"--name", "my-snapshot",
+		"--region", "IT-BG",
+		"--volume-uri", snapshotVolURI,
+	}
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockSnapshotsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			args: []string{
-				"storage", "snapshot", "create",
-				"--project-id", "proj-123",
-				"--name", "my-snapshot",
-				"--region", "IT-BG",
-				"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001",
-			},
-			setupMock: func(m *mockSnapshotsClient) {
+			args: createArgs,
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "snap-new", "my-snapshot"
-				m.createFn = func(_ context.Context, _ string, _ types.SnapshotRequest, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-					return &types.Response[types.SnapshotResponse]{
-						StatusCode: 200,
-						Data:       &types.SnapshotResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "snap-new") {
@@ -216,60 +186,41 @@ func TestSnapshotCreateCmd(t *testing.T) {
 			},
 		},
 		{
-			name:    "missing required flag --name",
-			args:    []string{"storage", "snapshot", "create", "--project-id", "proj-123", "--region", "IT-BG", "--volume-uri", "/v/vol-001"},
-			wantErr: true, errContains: "name",
-		},
-		{
-			name:    "missing required flag --volume-uri",
-			args:    []string{"storage", "snapshot", "create", "--project-id", "proj-123", "--name", "my-snapshot", "--region", "IT-BG"},
-			wantErr: true, errContains: "volume-uri",
-		},
-		{
-			name: "SDK error propagates",
-			args: []string{
-				"storage", "snapshot", "create",
-				"--project-id", "proj-123",
-				"--name", "my-snapshot",
-				"--region", "IT-BG",
-				"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001",
-			},
-			setupMock: func(m *mockSnapshotsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.SnapshotRequest, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
-			},
+			name:        "missing required flag --name",
+			args:        []string{"storage", "snapshot", "create", "--project-id", "proj-123", "--region", "IT-BG", "--volume-uri", snapshotVolURI},
 			wantErr:     true,
-			errContains: "creating",
+			errContains: "name",
+		},
+		{
+			name:        "missing required flag --volume-uri",
+			args:        []string{"storage", "snapshot", "create", "--project-id", "proj-123", "--name", "my-snapshot", "--region", "IT-BG"},
+			wantErr:     true,
+			errContains: "volume-uri",
 		},
 		{
 			name: "API error propagates",
-			args: []string{
-				"storage", "snapshot", "create",
-				"--project-id", "proj-123",
-				"--name", "my-snapshot",
-				"--region", "IT-BG",
-				"--volume-uri", "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001",
+			args: createArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/snapshots", errorResponse(404, "Not Found", "resource not found"))
 			},
-			setupMock: func(m *mockSnapshotsClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.SnapshotRequest, _ *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
-					return &types.Response[types.SnapshotResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			wantErr: true, errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "server error propagates",
+			args: createArgs,
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Storage/snapshots", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "creating",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSnapshotsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -281,17 +232,16 @@ func TestSnapshotCreateCmd(t *testing.T) {
 func TestSnapshotDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockSnapshotsClient)
+		setupSrv    func(*arubaTestServer)
+		extraArgs   []string
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "snap-001") {
@@ -300,12 +250,13 @@ func TestSnapshotDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			name:      "--dry-run: prints intent, does not call Delete",
+			extraArgs: []string{"--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "snap-001", "my-snapshot"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", jsonResponse(200, types.SnapshotResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "snap-001") {
@@ -314,40 +265,29 @@ func TestSnapshotDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", errorResponse(404, "Not Found", "resource not found"))
 			},
-			wantErr:     true,
-			errContains: "deleting",
+			wantErr: true, errContains: "API error (status 404): Not Found",
 		},
 		{
-			name: "API error propagates",
-			setupMock: func(m *mockSnapshotsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Storage/snapshots/snap-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
-			wantErr:     true,
-			errContains: "API error (status 404): Not Found",
+			wantErr: true, errContains: "deleting",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockSnapshotsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
 			args := []string{"storage", "snapshot", "delete", "snap-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withStorageMock(&mockStorageClient{snapshotsMock: m})), args)
+			args = append(args, tc.extraArgs...)
+			out, err := runCmdCapture(srv.Client(), args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)


### PR DESCRIPTION
## Summary

- Migrates `storage.blockstorage.go`, `storage.snapshot.go`, `storage.backup.go`, `storage.restore.go` (~35 SDK call sites) from the v0.1.x typed-request API to the v0.2.0 fluent wrapper layer
- Rewrites all 16 storage unit tests against the `arubaTestServer` httptest harness (replaces `mockVolumesClient`/`mockSnapshotsClient`/`mockStorageBackupsClient`/`mockStorageRestoreClient` stubs)
- Updates `ai/ARCHITECTURE.md`, `ai/CONVENTIONS.md`, `ai/TECH_DEBT.md` with storage-specific patterns (cross-family pre-validation, Restore's `IntoBackup`/`ToVolume`/backup-scoped `List`, TD-022 progress)

## Notable patterns

- **Backup Create**: validates source volume via `Volumes().Get` before building `NewStorageBackup().FromVolume(vol)`
- **Restore Create**: validates parent backup AND target volume via two cross-family Gets; uses `IntoBackup(bk)` (not `IntoProject`) and `ToVolume(target)`
- **Restore List**: backup-scoped — `Restores().List(ctx, backupRef(projectID, backupID), ...)` instead of project-scoped
- **Sub-client name**: `Volumes()` (no `BlockStorages()` alias)
- CLI surface (commands, flags, table output) is byte-identical; only `-o json`/`-o yaml` shape changes per #99 release notes

## Test plan

- [ ] `gofmt -l` on all 8 modified `cmd/storage.*` files returns no output (verified)
- [ ] Storage files compile cleanly (`go build ./cmd 2>&1 | grep "storage\."` returns no output — verified)
- [ ] Overall `go build ./cmd` remains red until #106–#110 land (expected, per TD-022)
- [ ] 16 unit tests follow the `arubaTestServer` harness pattern; cross-family create tests register all required GET + POST routes; dry-run delete tests register only GET (DELETE absence is the assertion)
- [ ] `ai/` docs updated: storage sub-clients, Ref helpers, cross-family patterns, Restore divergence, TD-022 progress

## Upstream SDK issues to open (post-merge)

1. Snapshot terminal-state map still says `"Available"` (`resource_snapshot.go:214-218`) — should be `"Active"` per CHANGELOG
2. List pagination stub for all four storage adapters — `Next/Prev/First/Last` error at runtime
3. `BlockStorage.Update` always sends `bootable=false` when never set — can flip server-side value
4. `StorageRestoreClient.Update`/`Delete` exposed but platform support undocumented

Closes #105