### PR TITLE
test(security): add KMS unit tests against arubaTestServer harness (#109)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -22,7 +22,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-016 | Multi-mode output implemented: 5 canonical formats (`table`, `table-json`, `table-yaml`, `json`, `yaml`) via `resolveOutputFormat` + `PrintOutput`; `PrintTable` is now a shim; `-o json`/`-o yaml` emit full SDK response (breaking change from original PR #30 flat shape) |
 | TD-017 | `listParams(cmd)` helper added; `--limit`/`--offset` flags added to all 25 list commands; list RunE handlers now pass pagination params to SDK |
 | TD-018 | Global client cache vars encapsulated in `clientState` struct with `resetClientState()` helper; all test reset blocks updated to use it |
-| TD-010 | Table-driven `RunE` tests added for all 23 testable command files (24 including pre-existing `network.vpc_test.go`); mock infrastructure in `cmd/mock_test.go` covers all sub-clients; `security.kms.go` skipped (concrete SDK type, cannot mock); nil-pointer bugs in `LocationResponse.Value` and `CreationDate.IsZero()` fixed as a side effect of test authoring; redundant double nil-check blocks left by AWK generation cleaned up in 5 files |
+| TD-010 | Table-driven `RunE` tests added for all 23 testable command files (24 including pre-existing `network.vpc_test.go`); mock infrastructure in `cmd/mock_test.go` covers all sub-clients; `security.kms_test.go` added via `arubaTestServer` harness in #109 (was previously skipped — concrete SDK type blocked concrete mocking); nil-pointer bugs in `LocationResponse.Value` and `CreationDate.IsZero()` fixed as a side effect of test authoring; redundant double nil-check blocks left by AWK generation cleaned up in 5 files |
 | TD-020 | Six helper functions added to `cmd/root.go` (`msgCreated`, `msgCreatedAsync`, `msgUpdated`, `msgUpdatedAsync`, `msgDeleted`, `msgAction`); all ~91 success `fmt.Print*` calls replaced across 20 cmd files; one double-nil-check fixed in `container.containerregistry.go` as a side effect |
 | TD-021 | `Long` and `Example` fields added to all 23 create commands across 22 cmd files; subnet already had a minimal `Long` which was replaced with a richer version |
 | TD-019 | `--dry-run` flag added to all 24 delete commands; in dry-run mode a `Get` validates existence and access then prints `[dry-run] Would delete …` without calling `Delete`; `msgDryRun` helper added to `cmd/root.go` |
@@ -48,7 +48,8 @@ Issues are grouped by severity. Address Critical items before new features ship;
 - #106 (database family: dbaas, database, user, backup) — merged onto `feat/sdk-v0.2.0-upgrade`.
 - #107 (container family: kaas, containerregistry) — merged onto `feat/sdk-v0.2.0-upgrade`.
 - #108 (schedule family: schedule.job; KMS also migrated as part of this PR) — merged onto `feat/sdk-v0.2.0-upgrade`.
-- #109–#110 (remaining families) — still open.
+- #109 (security.kms unit tests against arubaTestServer harness) — merged onto `feat/sdk-v0.2.0-upgrade`.
+- #110 (remaining families) — still open.
 
 `go build ./cmd` is now green for all migrated families. `make e2e-network` requires live credentials (validated after integration branch complete).
 
@@ -58,7 +59,7 @@ Known upstream SDK issues filed against `Arubacloud/sdk-go` during #108:
 - `VPC.Get` does not backfill `projectID` from the Ref (unlike ElasticIP, SecurityGroup, Subnet which all do `out.projectID = projectID`); workaround in `vpcUpdateCmd`: `cur.IntoProject(projectRef(projectID))` after Get.
 - `projectsClientImpl.Delete` does not parse error body into `resp.Error`, so the error title is absent from `apiErrFromV2` output (test expectation lowered to `"API error (status 404)"` instead of `"API error (status 404): Not Found"`).
 
-**Fix:** Close out #99's exit criteria (#109–#110 + #111), then mark TD-022 resolved.
+**Fix:** Close out #99's exit criteria (#110 + #111), then mark TD-022 resolved.
 
 ---
 

--- a/cmd/security.kms_test.go
+++ b/cmd/security.kms_test.go
@@ -1,0 +1,361 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestKMSListCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupSrv    func(*arubaTestServer)
+		args        []string
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success with results",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{
+					Values: []types.KmsResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"security", "kms", "list", "--project-id", "proj-123"},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kms-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "success empty",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{}))
+			},
+			args: []string{"security", "kms", "list", "--project-id", "proj-123"},
+		},
+		{
+			name: "--output json emits valid JSON",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{
+					Values: []types.KmsResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"security", "kms", "list", "--project-id", "proj-123", "--output", "json"},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
+				}
+			},
+		},
+		{
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			args:        []string{"security", "kms", "list", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "listing",
+		},
+		{
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", errorResponse(404, "Not Found", "resource not found"))
+			},
+			args:        []string{"security", "kms", "list", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestKMSGetCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", jsonResponse(200, types.KmsResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kms-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "server error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "getting",
+		},
+		{
+			name: "API error propagates",
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), []string{"security", "kms", "get", "kms-001", "--project-id", "proj-123"})
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestKMSCreateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"security", "kms", "create", "--project-id", "proj-123", "--name", "my-kms", "--region", "IT-BG"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-new", "my-kms"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kms-new") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "missing required flag --name",
+			args:        []string{"security", "kms", "create", "--project-id", "proj-123", "--region", "IT-BG"},
+			wantErr:     true,
+			errContains: "name",
+		},
+		{
+			name:        "missing required flag --region",
+			args:        []string{"security", "kms", "create", "--project-id", "proj-123", "--name", "my-kms"},
+			wantErr:     true,
+			errContains: "region",
+		},
+		{
+			name: "server error propagates",
+			args: []string{"security", "kms", "create", "--project-id", "proj-123", "--name", "my-kms", "--region", "IT-BG"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Security/kms", errorResponse(500, "Internal Server Error", "quota exceeded"))
+			},
+			wantErr:     true,
+			errContains: "creating",
+		},
+		{
+			name: "API error propagates",
+			args: []string{"security", "kms", "create", "--project-id", "proj-123", "--name", "my-kms", "--region", "IT-BG"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnPost("/projects/proj-123/providers/Aruba.Security/kms", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestKMSUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success",
+			args: []string{"security", "kms", "update", "kms-001", "--project-id", "proj-123", "--name", "renamed"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", jsonResponse(200, types.KmsResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Security/kms/kms-001", jsonResponse(200, types.KmsResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kms-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name:        "missing flags",
+			args:        []string{"security", "kms", "update", "kms-001", "--project-id", "proj-123"},
+			wantErr:     true,
+			errContains: "at least one of",
+		},
+		{
+			name: "pre-Get API error",
+			args: []string{"security", "kms", "update", "kms-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+		{
+			name: "Update server error",
+			args: []string{"security", "kms", "update", "kms-001", "--project-id", "proj-123", "--name", "x"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", jsonResponse(200, types.KmsResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+				srv.OnPut("/projects/proj-123/providers/Aruba.Security/kms/kms-001", errorResponse(500, "Internal Server Error", "boom"))
+			},
+			wantErr:     true,
+			errContains: "updating",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}
+
+func TestKMSDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		setupSrv    func(*arubaTestServer)
+		wantErr     bool
+		errContains string
+		assertOut   func(*testing.T, string)
+	}{
+		{
+			name: "success with --yes",
+			args: []string{"security", "kms", "delete", "kms-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Security/kms/kms-001", jsonResponse(200, nil))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kms-001") {
+					t.Errorf("expected ID in output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--dry-run: prints intent, does not call Delete",
+			args: []string{"security", "kms", "delete", "kms-001", "--project-id", "proj-123", "--yes", "--dry-run"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				// Only register Get; if Delete is called the harness t.Errorf on the
+				// unregistered DELETE route — stronger than a manual t.Fatal guard.
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-001", jsonResponse(200, types.KmsResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "kms-001") {
+					t.Errorf("expected ID in dry-run output, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "server error propagates",
+			args: []string{"security", "kms", "delete", "kms-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Security/kms/kms-001", errorResponse(500, "Internal Server Error", "resource in use"))
+			},
+			wantErr:     true,
+			errContains: "deleting",
+		},
+		{
+			name: "API error propagates",
+			args: []string{"security", "kms", "delete", "kms-001", "--project-id", "proj-123", "--yes"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnDelete("/projects/proj-123/providers/Aruba.Security/kms/kms-001", errorResponse(404, "Not Found", "resource not found"))
+			},
+			wantErr:     true,
+			errContains: "API error (status 404): Not Found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if tc.setupSrv != nil {
+				tc.setupSrv(srv)
+			}
+			out, err := runCmdCapture(srv.Client(), tc.args)
+			checkErr(t, err, tc.wantErr, tc.errContains)
+			if tc.assertOut != nil {
+				tc.assertOut(t, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/security.kms_test.go` with 5 table-driven test functions (~21 cases) for the KMS CRUD commands (`list`, `get`, `create`, `update`, `delete`)
- KMS was the only resource without unit tests — previously skipped because the concrete SDK type blocked mock-based testing; the v0.2.0 `arubaTestServer` HTTP fake unlocks this
- No production-code changes; CLI surface is unchanged

Closes #109. Part of #99 (SDK v0.2.0 migration).

## Test plan

- [x] `go build ./cmd/...` — clean
- [x] `go vet ./cmd/...` — clean
- [x] `gofmt -l ./cmd/security.kms_test.go` — no output (well-formatted)
- [x] `go test ./cmd/... -run TestKMS -timeout 120s` — all 21 cases pass
- [x] `go test ./cmd/... -timeout 120s` — full suite passes, no regressions