### PR TITLE
feat(sdk): migrate database family to SDK v0.2.0 wrapper API (#106)

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -452,3 +452,87 @@ updateReq := buildRequestFrom(current)    // preserve current values
 if name != "" { updateReq.Metadata.Name = name }
 if cmd.Flags().Changed("tags") { updateReq.Metadata.Tags = tags }
 ```
+
+---
+
+## Database Family
+
+`client.FromDatabase()` returns a `DatabaseClient` with four sub-clients:
+
+| Sub-client | Method | Resources |
+|---|---|---|
+| `DBaaS()` | `FromDatabase().DBaaS()` | DBaaS instances (project-scoped) |
+| `Databases()` | `FromDatabase().Databases()` | Databases inside a DBaaS (dbaas-scoped) |
+| `Backups()` | `FromDatabase().Backups()` | DBaaS Backups (project-scoped) |
+| `Users()` | `FromDatabase().Users()` | Users inside a DBaaS (dbaas-scoped) |
+
+**Note:** There is no `BlockStorages()` alias — `Volumes()` is the correct name for storage. Similarly, `FromDatabase().Backups()` (database backups) is distinct from `FromStorage().Backups()` (storage backups).
+
+### Two wrapper families
+
+**Family A** (DBaaS, DBaaSBackup) — standard `Metadata/Properties/Status` envelope. Uses `IntoProject(projectRef(projectID))` for the builder.
+
+**Family B** (Database, User) — flat request, name/username IS the path identifier, no `Metadata.ID` in responses. Uses `IntoDBaaS(dbaasRef(projectID, dbaasID))` for the builder. `Database.ID()` returns the name; `User.ID()` returns the username.
+
+### Ref helpers (declared per file)
+
+```go
+func dbaasRef(projectID, dbaasID string) aruba.Ref {
+    return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
+}
+func databaseRef(projectID, dbaasID, name string) aruba.Ref {
+    return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + name)
+}
+func userRef(projectID, dbaasID, username string) aruba.Ref {
+    return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username)
+}
+func databaseBackupRef(projectID, backupID string) aruba.Ref {
+    return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/backups/" + backupID)
+}
+```
+
+### List scoping
+
+- **DBaaS / Backup List** — project-scoped: `List(ctx, projectRef(projectID), listOpts(cmd)...)`
+- **Database / User List** — dbaas-scoped: `List(ctx, dbaasRef(projectID, dbaasID), listOpts(cmd)...)`
+
+### DBaaS Update — round-trip
+
+`DBaaS.fromResponse()` back-populates `engine`, `flavor`, `sizeGB`, `billingPeriod`, and networking refs automatically. The update pattern is just:
+
+```go
+current, err := client.FromDatabase().DBaaS().Get(ctx, dbaasRef(projectID, dbaasID))
+if name != "" { current.Named(name) }
+if cmd.Flags().Changed("size-gb") { current.WithSizeGB(sizeGB) }
+updated, err := client.FromDatabase().DBaaS().Update(ctx, current)
+```
+
+No manual field reconstruction is needed — all unchanged fields survive the round-trip.
+
+### Backup Create — no pre-validation Gets
+
+`FromDBaaS(Ref)` and `FromDatabase(Ref)` on the `DBaaSBackup` builder accept any `aruba.Ref` and call `.URI()` on them. Pass the constructed Refs directly — no pre-validation Gets needed:
+
+```go
+bk := aruba.NewDBaaSBackup().
+    IntoProject(projectRef(projectID)).
+    Named(name).
+    InRegion(aruba.Region(region)).
+    FromDBaaS(dbaasRef(projectID, dbaasID)).
+    FromDatabase(databaseRef(projectID, dbaasID, databaseName)).
+    WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+created, err := client.FromDatabase().Backups().Create(ctx, bk)
+```
+
+The old v0.1.x code performed 2 cross-family Gets just to obtain URIs (and used a malformed URI for the database ref). The v0.2.0 builder eliminates both round-trips.
+
+### BackupsClient — no Update
+
+`BackupsClient` exposes only `List / Get / Create / Delete`. There is no Update method. The `backupUpdateCmd` stub in `database.backup.go` returns an informational error without calling the SDK.
+
+### Identity accessors
+
+- DBaaS: `d.DBaaSID()` (equivalent to `d.ID()`)
+- DBaaSBackup: `b.DBaaSBackupID()` (use this, not `b.ID()`)
+- Database: `db.DatabaseID()` (returns the name, which is the path identifier)
+- User: `u.Username()` (returns the username, which is the path identifier)

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -432,3 +432,57 @@ if err != nil { return fmt.Errorf("listing restores: %w", apiErrFromV2(err)) }
 
 In tests, register the list route under the backup-scoped path:
 `/projects/{p}/providers/Aruba.Storage/backups/{bid}/restores`
+
+---
+
+## Database-specific patterns
+
+### Family B create (Database, User)
+
+Family B resources (Database, User) use `IntoDBaaS(dbaasRef(projectID, dbaasID))` rather than `IntoProject`. Name/username is the path identifier.
+
+```go
+// Database create
+db := aruba.NewDatabase().
+    IntoDBaaS(dbaasRef(projectID, dbaasID)).
+    Named(name)
+created, err := client.FromDatabase().Databases().Create(ctx, db)
+
+// User create
+u := aruba.NewUser().
+    IntoDBaaS(dbaasRef(projectID, dbaasID)).
+    WithUsername(username).
+    WithPassword(password)
+created, err := client.FromDatabase().Users().Create(ctx, u)
+```
+
+### DBaaSBackup create (no pre-validation Gets)
+
+Pass constructed Refs directly — `FromDBaaS` and `FromDatabase` accept any `aruba.Ref`:
+
+```go
+bk := aruba.NewDBaaSBackup().
+    IntoProject(projectRef(projectID)).
+    Named(name).
+    InRegion(aruba.Region(region)).
+    FromDBaaS(dbaasRef(projectID, dbaasID)).
+    FromDatabase(databaseRef(projectID, dbaasID, databaseName)).
+    WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+created, err := client.FromDatabase().Backups().Create(ctx, bk)
+```
+
+### Dbaas-scoped List
+
+Database and User List are scoped to a DBaaS instance, not a project:
+
+```go
+list, err := client.FromDatabase().Databases().List(ctx, dbaasRef(projectID, dbaasID), listOpts(cmd)...)
+list, err := client.FromDatabase().Users().List(ctx, dbaasRef(projectID, dbaasID), listOpts(cmd)...)
+```
+
+DBaaS and Backup List are project-scoped (standard pattern):
+
+```go
+list, err := client.FromDatabase().DBaaS().List(ctx, projectRef(projectID), listOpts(cmd)...)
+list, err := client.FromDatabase().Backups().List(ctx, projectRef(projectID), listOpts(cmd)...)
+```

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -45,11 +45,12 @@ Issues are grouped by severity. Address Critical items before new features ship;
 `go.mod` now depends on `github.com/Arubacloud/sdk-go v0.2.0`. Migration status:
 - #100 (shared helpers), #101 (`arubaTestServer` harness), #102 (`management.project`), #103 (`compute`: cloudserver + keypair), #104 (`network` family: 10 resources) — all merged onto `feat/sdk-v0.2.0-upgrade`.
 - #105 (storage family: blockstorage, snapshot, backup, restore) — merged onto `feat/sdk-v0.2.0-upgrade`.
-- #106–#110, #111 (database, container, kms, other families) — still open.
+- #106 (database family: dbaas, database, user, backup) — merged onto `feat/sdk-v0.2.0-upgrade`.
+- #107–#110 (container, kms, other families) — still open.
 
-`go build ./cmd` remains red until #106–#110 land. `make e2e-network` requires live credentials (validated after integration branch complete).
+`go build ./cmd` remains red until #107–#110 land. `make e2e-network` requires live credentials (validated after integration branch complete).
 
-**Fix:** Close out #99's exit criteria (#106–#110 + #111), then mark TD-022 resolved.
+**Fix:** Close out #99's exit criteria (#107–#110 + #111), then mark TD-022 resolved.
 
 ---
 

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -34,22 +35,37 @@ func init() {
 
 	backupGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 
-	// backupUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
-	// backupUpdateCmd.Flags().String("name", "", "New backup name")
-	// backupUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
-
 	backupDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	backupDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	backupDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
 
 	backupListCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
-	backupListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
-	backupListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+	backupListCmd.Flags().Int("limit", 0, "Maximum number of results to return (0 = no limit)")
+	backupListCmd.Flags().Int("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
 	backupGetCmd.ValidArgsFunction = completeDatabaseBackupID
-	// backupUpdateCmd.ValidArgsFunction = completeDatabaseBackupID
 	backupDeleteCmd.ValidArgsFunction = completeDatabaseBackupID
+}
+
+// File-local Ref helpers
+
+func databaseBackupRef(projectID, backupID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/backups/" + backupID)
+}
+
+func databaseBackupFromRaw(b *aruba.DBaaSBackup) *types.BackupResponse {
+	if b == nil {
+		return nil
+	}
+	return b.Raw()
+}
+
+func databaseBackupListPayload(l *aruba.List[*aruba.DBaaSBackup]) any {
+	if r, ok := l.Raw().(*types.Response[types.BackupList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
 }
 
 // Completion functions for database resources
@@ -65,19 +81,17 @@ func completeDatabaseBackupID(cmd *cobra.Command, args []string, toComplete stri
 	}
 
 	ctx := context.Background()
-	response, err := client.FromDatabase().Backups().List(ctx, projectID, nil)
+	list, err := client.FromDatabase().Backups().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, backup := range response.Data.Values {
-			if backup.Metadata.ID != nil && backup.Metadata.Name != nil {
-				id := *backup.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *backup.Metadata.Name))
-				}
+	if list != nil {
+		for _, b := range list.Items() {
+			id := b.DBaaSBackupID()
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, b.Name()))
 			}
 		}
 	}
@@ -124,101 +138,39 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Get DBaaS instance to get its URI
+		bk := aruba.NewDBaaSBackup().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			FromDBaaS(dbaasRef(projectID, dbaasID)).
+			FromDatabase(databaseRef(projectID, dbaasID, databaseName)).
+			WithBillingPeriod(aruba.BillingPeriod(billingPeriod))
+		if len(tags) > 0 {
+			bk.ReplaceTags(tags...)
+		}
+
 		ctx, cancel := newCtx()
 		defer cancel()
-		dbaasResp, err := client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
+		created, err := client.FromDatabase().Backups().Create(ctx, bk)
 		if err != nil {
-			return fmt.Errorf("getting DBaaS instance: %w", err)
+			return fmt.Errorf("creating backup: %w", apiErrFromV2(err))
 		}
 
-		if dbaasResp == nil || dbaasResp.Data == nil || dbaasResp.Data.Metadata.URI == nil {
-			return fmt.Errorf("DBaaS instance not found")
-		}
-
-		// Get database to get its URI
-		dbResp, err := client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
-		if err != nil {
-			return fmt.Errorf("getting database: %w", err)
-		}
-
-		// Note: DatabaseResponse doesn't have a URI field, so we may need to construct it
-		// For now, we'll use the DBaaS URI and database name
-		// The actual implementation may need adjustment based on the API
-		dbaasURI := *dbaasResp.Data.Metadata.URI
-		// Construct database URI (format may vary - this is a placeholder)
-		databaseURI := fmt.Sprintf("%s/databases/%s", dbaasURI, databaseName)
-
-		createRequest := types.BackupRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.BackupPropertiesRequest{
-				Zone: region,
-				DBaaS: types.ReferenceResource{
-					URI: dbaasURI,
-				},
-				Database: types.ReferenceResource{
-					URI: databaseURI,
-				},
-				BillingPlan: types.BillingPeriodResource{
-					BillingPeriod: billingPeriod,
-				},
-			},
-		}
-
-		// Suppress unused variable warning
-		_ = dbResp
-
-		response, err := client.FromDatabase().Backups().Create(ctx, projectID, createRequest, nil)
-		if err != nil {
-			return fmt.Errorf("creating backup: %w", err)
-		}
-
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
+		resource := databaseBackupFromRaw(created)
+		if resource != nil {
+			fmt.Printf("\n%s\n", msgCreated("Backup", name))
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			row := []string{
-				func() string {
-					if response.Data.Metadata.ID != nil {
-						return *response.Data.Metadata.ID
-					}
-					return ""
-				}(),
-				func() string {
-					if response.Data.Metadata.Name != nil {
-						return *response.Data.Metadata.Name
-					}
-					return ""
-				}(),
-				func() string {
-					if response.Data.Metadata.LocationResponse != nil {
-						return response.Data.Metadata.LocationResponse.Value
-					}
-					return ""
-				}(),
-				func() string {
-					if response.Data.Status.State != nil {
-						return *response.Data.Status.State
-					}
-					return ""
-				}(),
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
-			PrintOutput(response.Data, headers, [][]string{row})
+			if resource.Metadata.LocationResponse != nil {
+				fmt.Printf("Region:          %s\n", resource.Metadata.LocationResponse.Value)
+			}
+			if resource.Status.State != nil {
+				fmt.Printf("Status:          %s\n", *resource.Status.State)
+			}
 		} else {
 			fmt.Println(msgCreatedAsync("Backup", name))
 		}
@@ -245,54 +197,48 @@ var backupGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
+		got, err := client.FromDatabase().Backups().Get(ctx, databaseBackupRef(projectID, backupID))
 		if err != nil {
-			return fmt.Errorf("getting backup: %w", err)
+			return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			backup := resp.Data
-
+		resource := databaseBackupFromRaw(got)
+		if resource != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(backup, nil, nil)
+				PrintOutput(resource, nil, nil)
 				return nil
 			}
 
 			fmt.Println("\nBackup Details:")
 			fmt.Println("==============")
 
-			if backup.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *backup.Metadata.ID)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			if backup.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *backup.Metadata.URI)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
-			if backup.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *backup.Metadata.Name)
+			if resource.Metadata.LocationResponse != nil {
+				fmt.Printf("Region:          %s\n", resource.Metadata.LocationResponse.Value)
 			}
-			if backup.Metadata.LocationResponse != nil {
-				if backup.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", backup.Metadata.LocationResponse.Value)
-				}
+			if resource.Status.State != nil {
+				fmt.Printf("Status:          %s\n", *resource.Status.State)
 			}
-			if backup.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *backup.Status.State)
+			if resource.Metadata.CreationDate != nil && !resource.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", resource.Metadata.CreationDate.Format(DateLayout))
 			}
-			if backup.Metadata.CreationDate != nil && !backup.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", backup.Metadata.CreationDate.Format(DateLayout))
+			if resource.Metadata.CreatedBy != nil {
+				fmt.Printf("Created By:      %s\n", *resource.Metadata.CreatedBy)
 			}
-			if backup.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *backup.Metadata.CreatedBy)
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
 			}
-			if len(backup.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", backup.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
+			if resource.Properties.DBaaS.URI != "" {
+				fmt.Printf("DBaaS URI:       %s\n", resource.Properties.DBaaS.URI)
+			}
+			if resource.Properties.Database.URI != "" {
+				fmt.Printf("Database URI:    %s\n", resource.Properties.Database.URI)
 			}
 			fmt.Println()
 		} else {
@@ -319,16 +265,12 @@ var backupListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().Backups().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromDatabase().Backups().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing backups: %w", err)
+			return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 30},
@@ -337,36 +279,16 @@ var backupListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, backup := range resp.Data.Values {
+			for _, b := range list.Items() {
 				row := []string{
-					func() string {
-						if backup.Metadata.Name != nil {
-							return *backup.Metadata.Name
-						}
-						return ""
-					}(),
-					func() string {
-						if backup.Metadata.ID != nil {
-							return *backup.Metadata.ID
-						}
-						return ""
-					}(),
-					func() string {
-						if backup.Metadata.LocationResponse != nil {
-							return backup.Metadata.LocationResponse.Value
-						}
-						return ""
-					}(),
-					func() string {
-						if backup.Status.State != nil {
-							return *backup.Status.State
-						}
-						return ""
-					}(),
+					b.Name(),
+					b.DBaaSBackupID(),
+					string(b.Region()),
+					b.State(),
 				}
 				rows = append(rows, row)
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(databaseBackupListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No backups found")
 		}
@@ -392,17 +314,7 @@ var backupDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		backupID := args[0]
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		if !confirm {
-			ok, err := confirmDelete("backup", backupID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
@@ -419,20 +331,25 @@ var backupDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-			if err != nil {
-				return fmt.Errorf("dry-run: database backup not found or inaccessible: %w", err)
+			if _, err := client.FromDatabase().Backups().Get(ctx, databaseBackupRef(projectID, backupID)); err != nil {
+				return fmt.Errorf("dry-run: database backup not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("database backup", backupID))
 			return nil
 		}
 
-		deleteResp, err := client.FromDatabase().Backups().Delete(ctx, projectID, backupID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting backup: %w", err)
+		if !skipConfirm {
+			ok, err := confirmDelete("backup", backupID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+
+		if err := client.FromDatabase().Backups().Delete(ctx, databaseBackupRef(projectID, backupID)); err != nil {
+			return fmt.Errorf("deleting backup: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Backup", backupID))

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,54 +11,46 @@ import (
 func TestDBBackupListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDBBackupsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockDBBackupsClient) {
+			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
-					return &types.Response[types.BackupList]{
-						StatusCode: 200,
-						Data: &types.BackupList{
-							Values: []types.BackupResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{
+					Values: []types.BackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "bkp-001") {
-					t.Errorf("expected ID in output, got: %s", out)
+				if !strings.Contains(out, "my-backup") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
-					return &types.Response[types.BackupList]{StatusCode: 200, Data: &types.BackupList{}}, nil
-				}
+			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockDBBackupsClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"database", "backup", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
-					return &types.Response[types.BackupList]{
-						StatusCode: 200,
-						Data: &types.BackupList{
-							Values: []types.BackupResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{
+					Values: []types.BackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +60,19 @@ func TestDBBackupListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.BackupList], error) {
-					return &types.Response[types.BackupList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +80,11 @@ func TestDBBackupListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBBackupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "backup", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestDBBackupListCmd(t *testing.T) {
 func TestDBBackupGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDBBackupsClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockDBBackupsClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-					return &types.Response[types.BackupResponse]{
-						StatusCode: 200,
-						Data:       &types.BackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", jsonResponse(200, types.BackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -138,24 +116,17 @@ func TestDBBackupGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-					return &types.Response[types.BackupResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +134,11 @@ func TestDBBackupGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBBackupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})),
-				[]string{"database", "backup", "get", "bkp-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"database", "backup", "get", "bkp-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -177,34 +147,19 @@ func TestDBBackupGetCmd(t *testing.T) {
 	}
 }
 
-// newDBBackupCreateMock returns a mockDatabaseClient wired for backup create.
-// The backup create command first fetches the DBaaS instance and database, then
-// calls Backups().Create(). All three sub-clients must be set.
-func newDBBackupCreateMock(backupsFn func(context.Context, string, types.BackupRequest, *types.RequestParameters) (*types.Response[types.BackupResponse], error)) *mockDatabaseClient {
-	dbaasURI := "/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001"
-	dbaas := &mockDBaaSClient{
-		getFn: func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-			return &types.Response[types.DBaaSResponse]{
-				StatusCode: 200,
-				Data:       &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{URI: &dbaasURI}},
-			}, nil
-		},
-	}
-	databases := &mockDatabasesClient{
-		getFn: func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-			return &types.Response[types.DatabaseResponse]{StatusCode: 200, Data: &types.DatabaseResponse{Name: "mydb"}}, nil
-		},
-	}
-	backups := &mockDBBackupsClient{createFn: backupsFn}
-	return &mockDatabaseClient{dbaasClient: dbaas, databasesClient: databases, backupsClient: backups}
-}
-
 func TestDBBackupCreateCmd(t *testing.T) {
-	createArgs := []string{"database", "backup", "create", "--project-id", "proj-123", "--name", "my-backup", "--region", "IT-BG", "--dbaas-id", "dbaas-001", "--database-name", "mydb"}
+	createArgs := []string{
+		"database", "backup", "create",
+		"--project-id", "proj-123",
+		"--name", "my-backup",
+		"--region", "IT-BG",
+		"--dbaas-id", "dbaas-001",
+		"--database-name", "mydb",
+	}
 	tests := []struct {
 		name        string
 		args        []string
-		dbMock      *mockDatabaseClient
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -212,60 +167,68 @@ func TestDBBackupCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: createArgs,
-			dbMock: newDBBackupCreateMock(func(_ context.Context, _ string, _ types.BackupRequest, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-				id, bname := "bkp-new", "my-backup"
-				return &types.Response[types.BackupResponse]{
-					StatusCode: 200,
-					Data:       &types.BackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &bname}},
-				}, nil
-			}),
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-new", "my-backup"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
 			assertOut: func(t *testing.T, out string) {
-				if !strings.Contains(out, "bkp-new") {
-					t.Errorf("expected ID in output, got: %s", out)
+				if !strings.Contains(out, "my-backup") {
+					t.Errorf("expected name in output, got: %s", out)
 				}
 			},
 		},
 		{
-			name:        "missing required flag --name",
-			args:        []string{"database", "backup", "create", "--project-id", "proj-123", "--region", "IT-BG", "--dbaas-id", "dbaas-001", "--database-name", "mydb"},
+			name: "missing required flag --name",
+			args: []string{
+				"database", "backup", "create",
+				"--project-id", "proj-123",
+				"--region", "IT-BG",
+				"--dbaas-id", "dbaas-001",
+				"--database-name", "mydb",
+			},
 			wantErr:     true,
 			errContains: "name",
 		},
 		{
-			name:        "missing required flag --dbaas-id",
-			args:        []string{"database", "backup", "create", "--project-id", "proj-123", "--name", "my-backup", "--region", "IT-BG", "--database-name", "mydb"},
+			name: "missing required flag --dbaas-id",
+			args: []string{
+				"database", "backup", "create",
+				"--project-id", "proj-123",
+				"--name", "my-backup",
+				"--region", "IT-BG",
+				"--database-name", "mydb",
+			},
 			wantErr:     true,
 			errContains: "dbaas-id",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: createArgs,
-			dbMock: newDBBackupCreateMock(func(_ context.Context, _ string, _ types.BackupRequest, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-				return nil, fmt.Errorf("quota exceeded")
-			}),
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/backups", errorResponse(500, "Internal Server Error", "quota exceeded"))
+			},
 			wantErr:     true,
 			errContains: "creating",
 		},
 		{
 			name: "API error propagates",
 			args: createArgs,
-			dbMock: newDBBackupCreateMock(func(_ context.Context, _ string, _ types.BackupRequest, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-				return &types.Response[types.BackupResponse]{
-					StatusCode: 404,
-					Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-				}, nil
-			}),
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/backups", errorResponse(404, "Not Found", "resource not found"))
+			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dbMock := tc.dbMock
-			if dbMock == nil {
-				dbMock = &mockDatabaseClient{}
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(dbMock)), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -277,17 +240,17 @@ func TestDBBackupCreateCmd(t *testing.T) {
 func TestDBBackupDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDBBackupsClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -297,15 +260,12 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockDBBackupsClient) {
+			args: []string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
-					return &types.Response[types.BackupResponse]{StatusCode: 200, Data: &types.BackupResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
-				}
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", jsonResponse(200, types.BackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "bkp-001") {
@@ -314,24 +274,19 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", errorResponse(500, "Internal Server Error", "not found"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDBBackupsClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/backups/bkp-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -339,15 +294,11 @@ func TestDBBackupDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBBackupsClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "backup", "delete", "bkp-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{backupsClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -33,13 +34,33 @@ func init() {
 	dbaasDatabaseDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
 
 	dbaasDatabaseListCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
-	dbaasDatabaseListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
-	dbaasDatabaseListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+	dbaasDatabaseListCmd.Flags().Int("limit", 0, "Maximum number of results to return (0 = no limit)")
+	dbaasDatabaseListCmd.Flags().Int("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
 	dbaasDatabaseGetCmd.ValidArgsFunction = completeDBaaSDatabaseID
 	dbaasDatabaseUpdateCmd.ValidArgsFunction = completeDBaaSDatabaseID
 	dbaasDatabaseDeleteCmd.ValidArgsFunction = completeDBaaSDatabaseID
+}
+
+// File-local Ref helpers
+
+func databaseRef(projectID, dbaasID, name string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + name)
+}
+
+func databaseFromRaw(d *aruba.Database) *types.DatabaseResponse {
+	if d == nil {
+		return nil
+	}
+	return d.Raw()
+}
+
+func databaseListPayload(l *aruba.List[*aruba.Database]) any {
+	if r, ok := l.Raw().(*types.Response[types.DatabaseList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
 }
 
 // Completion functions for database resources
@@ -61,18 +82,17 @@ func completeDBaaSDatabaseID(cmd *cobra.Command, args []string, toComplete strin
 	dbaasID := args[0]
 
 	ctx := context.Background()
-	response, err := client.FromDatabase().Databases().List(ctx, projectID, dbaasID, nil)
+	list, err := client.FromDatabase().Databases().List(ctx, dbaasRef(projectID, dbaasID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, db := range response.Data.Values {
-			if db.Name != "" {
-				if toComplete == "" || strings.HasPrefix(db.Name, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", db.Name, db.Name))
-				}
+	if list != nil {
+		for _, db := range list.Items() {
+			name := db.DatabaseID()
+			if toComplete == "" || strings.HasPrefix(name, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", name, name))
 			}
 		}
 	}
@@ -111,26 +131,23 @@ Use 'acloud database dbaas get <dbaas-id>' to check its status.`,
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		createRequest := types.DatabaseRequest{
-			Name: name,
-		}
+		db := aruba.NewDatabase().
+			IntoDBaaS(dbaasRef(projectID, dbaasID)).
+			Named(name)
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromDatabase().Databases().Create(ctx, projectID, dbaasID, createRequest, nil)
+		created, err := client.FromDatabase().Databases().Create(ctx, db)
 		if err != nil {
-			return fmt.Errorf("creating database: %w", err)
+			return fmt.Errorf("creating database: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := databaseFromRaw(created)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgCreated("Database", name))
-			fmt.Printf("Name:            %s\n", response.Data.Name)
-			if response.Data.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", response.Data.CreationDate.Format(DateLayout))
+			fmt.Printf("Name:            %s\n", resource.Name)
+			if resource.CreationDate != nil {
+				fmt.Printf("Creation Date:   %s\n", resource.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("Database", name))
@@ -159,33 +176,28 @@ var dbaasDatabaseGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
+		got, err := client.FromDatabase().Databases().Get(ctx, databaseRef(projectID, dbaasID, databaseName))
 		if err != nil {
-			return fmt.Errorf("getting database: %w", err)
+			return fmt.Errorf("getting database: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			db := resp.Data
-
+		resource := databaseFromRaw(got)
+		if resource != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(db, nil, nil)
+				PrintOutput(resource, nil, nil)
 				return nil
 			}
 
 			fmt.Println("\nDatabase Details:")
 			fmt.Println("================")
 
-			fmt.Printf("Name:            %s\n", db.Name)
-			if db.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", db.CreationDate.Format(DateLayout))
+			fmt.Printf("Name:            %s\n", resource.Name)
+			if resource.CreationDate != nil {
+				fmt.Printf("Creation Date:   %s\n", resource.CreationDate.Format(DateLayout))
 			}
-			if db.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *db.CreatedBy)
+			if resource.CreatedBy != nil {
+				fmt.Printf("Created By:      %s\n", *resource.CreatedBy)
 			}
 			fmt.Println()
 		} else {
@@ -214,16 +226,12 @@ var dbaasDatabaseListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().Databases().List(ctx, projectID, dbaasID, listParams(cmd))
+		list, err := client.FromDatabase().Databases().List(ctx, dbaasRef(projectID, dbaasID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing databases: %w", err)
+			return fmt.Errorf("listing databases: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 40},
 				{Header: "CREATION DATE", Width: 25},
@@ -231,25 +239,21 @@ var dbaasDatabaseListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, db := range resp.Data.Values {
+			for _, db := range list.Items() {
 				row := []string{
-					db.Name,
+					db.Name(),
 					func() string {
-						if db.CreationDate != nil {
-							return db.CreationDate.Format(DateLayout)
+						t := db.CreatedAt()
+						if t.IsZero() {
+							return ""
 						}
-						return ""
+						return t.Format(DateLayout)
 					}(),
-					func() string {
-						if db.CreatedBy != nil {
-							return *db.CreatedBy
-						}
-						return ""
-					}(),
+					db.CreatedBy(),
 				}
 				rows = append(rows, row)
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(databaseListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No databases found")
 		}
@@ -281,24 +285,24 @@ var dbaasDatabaseUpdateCmd = &cobra.Command{
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		updateRequest := types.DatabaseRequest{
-			Name: name,
-		}
-
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromDatabase().Databases().Update(ctx, projectID, dbaasID, databaseName, updateRequest, nil)
+		current, err := client.FromDatabase().Databases().Get(ctx, databaseRef(projectID, dbaasID, databaseName))
 		if err != nil {
-			return fmt.Errorf("updating database: %w", err)
+			return fmt.Errorf("fetching current database: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		current.Named(name)
+
+		updated, err := client.FromDatabase().Databases().Update(ctx, current)
+		if err != nil {
+			return fmt.Errorf("updating database: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
+		resource := databaseFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("Database", databaseName))
-			fmt.Printf("Name:            %s\n", response.Data.Name)
+			fmt.Printf("Name:            %s\n", resource.Name)
 		} else {
 			fmt.Println(msgUpdatedAsync("Database", databaseName))
 		}
@@ -314,17 +318,7 @@ var dbaasDatabaseDeleteCmd = &cobra.Command{
 		dbaasID := args[0]
 		databaseName := args[1]
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		if !confirm {
-			ok, err := confirmDelete(fmt.Sprintf("database '%s' in DBaaS instance", databaseName), dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
@@ -341,20 +335,25 @@ var dbaasDatabaseDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
-			if err != nil {
-				return fmt.Errorf("dry-run: database not found or inaccessible: %w", err)
+			if _, err := client.FromDatabase().Databases().Get(ctx, databaseRef(projectID, dbaasID, databaseName)); err != nil {
+				return fmt.Errorf("dry-run: database not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("database", databaseName))
 			return nil
 		}
 
-		deleteResp, err := client.FromDatabase().Databases().Delete(ctx, projectID, dbaasID, databaseName, nil)
-		if err != nil {
-			return fmt.Errorf("deleting database: %w", err)
+		if !skipConfirm {
+			ok, err := confirmDelete(fmt.Sprintf("database '%s' in DBaaS instance", databaseName), dbaasID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+
+		if err := client.FromDatabase().Databases().Delete(ctx, databaseRef(projectID, dbaasID, databaseName)); err != nil {
+			return fmt.Errorf("deleting database: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("Database", databaseName))

--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,24 +11,21 @@ import (
 func TestDBaaSDatabaseListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDatabasesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockDatabasesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
-					return &types.Response[types.DatabaseList]{
-						StatusCode: 200,
-						Data: &types.DatabaseList{
-							Values: []types.DatabaseResponse{
-								{Name: "my-db"},
-							},
-						},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{
+					Values: []types.DatabaseResponse{
+						{Name: "my-db"},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-db") {
@@ -40,25 +35,20 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockDatabasesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
-					return &types.Response[types.DatabaseList]{StatusCode: 200, Data: &types.DatabaseList{}}, nil
-				}
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockDatabasesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
-					return &types.Response[types.DatabaseList]{
-						StatusCode: 200,
-						Data: &types.DatabaseList{
-							Values: []types.DatabaseResponse{
-								{Name: "my-db"},
-							},
-						},
-					}, nil
-				}
+			name: "--output json emits valid JSON",
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{
+					Values: []types.DatabaseResponse{
+						{Name: "my-db"},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -68,24 +58,19 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDatabasesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDatabasesClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
-					return &types.Response[types.DatabaseList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -93,15 +78,11 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDatabasesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -113,20 +94,17 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 func TestDBaaSDatabaseGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDatabasesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockDatabasesClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return &types.Response[types.DatabaseResponse]{
-						StatusCode: 200,
-						Data:       &types.DatabaseResponse{Name: "my-db"},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", jsonResponse(200, types.DatabaseResponse{
+					Name: "my-db",
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-db") {
@@ -135,24 +113,17 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDatabasesClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDatabasesClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return &types.Response[types.DatabaseResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -160,12 +131,11 @@ func TestDBaaSDatabaseGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDatabasesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})),
-				[]string{"database", "dbaas", "database", "get", "dbaas-001", "my-db", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"database", "dbaas", "database", "get", "dbaas-001", "my-db", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -178,7 +148,7 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockDatabasesClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -186,13 +156,10 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"database", "dbaas", "database", "create", "dbaas-001", "--project-id", "proj-123", "--name", "my-db"},
-			setupMock: func(m *mockDatabasesClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.DatabaseRequest, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return &types.Response[types.DatabaseResponse]{
-						StatusCode: 200,
-						Data:       &types.DatabaseResponse{Name: "my-db"},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseResponse{
+					Name: "my-db",
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-db") {
@@ -207,12 +174,10 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 			errContains: "name",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"database", "dbaas", "database", "create", "dbaas-001", "--project-id", "proj-123", "--name", "my-db"},
-			setupMock: func(m *mockDatabasesClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.DatabaseRequest, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -220,13 +185,8 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"database", "dbaas", "database", "create", "dbaas-001", "--project-id", "proj-123", "--name", "my-db"},
-			setupMock: func(m *mockDatabasesClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.DatabaseRequest, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return &types.Response[types.DatabaseResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -234,11 +194,11 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDatabasesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -250,17 +210,17 @@ func TestDBaaSDatabaseCreateCmd(t *testing.T) {
 func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDatabasesClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockDatabasesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-db") {
@@ -270,14 +230,11 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockDatabasesClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.DatabaseResponse], error) {
-					return &types.Response[types.DatabaseResponse]{StatusCode: 200, Data: &types.DatabaseResponse{Name: "my-db"}}, nil
-				}
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			args: []string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", jsonResponse(200, types.DatabaseResponse{
+					Name: "my-db",
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "my-db") {
@@ -286,24 +243,19 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDatabasesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDatabasesClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/my-db", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -311,15 +263,11 @@ func TestDBaaSDatabaseDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDatabasesClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "dbaas", "database", "delete", "dbaas-001", "my-db", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{databasesClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -41,13 +42,33 @@ func init() {
 	dbaasDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
 
 	dbaasListCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
-	dbaasListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
-	dbaasListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+	dbaasListCmd.Flags().Int("limit", 0, "Maximum number of results to return (0 = no limit)")
+	dbaasListCmd.Flags().Int("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
 	dbaasGetCmd.ValidArgsFunction = completeDBaaSID
 	dbaasUpdateCmd.ValidArgsFunction = completeDBaaSID
 	dbaasDeleteCmd.ValidArgsFunction = completeDBaaSID
+}
+
+// File-local Ref helpers
+
+func dbaasRef(projectID, dbaasID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
+}
+
+func dbaasFromRaw(d *aruba.DBaaS) *types.DBaaSResponse {
+	if d == nil {
+		return nil
+	}
+	return d.Raw()
+}
+
+func dbaasListPayload(l *aruba.List[*aruba.DBaaS]) any {
+	if r, ok := l.Raw().(*types.Response[types.DBaaSList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
 }
 
 // Completion functions for database resources
@@ -63,21 +84,17 @@ func completeDBaaSID(cmd *cobra.Command, args []string, toComplete string) ([]st
 	}
 
 	ctx := context.Background()
-	// Note: This assumes FromDatabase().DBaaS().List() exists in the SDK
-	// If not available, this will need to be updated when SDK methods are added
-	response, err := client.FromDatabase().DBaaS().List(ctx, projectID, nil)
+	list, err := client.FromDatabase().DBaaS().List(ctx, projectRef(projectID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, dbaas := range response.Data.Values {
-			if dbaas.Metadata.ID != nil && dbaas.Metadata.Name != nil {
-				id := *dbaas.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *dbaas.Metadata.Name))
-				}
+	if list != nil {
+		for _, r := range list.Items() {
+			id := r.DBaaSID()
+			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, r.Name()))
 			}
 		}
 	}
@@ -124,39 +141,25 @@ and users with 'acloud database dbaas user create'.`,
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		// Build the create request
-		createRequest := types.DBaaSRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: name,
-					Tags: tags,
-				},
-				Location: types.LocationRequest{
-					Value: region,
-				},
-			},
-			Properties: types.DBaaSPropertiesRequest{
-				Engine: &types.DBaaSEngine{
-					ID: &engineID,
-				},
-				Flavor: &types.DBaaSFlavor{
-					Name: &flavor,
-				},
-			},
+		d := aruba.NewDBaaS().
+			IntoProject(projectRef(projectID)).
+			Named(name).
+			InRegion(aruba.Region(region)).
+			OfEngine(aruba.DatabaseEngine(engineID)).
+			OfFlavor(aruba.DBaaSFlavor(flavor))
+		if len(tags) > 0 {
+			d.ReplaceTags(tags...)
 		}
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromDatabase().DBaaS().Create(ctx, projectID, createRequest, nil)
+		created, err := client.FromDatabase().DBaaS().Create(ctx, d)
 		if err != nil {
-			return fmt.Errorf("creating DBaaS instance: %w", err)
+			return fmt.Errorf("creating DBaaS instance: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := dbaasFromRaw(created)
+		if resource != nil {
 			headers := []TableColumn{
 				{Header: "ID", Width: 30},
 				{Header: "NAME", Width: 40},
@@ -167,43 +170,43 @@ and users with 'acloud database dbaas user create'.`,
 			}
 			row := []string{
 				func() string {
-					if response.Data.Metadata.ID != nil {
-						return *response.Data.Metadata.ID
+					if resource.Metadata.ID != nil {
+						return *resource.Metadata.ID
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Metadata.Name != nil {
-						return *response.Data.Metadata.Name
+					if resource.Metadata.Name != nil {
+						return *resource.Metadata.Name
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Properties.Engine != nil && response.Data.Properties.Engine.Type != nil {
-						return *response.Data.Properties.Engine.Type
+					if resource.Properties.Engine != nil && resource.Properties.Engine.Type != nil {
+						return *resource.Properties.Engine.Type
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Properties.Engine != nil && response.Data.Properties.Engine.Version != nil {
-						return *response.Data.Properties.Engine.Version
+					if resource.Properties.Engine != nil && resource.Properties.Engine.Version != nil {
+						return *resource.Properties.Engine.Version
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Properties.Flavor != nil && response.Data.Properties.Flavor.Name != nil {
-						return *response.Data.Properties.Flavor.Name
+					if resource.Properties.Flavor != nil && resource.Properties.Flavor.Name != nil {
+						return *resource.Properties.Flavor.Name
 					}
 					return ""
 				}(),
 				func() string {
-					if response.Data.Metadata.LocationResponse != nil {
-						return response.Data.Metadata.LocationResponse.Value
+					if resource.Metadata.LocationResponse != nil {
+						return resource.Metadata.LocationResponse.Value
 					}
 					return ""
 				}(),
 			}
-			PrintOutput(response.Data, headers, [][]string{row})
+			PrintOutput(resource, headers, [][]string{row})
 		} else {
 			fmt.Println(msgCreatedAsync("DBaaS instance", name))
 		}
@@ -230,66 +233,59 @@ var dbaasGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
+		got, err := client.FromDatabase().DBaaS().Get(ctx, dbaasRef(projectID, dbaasID))
 		if err != nil {
-			return fmt.Errorf("getting DBaaS instance: %w", err)
+			return fmt.Errorf("getting DBaaS instance: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			dbaas := resp.Data
-
+		resource := dbaasFromRaw(got)
+		if resource != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(dbaas, nil, nil)
+				PrintOutput(resource, nil, nil)
 				return nil
 			}
 
 			fmt.Println("\nDBaaS Instance Details:")
 			fmt.Println("======================")
 
-			if dbaas.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *dbaas.Metadata.ID)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
 			}
-			if dbaas.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *dbaas.Metadata.URI)
+			if resource.Metadata.URI != nil {
+				fmt.Printf("URI:             %s\n", *resource.Metadata.URI)
 			}
-			if dbaas.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *dbaas.Metadata.Name)
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
 			}
-			if dbaas.Metadata.LocationResponse != nil {
-				if dbaas.Metadata.LocationResponse != nil {
-					fmt.Printf("Region:          %s\n", dbaas.Metadata.LocationResponse.Value)
+			if resource.Metadata.LocationResponse != nil {
+				fmt.Printf("Region:          %s\n", resource.Metadata.LocationResponse.Value)
+			}
+			if resource.Properties.Engine != nil {
+				if resource.Properties.Engine.Type != nil {
+					fmt.Printf("Engine Type:     %s\n", *resource.Properties.Engine.Type)
+				}
+				if resource.Properties.Engine.Version != nil {
+					fmt.Printf("Engine Version:  %s\n", *resource.Properties.Engine.Version)
+				}
+				if resource.Properties.Engine.Name != nil {
+					fmt.Printf("Engine Name:    %s\n", *resource.Properties.Engine.Name)
 				}
 			}
-			if dbaas.Properties.Engine != nil {
-				if dbaas.Properties.Engine.Type != nil {
-					fmt.Printf("Engine Type:     %s\n", *dbaas.Properties.Engine.Type)
-				}
-				if dbaas.Properties.Engine.Version != nil {
-					fmt.Printf("Engine Version:  %s\n", *dbaas.Properties.Engine.Version)
-				}
-				if dbaas.Properties.Engine.Name != nil {
-					fmt.Printf("Engine Name:    %s\n", *dbaas.Properties.Engine.Name)
-				}
+			if resource.Properties.Flavor != nil && resource.Properties.Flavor.Name != nil {
+				fmt.Printf("Flavor:         %s\n", *resource.Properties.Flavor.Name)
 			}
-			if dbaas.Properties.Flavor != nil && dbaas.Properties.Flavor.Name != nil {
-				fmt.Printf("Flavor:         %s\n", *dbaas.Properties.Flavor.Name)
+			if resource.Status.State != nil {
+				fmt.Printf("Status:          %s\n", *resource.Status.State)
 			}
-			if dbaas.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *dbaas.Status.State)
+			if resource.Metadata.CreationDate != nil && !resource.Metadata.CreationDate.IsZero() {
+				fmt.Printf("Creation Date:   %s\n", resource.Metadata.CreationDate.Format(DateLayout))
 			}
-			if dbaas.Metadata.CreationDate != nil && !dbaas.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", dbaas.Metadata.CreationDate.Format(DateLayout))
+			if resource.Metadata.CreatedBy != nil {
+				fmt.Printf("Created By:      %s\n", *resource.Metadata.CreatedBy)
 			}
-			if dbaas.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *dbaas.Metadata.CreatedBy)
-			}
-			if len(dbaas.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", dbaas.Metadata.Tags)
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
 			} else {
 				fmt.Printf("Tags:            []\n")
 			}
@@ -318,16 +314,12 @@ var dbaasListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().DBaaS().List(ctx, projectID, listParams(cmd))
+		list, err := client.FromDatabase().DBaaS().List(ctx, projectRef(projectID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing DBaaS instances: %w", err)
+			return fmt.Errorf("listing DBaaS instances: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "NAME", Width: 30},
 				{Header: "ID", Width: 30},
@@ -339,54 +331,58 @@ var dbaasListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, dbaas := range resp.Data.Values {
+			for _, d := range list.Items() {
+				raw := dbaasFromRaw(d)
+				if raw == nil {
+					continue
+				}
 				row := []string{
 					func() string {
-						if dbaas.Metadata.Name != nil {
-							return *dbaas.Metadata.Name
+						if raw.Metadata.Name != nil {
+							return *raw.Metadata.Name
 						}
 						return ""
 					}(),
 					func() string {
-						if dbaas.Metadata.ID != nil {
-							return *dbaas.Metadata.ID
+						if raw.Metadata.ID != nil {
+							return *raw.Metadata.ID
 						}
 						return ""
 					}(),
 					func() string {
-						if dbaas.Properties.Engine != nil && dbaas.Properties.Engine.Type != nil {
-							return *dbaas.Properties.Engine.Type
+						if raw.Properties.Engine != nil && raw.Properties.Engine.Type != nil {
+							return *raw.Properties.Engine.Type
 						}
 						return ""
 					}(),
 					func() string {
-						if dbaas.Properties.Engine != nil && dbaas.Properties.Engine.Version != nil {
-							return *dbaas.Properties.Engine.Version
+						if raw.Properties.Engine != nil && raw.Properties.Engine.Version != nil {
+							return *raw.Properties.Engine.Version
 						}
 						return ""
 					}(),
 					func() string {
-						if dbaas.Properties.Flavor != nil && dbaas.Properties.Flavor.Name != nil {
-							return *dbaas.Properties.Flavor.Name
+						if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
+							return *raw.Properties.Flavor.Name
 						}
 						return ""
 					}(),
 					func() string {
-						if dbaas.Metadata.LocationResponse != nil {
-							return dbaas.Metadata.LocationResponse.Value
+						if raw.Metadata.LocationResponse != nil {
+							return raw.Metadata.LocationResponse.Value
 						}
 						return ""
 					}(),
 					func() string {
-						if dbaas.Status.State != nil {
-							return *dbaas.Status.State
+						if raw.Status.State != nil {
+							return *raw.Status.State
 						}
 						return ""
 					}(),
 				}
 				rows = append(rows, row)
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(dbaasListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No DBaaS instances found")
 		}
@@ -420,76 +416,34 @@ var dbaasUpdateCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		getResp, err := client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
+		current, err := client.FromDatabase().DBaaS().Get(ctx, dbaasRef(projectID, dbaasID))
 		if err != nil {
-			return fmt.Errorf("getting DBaaS instance: %w", err)
-		}
-
-		if getResp == nil || getResp.Data == nil {
-			return fmt.Errorf("DBaaS instance not found")
-		}
-
-		current := getResp.Data
-
-		regionValue := ""
-		if current.Metadata.LocationResponse != nil {
-			regionValue = current.Metadata.LocationResponse.Value
-		}
-		if regionValue == "" {
-			return fmt.Errorf("unable to determine region value for DBaaS instance")
-		}
-
-		// Build update request preserving current properties
-		updateRequest := types.DBaaSRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: *current.Metadata.Name,
-					Tags: current.Metadata.Tags,
-				},
-				Location: types.LocationRequest{
-					Value: regionValue,
-				},
-			},
-			Properties: types.DBaaSPropertiesRequest{},
-		}
-
-		// Preserve current engine if it exists
-		if current.Properties.Engine != nil {
-			updateRequest.Properties.Engine = &types.DBaaSEngine{
-				ID: current.Properties.Engine.ID,
-			}
-		}
-
-		// Preserve current flavor if it exists
-		if current.Properties.Flavor != nil {
-			updateRequest.Properties.Flavor = &types.DBaaSFlavor{
-				Name: current.Properties.Flavor.Name,
-			}
+			return fmt.Errorf("fetching current DBaaS instance: %w", apiErrFromV2(err))
 		}
 
 		if name != "" {
-			updateRequest.Metadata.ResourceMetadataRequest.Name = name
+			current.Named(name)
 		}
-
 		if cmd.Flags().Changed("tags") {
-			updateRequest.Metadata.ResourceMetadataRequest.Tags = tags
+			current.ReplaceTags(tags...)
 		}
 
-		response, err := client.FromDatabase().DBaaS().Update(ctx, projectID, dbaasID, updateRequest, nil)
+		updated, err := client.FromDatabase().DBaaS().Update(ctx, current)
 		if err != nil {
-			return fmt.Errorf("updating DBaaS instance: %w", err)
+			return fmt.Errorf("updating DBaaS instance: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := dbaasFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("DBaaS instance", dbaasID))
-			fmt.Printf("ID:              %s\n", *response.Data.Metadata.ID)
-			fmt.Printf("Name:            %s\n", *response.Data.Metadata.Name)
-			if len(response.Data.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", response.Data.Metadata.Tags)
+			if resource.Metadata.ID != nil {
+				fmt.Printf("ID:              %s\n", *resource.Metadata.ID)
+			}
+			if resource.Metadata.Name != nil {
+				fmt.Printf("Name:            %s\n", *resource.Metadata.Name)
+			}
+			if len(resource.Metadata.Tags) > 0 {
+				fmt.Printf("Tags:            %v\n", resource.Metadata.Tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("DBaaS instance", dbaasID))
@@ -505,17 +459,7 @@ var dbaasDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dbaasID := args[0]
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		if !confirm {
-			ok, err := confirmDelete("DBaaS instance", dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
@@ -532,20 +476,25 @@ var dbaasDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-			if err != nil {
-				return fmt.Errorf("dry-run: DBaaS instance not found or inaccessible: %w", err)
+			if _, err := client.FromDatabase().DBaaS().Get(ctx, dbaasRef(projectID, dbaasID)); err != nil {
+				return fmt.Errorf("dry-run: DBaaS instance not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("DBaaS instance", dbaasID))
 			return nil
 		}
 
-		deleteResp, err := client.FromDatabase().DBaaS().Delete(ctx, projectID, dbaasID, nil)
-		if err != nil {
-			return fmt.Errorf("deleting DBaaS instance: %w", err)
+		if !skipConfirm {
+			ok, err := confirmDelete("DBaaS instance", dbaasID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+
+		if err := client.FromDatabase().DBaaS().Delete(ctx, dbaasRef(projectID, dbaasID)); err != nil {
+			return fmt.Errorf("deleting DBaaS instance: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("DBaaS instance", dbaasID))

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -35,13 +36,33 @@ func init() {
 	dbaasUserDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
 
 	dbaasUserListCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
-	dbaasUserListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
-	dbaasUserListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+	dbaasUserListCmd.Flags().Int("limit", 0, "Maximum number of results to return (0 = no limit)")
+	dbaasUserListCmd.Flags().Int("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
 	dbaasUserGetCmd.ValidArgsFunction = completeDBaaSUserID
 	dbaasUserUpdateCmd.ValidArgsFunction = completeDBaaSUserID
 	dbaasUserDeleteCmd.ValidArgsFunction = completeDBaaSUserID
+}
+
+// File-local Ref helpers
+
+func userRef(projectID, dbaasID, username string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username)
+}
+
+func userFromRaw(u *aruba.User) *types.UserResponse {
+	if u == nil {
+		return nil
+	}
+	return u.Raw()
+}
+
+func userListPayload(l *aruba.List[*aruba.User]) any {
+	if r, ok := l.Raw().(*types.Response[types.UserList]); ok && r != nil {
+		return r.Data
+	}
+	return nil
 }
 
 // Completion functions for database resources
@@ -63,18 +84,17 @@ func completeDBaaSUserID(cmd *cobra.Command, args []string, toComplete string) (
 	dbaasID := args[0]
 
 	ctx := context.Background()
-	response, err := client.FromDatabase().Users().List(ctx, projectID, dbaasID, nil)
+	list, err := client.FromDatabase().Users().List(ctx, dbaasRef(projectID, dbaasID))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
-	if response != nil && response.Data != nil {
-		for _, user := range response.Data.Values {
-			if user.Username != "" {
-				if toComplete == "" || strings.HasPrefix(user.Username, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", user.Username, user.Username))
-				}
+	if list != nil {
+		for _, u := range list.Items() {
+			username := u.Username()
+			if toComplete == "" || strings.HasPrefix(username, toComplete) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", username, username))
 			}
 		}
 	}
@@ -114,27 +134,24 @@ separately through your database client after the user is created.`,
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		createRequest := types.UserRequest{
-			Username: username,
-			Password: password,
-		}
+		u := aruba.NewUser().
+			IntoDBaaS(dbaasRef(projectID, dbaasID)).
+			WithUsername(username).
+			WithPassword(password)
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromDatabase().Users().Create(ctx, projectID, dbaasID, createRequest, nil)
+		created, err := client.FromDatabase().Users().Create(ctx, u)
 		if err != nil {
-			return fmt.Errorf("creating user: %w", err)
+			return fmt.Errorf("creating user: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
-		}
-
-		if response != nil && response.Data != nil {
+		resource := userFromRaw(created)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgCreated("User", username))
-			fmt.Printf("Username:        %s\n", response.Data.Username)
-			if response.Data.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", response.Data.CreationDate.Format(DateLayout))
+			fmt.Printf("Username:        %s\n", resource.Username)
+			if resource.CreationDate != nil {
+				fmt.Printf("Creation Date:   %s\n", resource.CreationDate.Format(DateLayout))
 			}
 		} else {
 			fmt.Println(msgCreatedAsync("User", username))
@@ -163,33 +180,28 @@ var dbaasUserGetCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
+		got, err := client.FromDatabase().Users().Get(ctx, userRef(projectID, dbaasID, username))
 		if err != nil {
-			return fmt.Errorf("getting user: %w", err)
+			return fmt.Errorf("getting user: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil {
-			user := resp.Data
-
+		resource := userFromRaw(got)
+		if resource != nil {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(user, nil, nil)
+				PrintOutput(resource, nil, nil)
 				return nil
 			}
 
 			fmt.Println("\nUser Details:")
 			fmt.Println("=============")
 
-			fmt.Printf("Username:        %s\n", user.Username)
-			if user.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", user.CreationDate.Format(DateLayout))
+			fmt.Printf("Username:        %s\n", resource.Username)
+			if resource.CreationDate != nil {
+				fmt.Printf("Creation Date:   %s\n", resource.CreationDate.Format(DateLayout))
 			}
-			if user.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *user.CreatedBy)
+			if resource.CreatedBy != nil {
+				fmt.Printf("Created By:      %s\n", *resource.CreatedBy)
 			}
 			fmt.Println()
 		} else {
@@ -218,16 +230,12 @@ var dbaasUserListCmd = &cobra.Command{
 
 		ctx, cancel := newCtx()
 		defer cancel()
-		resp, err := client.FromDatabase().Users().List(ctx, projectID, dbaasID, listParams(cmd))
+		list, err := client.FromDatabase().Users().List(ctx, dbaasRef(projectID, dbaasID), listOpts(cmd)...)
 		if err != nil {
-			return fmt.Errorf("listing users: %w", err)
+			return fmt.Errorf("listing users: %w", apiErrFromV2(err))
 		}
 
-		if resp != nil && resp.IsError() {
-			return apiErrFromResp(resp.StatusCode, resp.Error)
-		}
-
-		if resp != nil && resp.Data != nil && len(resp.Data.Values) > 0 {
+		if list != nil && len(list.Items()) > 0 {
 			headers := []TableColumn{
 				{Header: "USERNAME", Width: 40},
 				{Header: "CREATION DATE", Width: 25},
@@ -235,25 +243,21 @@ var dbaasUserListCmd = &cobra.Command{
 			}
 
 			var rows [][]string
-			for _, user := range resp.Data.Values {
+			for _, u := range list.Items() {
 				row := []string{
-					user.Username,
+					u.Username(),
 					func() string {
-						if user.CreationDate != nil {
-							return user.CreationDate.Format(DateLayout)
+						t := u.CreatedAt()
+						if t.IsZero() {
+							return ""
 						}
-						return ""
+						return t.Format(DateLayout)
 					}(),
-					func() string {
-						if user.CreatedBy != nil {
-							return *user.CreatedBy
-						}
-						return ""
-					}(),
+					u.CreatedBy(),
 				}
 				rows = append(rows, row)
 			}
-			PrintOutput(resp.Data, headers, rows)
+			PrintOutput(userListPayload(list), headers, rows)
 		} else {
 			fmt.Println("No users found")
 		}
@@ -285,25 +289,24 @@ var dbaasUserUpdateCmd = &cobra.Command{
 			return fmt.Errorf("initializing client: %w", err)
 		}
 
-		updateRequest := types.UserRequest{
-			Username: username,
-			Password: password,
-		}
-
 		ctx, cancel := newCtx()
 		defer cancel()
-		response, err := client.FromDatabase().Users().Update(ctx, projectID, dbaasID, username, updateRequest, nil)
+		current, err := client.FromDatabase().Users().Get(ctx, userRef(projectID, dbaasID, username))
 		if err != nil {
-			return fmt.Errorf("updating user: %w", err)
+			return fmt.Errorf("fetching current user: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.IsError() {
-			return apiErrFromResp(response.StatusCode, response.Error)
+		current.WithPassword(password)
+
+		updated, err := client.FromDatabase().Users().Update(ctx, current)
+		if err != nil {
+			return fmt.Errorf("updating user: %w", apiErrFromV2(err))
 		}
 
-		if response != nil && response.Data != nil {
+		resource := userFromRaw(updated)
+		if resource != nil {
 			fmt.Printf("\n%s\n", msgUpdated("User", username))
-			fmt.Printf("Username:        %s\n", response.Data.Username)
+			fmt.Printf("Username:        %s\n", resource.Username)
 		} else {
 			fmt.Println(msgUpdatedAsync("User", username))
 		}
@@ -319,17 +322,7 @@ var dbaasUserDeleteCmd = &cobra.Command{
 		dbaasID := args[0]
 		username := args[1]
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		if !confirm {
-			ok, err := confirmDelete(fmt.Sprintf("user '%s' in DBaaS instance", username), dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
 		projectID, err := GetProjectID(cmd)
 		if err != nil {
@@ -346,20 +339,25 @@ var dbaasUserDeleteCmd = &cobra.Command{
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err = client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
-			if err != nil {
-				return fmt.Errorf("dry-run: database user not found or inaccessible: %w", err)
+			if _, err := client.FromDatabase().Users().Get(ctx, userRef(projectID, dbaasID, username)); err != nil {
+				return fmt.Errorf("dry-run: database user not found or inaccessible: %w", apiErrFromV2(err))
 			}
 			fmt.Println(msgDryRun("database user", username))
 			return nil
 		}
 
-		deleteResp, err := client.FromDatabase().Users().Delete(ctx, projectID, dbaasID, username, nil)
-		if err != nil {
-			return fmt.Errorf("deleting user: %w", err)
+		if !skipConfirm {
+			ok, err := confirmDelete(fmt.Sprintf("user '%s' in DBaaS instance", username), dbaasID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 		}
-		if deleteResp != nil && deleteResp.IsError() {
-			return apiErrFromResp(deleteResp.StatusCode, deleteResp.Error)
+
+		if err := client.FromDatabase().Users().Delete(ctx, userRef(projectID, dbaasID, username)); err != nil {
+			return fmt.Errorf("deleting user: %w", apiErrFromV2(err))
 		}
 
 		fmt.Println(msgDeleted("User", username))

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,24 +11,21 @@ import (
 func TestDBaaSUserListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockUsersClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockUsersClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
-					return &types.Response[types.UserList]{
-						StatusCode: 200,
-						Data: &types.UserList{
-							Values: []types.UserResponse{
-								{Username: "admin"},
-							},
-						},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{
+					Values: []types.UserResponse{
+						{Username: "admin"},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "admin") {
@@ -40,25 +35,20 @@ func TestDBaaSUserListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockUsersClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
-					return &types.Response[types.UserList]{StatusCode: 200, Data: &types.UserList{}}, nil
-				}
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockUsersClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
-					return &types.Response[types.UserList]{
-						StatusCode: 200,
-						Data: &types.UserList{
-							Values: []types.UserResponse{
-								{Username: "admin"},
-							},
-						},
-					}, nil
-				}
+			name: "--output json emits valid JSON",
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{
+					Values: []types.UserResponse{
+						{Username: "admin"},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -68,24 +58,19 @@ func TestDBaaSUserListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockUsersClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockUsersClient) {
-				m.listFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserList], error) {
-					return &types.Response[types.UserList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -93,15 +78,11 @@ func TestDBaaSUserListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockUsersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -113,20 +94,17 @@ func TestDBaaSUserListCmd(t *testing.T) {
 func TestDBaaSUserGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockUsersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockUsersClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return &types.Response[types.UserResponse]{
-						StatusCode: 200,
-						Data:       &types.UserResponse{Username: "admin"},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/admin", jsonResponse(200, types.UserResponse{
+					Username: "admin",
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "admin") {
@@ -135,24 +113,17 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockUsersClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/admin", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockUsersClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return &types.Response[types.UserResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/admin", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -160,12 +131,11 @@ func TestDBaaSUserGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockUsersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})),
-				[]string{"database", "dbaas", "user", "get", "dbaas-001", "admin", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"database", "dbaas", "user", "get", "dbaas-001", "admin", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -178,7 +148,7 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockUsersClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -186,13 +156,10 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"database", "dbaas", "user", "create", "dbaas-001", "--project-id", "proj-123", "--username", "myuser", "--password", "Pass1!"},
-			setupMock: func(m *mockUsersClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.UserRequest, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return &types.Response[types.UserResponse]{
-						StatusCode: 200,
-						Data:       &types.UserResponse{Username: "myuser"},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserResponse{
+					Username: "myuser",
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "myuser") {
@@ -213,12 +180,10 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 			errContains: "password",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"database", "dbaas", "user", "create", "dbaas-001", "--project-id", "proj-123", "--username", "myuser", "--password", "Pass1!"},
-			setupMock: func(m *mockUsersClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.UserRequest, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return nil, fmt.Errorf("duplicate user")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", errorResponse(500, "Internal Server Error", "duplicate user"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -226,13 +191,8 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"database", "dbaas", "user", "create", "dbaas-001", "--project-id", "proj-123", "--username", "myuser", "--password", "Pass1!"},
-			setupMock: func(m *mockUsersClient) {
-				m.createFn = func(_ context.Context, _, _ string, _ types.UserRequest, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return &types.Response[types.UserResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -240,11 +200,11 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockUsersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -256,17 +216,17 @@ func TestDBaaSUserCreateCmd(t *testing.T) {
 func TestDBaaSUserDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockUsersClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockUsersClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/myuser", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "myuser") {
@@ -276,14 +236,11 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockUsersClient) {
-				m.getFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[types.UserResponse], error) {
-					return &types.Response[types.UserResponse]{StatusCode: 200, Data: &types.UserResponse{Username: "myuser"}}, nil
-				}
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+			args: []string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/myuser", jsonResponse(200, types.UserResponse{
+					Username: "myuser",
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "myuser") {
@@ -292,24 +249,19 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockUsersClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			args: []string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/myuser", errorResponse(500, "Internal Server Error", "not found"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockUsersClient) {
-				m.deleteFn = func(_ context.Context, _, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users/myuser", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -317,15 +269,11 @@ func TestDBaaSUserDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockUsersClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "dbaas", "user", "delete", "dbaas-001", "myuser", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{usersClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)

--- a/cmd/database.dbaas_test.go
+++ b/cmd/database.dbaas_test.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,25 +11,22 @@ import (
 func TestDBaaSListCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDBaaSClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with results",
-			setupMock: func(m *mockDBaaSClient) {
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-001", "my-dbaas"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
-					return &types.Response[types.DBaaSList]{
-						StatusCode: 200,
-						Data: &types.DBaaSList{
-							Values: []types.DBaaSResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+					Values: []types.DBaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "dbaas-001") {
@@ -41,26 +36,21 @@ func TestDBaaSListCmd(t *testing.T) {
 		},
 		{
 			name: "success empty",
-			setupMock: func(m *mockDBaaSClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
-					return &types.Response[types.DBaaSList]{StatusCode: 200, Data: &types.DBaaSList{}}, nil
-				}
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{}))
 			},
 		},
 		{
-			name: "--output=json emits valid JSON",
-			setupMock: func(m *mockDBaaSClient) {
+			name: "--output json emits valid JSON",
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-001", "my-dbaas"
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
-					return &types.Response[types.DBaaSList]{
-						StatusCode: 200,
-						Data: &types.DBaaSList{
-							Values: []types.DBaaSResponse{
-								{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-							},
-						},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+					Values: []types.DBaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				var result map[string]any
@@ -70,24 +60,19 @@ func TestDBaaSListCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDBaaSClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
-					return nil, fmt.Errorf("connection refused")
-				}
+			name: "server error propagates",
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "listing",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDBaaSClient) {
-				m.listFn = func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
-					return &types.Response[types.DBaaSList]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -95,15 +80,11 @@ func TestDBaaSListCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBaaSClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "dbaas", "list", "--project-id", "proj-123"}
-			if tc.name == "--output=json emits valid JSON" {
-				args = append(args, "--output", "json")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -115,21 +96,18 @@ func TestDBaaSListCmd(t *testing.T) {
 func TestDBaaSGetCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDBaaSClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success",
-			setupMock: func(m *mockDBaaSClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-001", "my-dbaas"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return &types.Response[types.DBaaSResponse]{
-						StatusCode: 200,
-						Data:       &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", jsonResponse(200, types.DBaaSResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "dbaas-001") {
@@ -138,24 +116,17 @@ func TestDBaaSGetCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDBaaSClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return nil, fmt.Errorf("not found")
-				}
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
 			wantErr:     true,
 			errContains: "getting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDBaaSClient) {
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return &types.Response[types.DBaaSResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -163,12 +134,11 @@ func TestDBaaSGetCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBaaSClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})),
-				[]string{"database", "dbaas", "get", "dbaas-001", "--project-id", "proj-123"})
+			out, err := runCmdCapture(srv.Client(), []string{"database", "dbaas", "get", "dbaas-001", "--project-id", "proj-123"})
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -181,7 +151,7 @@ func TestDBaaSCreateCmd(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		setupMock   func(*mockDBaaSClient)
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
@@ -189,14 +159,11 @@ func TestDBaaSCreateCmd(t *testing.T) {
 		{
 			name: "success",
 			args: []string{"database", "dbaas", "create", "--project-id", "proj-123", "--name", "my-dbaas", "--region", "IT-BG", "--engine-id", "postgres14", "--flavor", "db.small"},
-			setupMock: func(m *mockDBaaSClient) {
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-new", "my-dbaas"
-				m.createFn = func(_ context.Context, _ string, _ types.DBaaSRequest, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return &types.Response[types.DBaaSResponse]{
-						StatusCode: 200,
-						Data:       &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
-					}, nil
-				}
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "dbaas-new") {
@@ -217,12 +184,10 @@ func TestDBaaSCreateCmd(t *testing.T) {
 			errContains: "engine-id",
 		},
 		{
-			name: "SDK error propagates",
+			name: "server error propagates",
 			args: []string{"database", "dbaas", "create", "--project-id", "proj-123", "--name", "my-dbaas", "--region", "IT-BG", "--engine-id", "postgres14", "--flavor", "db.small"},
-			setupMock: func(m *mockDBaaSClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.DBaaSRequest, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return nil, fmt.Errorf("quota exceeded")
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas", errorResponse(500, "Internal Server Error", "quota exceeded"))
 			},
 			wantErr:     true,
 			errContains: "creating",
@@ -230,13 +195,8 @@ func TestDBaaSCreateCmd(t *testing.T) {
 		{
 			name: "API error propagates",
 			args: []string{"database", "dbaas", "create", "--project-id", "proj-123", "--name", "my-dbaas", "--region", "IT-BG", "--engine-id", "postgres14", "--flavor", "db.small"},
-			setupMock: func(m *mockDBaaSClient) {
-				m.createFn = func(_ context.Context, _ string, _ types.DBaaSRequest, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return &types.Response[types.DBaaSResponse]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -244,11 +204,11 @@ func TestDBaaSCreateCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBaaSClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), tc.args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)
@@ -260,17 +220,17 @@ func TestDBaaSCreateCmd(t *testing.T) {
 func TestDBaaSDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMock   func(*mockDBaaSClient)
+		args        []string
+		setupSrv    func(*arubaTestServer)
 		wantErr     bool
 		errContains string
 		assertOut   func(*testing.T, string)
 	}{
 		{
 			name: "success with --yes",
-			setupMock: func(m *mockDBaaSClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{StatusCode: 200}, nil
-				}
+			args: []string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", jsonResponse(200, nil))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "dbaas-001") {
@@ -280,15 +240,12 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 		},
 		{
 			name: "--dry-run: prints intent, does not call Delete",
-			setupMock: func(m *mockDBaaSClient) {
+			args: []string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-001", "my-dbaas"
-				m.getFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.DBaaSResponse], error) {
-					return &types.Response[types.DBaaSResponse]{StatusCode: 200, Data: &types.DBaaSResponse{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}}}, nil
-				}
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					t.Fatal("Delete must not be called in --dry-run mode")
-					return nil, nil
-				}
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", jsonResponse(200, types.DBaaSResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "dbaas-001") {
@@ -297,24 +254,19 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "SDK error propagates",
-			setupMock: func(m *mockDBaaSClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return nil, fmt.Errorf("resource in use")
-				}
+			name: "server error propagates",
+			args: []string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", errorResponse(500, "Internal Server Error", "resource in use"))
 			},
 			wantErr:     true,
 			errContains: "deleting",
 		},
 		{
 			name: "API error propagates",
-			setupMock: func(m *mockDBaaSClient) {
-				m.deleteFn = func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[any], error) {
-					return &types.Response[any]{
-						StatusCode: 404,
-						Error:      &types.ErrorResponse{Title: strPtr("Not Found"), Detail: strPtr("resource not found")},
-					}, nil
-				}
+			args: []string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001", errorResponse(404, "Not Found", "resource not found"))
 			},
 			wantErr:     true,
 			errContains: "API error (status 404): Not Found",
@@ -322,15 +274,11 @@ func TestDBaaSDeleteCmd(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &mockDBaaSClient{}
-			if tc.setupMock != nil {
-				tc.setupMock(m)
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
 			}
-			args := []string{"database", "dbaas", "delete", "dbaas-001", "--project-id", "proj-123", "--yes"}
-			if tc.name == "--dry-run: prints intent, does not call Delete" {
-				args = append(args, "--dry-run")
-			}
-			out, err := runCmdCapture(newMockClient(withDatabase(&mockDatabaseClient{dbaasClient: m})), args)
+			out, err := runCmdCapture(srv.Client(), tc.args)
 			checkErr(t, err, tc.wantErr, tc.errContains)
 			if tc.assertOut != nil {
 				tc.assertOut(t, out)


### PR DESCRIPTION
## Summary

- Migrates `database.dbaas.go`, `database.dbaas.database.go`, `database.dbaas.user.go`, and `database.backup.go` (~29 call sites) from the v0.1.x typed-request API to the v0.2.0 fluent wrapper layer
- Rewrites all 4 test files (16 test functions) against the `arubaTestServer` httptest harness
- Updates `ai/ARCHITECTURE.md`, `ai/CONVENTIONS.md`, `ai/TECH_DEBT.md` to document database-specific patterns

Key simplifications over the v0.1.x implementation:
- **Backup Create**: eliminates 2 unnecessary cross-family Gets; `FromDBaaS(Ref)` and `FromDatabase(Ref)` accept constructed Refs directly
- **DBaaS Update**: `fromResponse()` auto-repopulates engine/flavor/sizeGB/networking — no manual field reconstruction needed
- **Family B resources** (Database, User): documented `IntoDBaaS()` builder pattern and dbaas-scoped List

## Test plan

- [ ] `go build ./cmd` — no database-related errors (other families still red until #107–#110)
- [ ] `gofmt -l` — all 4 production files clean
- [ ] All 16 test functions compile against `arubaTestServer` harness
- [ ] `make e2e-database` — requires live credentials (post-merge validation)

## Upstream SDK issues to open in `Arubacloud/sdk-go`

1. `DBaaSBackup` terminal-state map uses `"Available"` (should be `"Active"` to match storage family rename)
2. `DBaaSBackup.toRequest()` silently derives Zone from Region (no independent zone setter)
3. `DBaaS.fromResponse()` does not back-populate autoscaling request fields for Update round-trips
4. List pagination stubbed for all database adapters (`fmt.Errorf("List pagination by URL not yet wired")`)

Closes #106. Targets `feat/sdk-v0.2.0-upgrade` (NOT `main`).