### PR TITLE
Bump github.com/Arubacloud/sdk-go to v1.0.0

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -43,7 +43,7 @@ If `LoadConfig()` fails (missing `~/.acloud.yaml`), the error is wrapped:
 
 ## SDK Call Pattern
 
-SDK v0.3.0 uses a fluent **wrapper layer**. `client.From<Svc>()` returns a typed
+SDK v1.0.0 uses a fluent **wrapper layer**. `client.From<Svc>()` returns a typed
 sub-client; each CRUD method returns a hydrated wrapper type or `*aruba.List[T]`
 rather than raw `types.*Response` structs.
 
@@ -119,7 +119,7 @@ rs := aruba.NewStorageRestore().IntoBackup(bk).Named(name).InRegion(aruba.Region
 list, err := client.FromStorage().Restores().List(ctx, backupRef(projectID, backupID), listOpts(cmd)...)
 ```
 
-All four storage wrappers' `Raw()` returns the **full** typed response (e.g. `*types.StorageBackupResponse`). No `RawHTTP()` re-parse is needed, unlike `*aruba.Project`.
+All four storage wrappers' `Raw()` returns the **full** typed response (e.g. `*types.StorageBackupResponse`). `*aruba.Project` also has `RawJSON()/RawYAML()` since v1.0.0, so `RawHTTP()` re-parse is no longer needed anywhere.
 
 **Multi-level nested Refs (network family)** — VPC-scoped resources (Subnet,
 SecurityGroup, VPCPeering) require 3-segment Refs; deeper resources (SecurityRule,
@@ -151,10 +151,11 @@ independent sub-builders: `NewVPNIPConfig()`, `NewVPNIKE()`, `NewVPNESP()`,
 **VPN `fromResponse` does not rehydrate sub-builders** — `VPNTunnel.fromResponse()`
 only populates top-level fields (`vpnType`, `vpnClientProtocol`, `billingPeriod`,
 `peerClientPublicIP`). A naïve wrapper `Update` would drop the IKE/ESP/PSK/IPConfig
-sub-builders from the PUT body. `network.vpntunnel.go` works around this with a
-file-local `vpnTunnelReattachSettings(cur *aruba.VPNTunnel)` helper that
-reconstructs the sub-builders from `cur.Raw().Properties.*` and re-attaches them
-before calling `Update`.
+sub-builders from the PUT body. `network.vpntunnel.go` works around this by reading
+the sub-builders from `vpn.Raw().Properties.VPNClientSettingsCommon.*` (field renamed
+in v1.0.0 from `VPNClientSettings` → `VPNClientSettingsCommon`) and re-attaching
+them before calling `Update`. This is a documented TECH_DEBT (TD-034) pending
+sdk-go exposing typed `IKE()`, `ESP()`, `PSK()` read accessors on `*aruba.VPNTunnel`.
 
 **VPN crypto enums split per direction** — v0.3.0 provides per-direction types
 (introduced in v0.2.0, carried forward): `aruba.IKEEncryption` / `aruba.ESPEncryption`,
@@ -192,24 +193,29 @@ if err != nil {
 
 **Rendering** — wrapper types (`*aruba.<T>`) carry only unexported fields and are not
 directly JSON-marshalable via `encoding/json`. For table columns the wrapper exposes
-(`.ID()`, `.Name()`, `.State()`, `.CreatedAt()`, …) use the accessors directly.
+(`.ID()`, `.Name()`, `.State()`, `.CreatedAt()`, `.Region()`, …) use the accessors directly.
+sdk-go v1.0.0 added additional flattened accessors: `CloudServer.ElasticIP()`,
+`CloudServer.Subnets()`, `CloudServer.SecurityGroups()`, `KaaS.KubernetesVersion()`,
+`KaaS.PodCIDR()`, `DBaaS.EngineVersion()`, `Job.ScheduleAt()`, etc.
 
-`PrintOutput` delegates full-payload rendering (`-o json` / `-o yaml`) through three
+`PrintOutput` delegates full-payload rendering (`-o json` / `-o yaml`) through two
 dispatch branches in `printJSON` / `printYAML`:
 
-1. **`rawMarshaler`** (preferred) — `RawJSON()` / `RawYAML()` called on the wrapper.
-   All wrapper types except `*aruba.Project` satisfy this interface in v0.3.0.
+1. **`rawMarshaler`** (all wrappers) — `RawJSON()` / `RawYAML()` called on the wrapper.
+   All wrapper types including `*aruba.Project` satisfy this interface in sdk-go v1.0.0.
    **Always pass the SDK wrapper (not `.Raw()`) as the first arg to `PrintOutput`.**
-2. **`rawHTTPer`** (legacy, `*aruba.Project` only) — falls back to `RawHTTP()` for
-   re-parsing the raw HTTP response body. Used only in `management.project.go` until
-   sdk-go ships `RawJSON()/RawYAML()` on `*aruba.Project`.
-3. **`json.MarshalIndent`** (anonymous structs) — delete-confirmation result rows use
+2. **`json.MarshalIndent`** (anonymous structs) — delete-confirmation result rows use
    small anonymous structs (`struct{ID, Status string}{...}`) that satisfy neither
    interface. These fall through to `json.MarshalIndent`. Intentional — delete handlers
    never need SDK-shaped full-payload output.
 
+The `rawHTTPer` fallback branch (v0.3.0) was deleted in the sdk-go v1.0.0 migration
+(TD-032 / TD-036). `*aruba.Project` now satisfies `rawMarshaler` directly.
+
 This keeps the **single-import principle**: only `github.com/Arubacloud/sdk-go/pkg/aruba`
-is imported in non-test `cmd/` files.
+is imported in non-test `cmd/` files. The one documented exception is `container.kaas.go`
+which still imports `pkg/types` for `types.KaaSAPIServerAccessProfilePropertiesRequest`
+until sdk-go provides a fluent aruba-level builder (TD-033).
 
 For list `-o json`/`-o yaml`, `*aruba.List[T]` also satisfies `rawMarshaler`; no
 separate `<resource>ListPayload` helper is needed for the output call itself, though
@@ -435,32 +441,19 @@ Always returns `cobra.ShellCompDirectiveNoFileComp`. On any error, returns `nil,
 
 ## Request Building
 
-SDK requests use nested struct composition with pointer-valued optional fields:
+SDK requests are built using the fluent wrapper builders — do **not** reference
+`pkg/types` structs directly in `cmd/` production files. The `pkg/types` package is
+only used in `_test.go` files (to build mock HTTP fixtures) and in one annotated
+production exception (`container.kaas.go`, TD-033).
 
+**Update pattern** — fetch the current resource first, mutate the hydrated wrapper,
+then call `Update`:
 ```go
-types.BlockStorageRequest{
-    Metadata: types.RegionalResourceMetadataRequest{
-        ResourceMetadataRequest: types.ResourceMetadataRequest{
-            Name: name,
-            Tags: tags,
-        },
-        Location: types.LocationRequest{Value: region},
-    },
-    Properties: types.BlockStoragePropertiesRequest{
-        SizeGB:        size,
-        BillingPeriod: billingPeriod,
-        Type:          types.BlockStorageType(volumeType),
-    },
-}
-```
-
-**Update pattern** — fetch the current resource first to preserve values not being updated, then overwrite changed fields:
-```go
-getResp, _ := client.From...().Resource().Get(ctx, projectID, id, nil)
-current := getResp.Data
-updateReq := buildRequestFrom(current)    // preserve current values
-if name != "" { updateReq.Metadata.Name = name }
-if cmd.Flags().Changed("tags") { updateReq.Metadata.Tags = tags }
+current, err := client.From<Svc>().<Resource>().Get(ctx, ref)
+if err != nil { ... }
+if name != "" { current.Named(name) }
+if cmd.Flags().Changed("tags") { current.RetaggedAs(tags...) }
+updated, err := client.From<Svc>().<Resource>().Update(ctx, current)
 ```
 
 ---
@@ -645,18 +638,13 @@ The response field is still `resource.Properties.PublicIp.URI` (unchanged wire f
 func jobRef(projectID, jobID string) aruba.Ref {
     return aruba.URI("/projects/" + projectID + "/providers/Aruba.Schedule/jobs/" + jobID)
 }
-func jobFromRaw(j *aruba.Job) *types.JobResponse { return j.Raw() }
-func jobListPayload(l *aruba.List[*aruba.Job]) any {
-    if r, ok := l.Raw().(*types.Response[types.JobList]); ok && r != nil {
-        return r.Data
-    }
-    return nil
-}
 ```
+
+Pass `job` (the wrapper) directly to `PrintOutput` — it satisfies `rawMarshaler` via `RawJSON()/RawYAML()`.
 
 ### Identity accessors
 
-`j.JobID()` (not `j.ID()`), `j.Name()`, `j.Region()` (→ `aruba.Region`, cast with `string()`), `j.JobType()` (→ `types.JobType`), `j.Enabled()` bool, `j.State()` string.
+`j.JobID()` (not `j.ID()`), `j.Name()`, `j.Region()` (→ `aruba.Region`, cast with `string()`). sdk-go v1.0.0 added `j.ScheduleAt()`, `j.ExecuteUntil()`, `j.NextExecutionAt()`, `j.Steps()`.
 
 ### Schedule modes — mutually exclusive
 
@@ -670,12 +658,10 @@ j.WithCron(cronExpr).RecurringUntil(endTime)
 
 Call `j.Err()` after builder setup to surface any validation errors before the Create call.
 
-### `Enabled()`/`Disabled()` setters (v0.3.0)
+### `Enabled()`/`Disabled()` setters
 
-In v0.3.0 the boolean `WithEnabled(bool)` setter is replaced by two explicit methods:
-`Enabled()` and `Disabled()`. Use `j.Enabled()` or `j.Disabled()` to set the job
-state — the `omitempty` wire issue that affected the old `WithEnabled(false)` call
-is resolved upstream in v0.3.0.
+Use `j.Enabled()` or `j.Disabled()` to set the job state. These replaced `WithEnabled(bool)`
+in v0.3.0; the `omitempty` wire issue with `WithEnabled(false)` is resolved.
 
 ## Security (KMS) Family
 
@@ -691,4 +677,4 @@ func kmsRef(projectID, kmsID string) aruba.Ref {
 
 ### Identity accessor
 
-`k.KMSID()` (not `k.ID()`). Other accessors: `k.Name()`, `k.Region()`, `k.State()`, `k.Raw()` → `*types.KMSResponse`.
+`k.KMSID()` (not `k.ID()`). Other accessors: `k.Name()`, `k.Region()`, `k.State()`.

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -148,14 +148,12 @@ independent sub-builders: `NewVPNIPConfig()`, `NewVPNIKE()`, `NewVPNESP()`,
 `NewVPNPSK()`. Each is constructed separately and attached via
 `WithIPConfig`/`WithIKESettings`/`WithESPSettings`/`WithPSKSettings`.
 
-**VPN `fromResponse` does not rehydrate sub-builders** — `VPNTunnel.fromResponse()`
-only populates top-level fields (`vpnType`, `vpnClientProtocol`, `billingPeriod`,
-`peerClientPublicIP`). A naïve wrapper `Update` would drop the IKE/ESP/PSK/IPConfig
-sub-builders from the PUT body. `network.vpntunnel.go` works around this by reading
-the sub-builders from `vpn.Raw().Properties.VPNClientSettingsCommon.*` (field renamed
-in v1.0.0 from `VPNClientSettings` → `VPNClientSettingsCommon`) and re-attaching
-them before calling `Update`. This is a documented TECH_DEBT (TD-034) pending
-sdk-go exposing typed `IKE()`, `ESP()`, `PSK()` read accessors on `*aruba.VPNTunnel`.
+**VPN `fromResponse` rehydrates sub-builders in v1.0.0** — `VPNTunnel.fromResponse()`
+fully populates the `ike`, `esp`, `psk` wrapper fields from the response. After a
+`Get`, `vpn.IKE()`, `vpn.ESP()`, `vpn.PSK()` all return hydrated sub-builders, and
+`Update` includes them in the PUT body via `toRequest()`. No manual re-attachment is
+needed. The old reattach block in `network.vpntunnel.go` was deleted in the v1.0.0
+migration (TD-034).
 
 **VPN crypto enums split per direction** — v0.3.0 provides per-direction types
 (introduced in v0.2.0, carried forward): `aruba.IKEEncryption` / `aruba.ESPEncryption`,

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -101,9 +101,10 @@ Two groups: stdlib, then external. Each group is alphabetically ordered.
 
 **Single-import policy** — non-test `cmd/` files must only import
 `github.com/Arubacloud/sdk-go/pkg/aruba`. Importing `pkg/types` directly from
-non-test cmd files is not permitted. The only documented escape hatch in v0.3.0 is
-`container.kaas.go`, which must reference `types.APIServerAccessProfileProperties`
-until the SDK provides a convenience setter for that field.
+non-test cmd files is not permitted. The one documented exception (TD-033) is
+`container.kaas.go`, which references `types.KaaSAPIServerAccessProfilePropertiesRequest`
+until sdk-go provides an `aruba`-level constructor for that type. All `pkg/types`
+references in non-test cmd files must be annotated with `// TECH_DEBT: TD-033`.
 
 ---
 
@@ -199,7 +200,7 @@ Never dereference a response pointer without a nil guard.
 
 ## Standard Command Bodies
 
-SDK v0.3.0 uses a fluent wrapper layer. `client.From<Svc>().<Resource>()` returns a
+SDK v1.0.0 uses a fluent wrapper layer. `client.From<Svc>().<Resource>()` returns a
 typed client whose CRUD methods take/return hydrated wrapper types (`*aruba.<T>`,
 `*aruba.List[*aruba.<T>]`) rather than raw request/response structs. Non-2xx
 responses surface as `*aruba.HTTPError` in the error return — there is no separate
@@ -209,8 +210,9 @@ a verb prefix for all error sites.
 **Wrapper note:** `*aruba.<T>` wrapper types carry only unexported fields and are not
 directly JSON-marshalable via `encoding/json`. For single-resource rendering and
 `-o json`/`-o yaml` payloads, `PrintOutput` delegates to the SDK's `RawJSON()`/
-`RawYAML()` methods (via the local `rawMarshaler` interface). Only `*aruba.Project`
-falls back to `RawHTTP()` re-parsing (via `rawHTTPer`) — see `management.project.go`.
+`RawYAML()` methods (via the local `rawMarshaler` interface). All wrapper types
+including `*aruba.Project` satisfy `rawMarshaler` in sdk-go v1.0.0. The old
+`rawHTTPer` fallback was deleted (TD-032 / TD-036).
 For project-scoped resources, build the create wrapper with `.InProject(projectRef(projectID))`
 and use a file-local `<resource>Ref(projectID, id)` helper (encoding both project +
 resource IDs in the URI) for `Get` and `Delete`.
@@ -372,13 +374,13 @@ Table rows are still built from `raw.*` fields (via `.Raw()`) for now — the SD
 not yet expose every field through wrapper accessors. Only the `PrintOutput` first arg
 changes.
 
-Two intentional exceptions:
-- **`*aruba.Project`** — lacks `RawJSON()/RawYAML()` in v0.3.0; `management.project.go`
-  uses `RawHTTP()` re-parse via `rawHTTPer`. Do not change this until the SDK ships the
-  interface.
+One intentional exception:
 - **Anonymous struct delete results** — `PrintOutput(struct{ID, Status string}{...}, ...)`
   is intentional; these small structs fall through to `json.MarshalIndent` which is fine
   for the trimmed delete-confirmation shape.
+
+Note: the `*aruba.Project` / `rawHTTPer` exception existed in v0.3.0 and was removed
+in the sdk-go v1.0.0 migration (TD-032). `*aruba.Project` now satisfies `rawMarshaler`.
 
 ---
 
@@ -390,7 +392,7 @@ Two intentional exceptions:
 - Skip live-API tests with `ACLOUD_TEST_SKIP_CLIENT=true`.
 - Table-driven tests are preferred for multiple input/output cases.
 
-### Test client — httptest harness (v0.2.0+, current v0.3.0)
+### Test client — httptest harness (v0.2.0+, current v1.0.0)
 
 Since SDK v0.2.0, wrapper types (`aruba.CloudServer`, `aruba.VPC`, …) carry unexported internal state that can only be populated by the SDK's own adapters. Hand-built fake structs cannot produce a hydrated wrapper with real `.ID()`/`.State()`/`List[T]` values.
 
@@ -603,7 +605,7 @@ j := aruba.NewJob().
     Named(name).
     InRegion(aruba.Region(region)).
     OfType(aruba.JobType(jobType)).
-    Enabled()  // or .Disabled() — replaces WithEnabled(bool) in v0.3.0
+    Enabled()  // or .Disabled() — explicit state setters (since v0.3.0)
 
 if cronExpr != "" {
     endTime, _ := time.Parse(time.RFC3339, endTimeStr)
@@ -632,11 +634,11 @@ if err != nil { return fmt.Errorf("getting schedule job: %w", apiErrFromV2(err))
 
 if name != "" { cur.Named(name) }
 if enabledSet {
-    if enabled { cur.Enabled() } else { cur.Disabled() }  // v0.3.0: replaces WithEnabled(bool)
+    if enabled { cur.Enabled() } else { cur.Disabled() }  // explicit state setters (since v0.3.0)
 }
 if cmd.Flags().Changed("tags") { cur.RetaggedAs(tags...) }
 
 updated, err := client.FromSchedule().Jobs().Update(ctx, cur)
 ```
 
-The `omitempty` issue that affected `WithEnabled(false)` in earlier SDK versions is resolved in v0.3.0 via the explicit `Enabled()`/`Disabled()` setters.
+The `omitempty` issue that affected `WithEnabled(false)` in earlier SDK versions was resolved in v0.3.0 via the explicit `Enabled()`/`Disabled()` setters.

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -32,6 +32,8 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-022 | SDK fully migrated from v0.1.x → v0.2.0 wrapper API across all families (#100–#110); bumped to v0.2.1 (#111) which resolved all four upstream papercuts (#282–#285: Job.WithEnabled omitempty, List pagination stubs, VPC.Get missing projectID backfill, projectsClientImpl.Delete missing error-body parse). v0.2.1 also added typed Ref builders (VPCRef, SubnetRef, etc.) and WithBillingPeriod/ReplaceNodePools setters — all adopted in #111. Bumped to v0.3.0 on branch `upgrade-sdk`: natural-language setter vocabulary (InProject, InVPC, RetaggedAs, BilledBy, HighlyAvailable(), Enabled()/Disabled()), URI segment casing aligned (securityGroups, securityRules, blockStorages, loadBalancers, keyPairs), both local vendor patches removed (securityGroups casing fix and List[T].Raw() JSON marshalability — now upstream in v0.3.0), single-import achieved for all non-test cmd/ files (escape hatch: container.kaas.go uses types.APIServerAccessProfileProperties until SDK provides a setter), output handlers now delegate to SDK's RawJSON()/RawYAML() via rawMarshaler interface (all 20 cmd files pass the wrapper, not `.Raw()`, to PrintOutput), and cross-resource reference flags refactored from `--<res>-uri` to `--<res>-id` using SDK Ref helpers (VPCRef, SubnetRef, SecurityGroupRef, ElasticIPRef). |
 | TD-032 | `rawHTTPer` interface and both fallback branches in `printJSON`/`printYAML` deleted from `cmd/root.go`. sdk-go v1.0.0 (released 2026-05-29) added `RawJSON()/RawYAML()` to `*aruba.Project`, so it now satisfies `rawMarshaler` directly. The `"net/http"` import and the `fakeRawHTTPer` test type also removed. `management.project.go` was already passing the wrapper directly to `PrintOutput` — no change there. Tests `TestPrintJSON/rawHTTPer_*` and `TestPrintYAML/rawHTTPer_*` deleted. |
 | TD-036 | sdk-go bumped from v0.3.0 → v1.0.0 (GA, released 2026-05-29) on branch `upgrade-sdk-v1`. Breaking changes in `pkg/types`: strict role-suffix naming (`*PropertiesResult`→`*PropertiesResponse`, bare `*List`→`*ListResponse`, `*Common`-suffixed nested types). Production code impact: 7 compile-error fixes in `container.containerregistry.go`, `container.kaas.go`, `management.project.go`, `network.elasticip.go`, `network.subnet.go`, `network.vpcpeeringroute.go`, `network.vpntunnel.go`. Test files: ~46 type-rename substitutions across 28 `_test.go` files. Completion functions migrated to wrapper accessors (`.ID()`, `.Name()`) in 14 cmd files, eliminating ~50 `.Raw().Metadata.ID/Name` reads. |
+| TD-034 | VPN tunnel update handler manual IKE/ESP/PSK reattach block removed from `cmd/network.vpntunnel.go`. sdk-go v1.0.0 `fromResponse` now fully rehydrates IKE/ESP/PSK into the `*VPNIKE`/`*VPNESP`/`*VPNPSK` wrapper fields exposed via `IKE()`/`ESP()`/`PSK()` accessors; `toRequest()` builds the PUT body from those fields. Closed #132. Residual: `redactVPNTunnelSecrets` still mutates `t.response.Properties.VPNClientSettingsCommon.PSK.Secret` directly because `RawJSON()` serializes `t.response`; upstream `RedactPSK()` mutator still needed (tracked in #132 comment). |
+| TD-035 | Subnet update DHCP preservation block migrated to wrapper accessors in `cmd/network.subnet.go`. `subnet.Type()` replaces `subnet.Raw().Properties.Type`; `subnet.DHCP()` replaces `.Raw().Properties.DHCP` with full `IsEnabled()`/`Routes()`/`DNS()` read access on `*SubnetDHCPCommon`. Zero `.Raw()` calls remain for this code path. Closed #133. |
 
 ---
 
@@ -122,36 +124,20 @@ Two residual `.Raw()` / `types.*` usages remain in production code after the v1.
 
 ---
 
-### TD-034 · VPN tunnel uses `.Raw()` for PSK redaction and IKE/ESP/PSK reattach on update
+### TD-034 · `redactVPNTunnelSecrets` still uses `.Raw()` for PSK.Secret mutation
 
-Two blocks in `cmd/network.vpntunnel.go` require direct raw-struct access:
+The `redactVPNTunnelSecrets` function in `cmd/network.vpntunnel.go` mutates
+`tunnel.Raw().Properties.VPNClientSettingsCommon.PSK.Secret = nil` to strip the secret
+before `-o json`/`-o yaml` output. This is necessary because `RawJSON()`/`RawYAML()`
+serialize `t.response` (the raw struct), not the wrapper state. The IKE/ESP/PSK
+reattach block was eliminated in the v1.0.0 migration (TD-034 resolved), but this
+single mutation site remains.
 
-1. **`redactVPNTunnelSecrets` (line ~145)** — mutates `tunnel.Raw().Properties.VPNClientSettingsCommon.PSK.Secret`
-   in place to strip the PSK secret before `-o json`/`-o yaml` output. sdk-go v1.0.0 provides
-   no wrapper-level mutator for secret redaction.
-2. **Update `RunE` (line ~582)** — reads `vpn.Raw().Properties.VPNClientSettingsCommon.*` to
-   reconstruct IKE/ESP/PSK sub-builders before calling `Update`, because `fromResponse` does
-   not rehydrate them. sdk-go v1.0.0 does not expose `IKE()` / `ESP()` / `PSK()` read accessors.
+**Fix (blocked on sdk-go):** Once sdk-go adds a `RedactPSK()` method (or a write-through
+mutator) on `*aruba.VPNTunnel` that zeros both the wrapper's PSK secret AND the
+corresponding field in the cached raw struct, remove the `.Raw()` call here.
 
-**Fix (blocked on sdk-go):** Once sdk-go exposes (a) a `RedactPSK()` or write-through mutator
-and (b) typed `IKE()`, `ESP()`, `PSK()` read accessors on `*aruba.VPNTunnel`, remove both
-blocks and replace with accessor calls.
-
-**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/132
-
----
-
-### TD-035 · Subnet update uses `.Raw()` for DHCP type and config preservation
-
-`cmd/network.subnet.go` (update `RunE`, line ~360) reads `subnet.Raw().Properties.Type`
-and `subnet.Raw().Properties.DHCP` to preserve existing DHCP routes/DNS when rebuilding
-the update payload. sdk-go v1.0.0 does not expose `Type()` or `DHCP()` wrapper accessors
-on `*aruba.Subnet`.
-
-**Fix (blocked on sdk-go):** Once sdk-go adds `Type()` and `DHCP()` (or equivalent) getters
-to `*aruba.Subnet`, remove the `.Raw()` reads and use the accessors.
-
-**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/133
+**Tracked in:** https://github.com/Arubacloud/acloud-cli/issues/132 (comment)
 
 ---
 

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -30,6 +30,8 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-023 | Verbose error-body dump in `storage.backup` / `storage.restore` now uses `json.MarshalIndent(response.Error, …)`; generic `map[string]interface{}` unmarshal removed |
 | TD-024 | VPN crypto enums split per-direction in v0.2.0: the five unified slices (`vpnEncryptionAlgorithms`, `vpnHashAlgorithms`, `vpnDHGroups`, `vpnDPDActions`, `vpnPFSGroups`) are replaced with seven per-direction slices (`vpnIKEEncryptionAlgorithms`, `vpnESPEncryptionAlgorithms`, `vpnIKEHashAlgorithms`, `vpnESPHashAlgorithms`, `vpnIKEDHGroups`, `vpnIKEDPDActions`, `vpnESPPFSGroups`) built from `aruba.IKE*`/`aruba.ESP*` constants; each `--ike-*`/`--esp-*` flag is keyed to its correct family in the validation table; accepted string values are unchanged (CLI behaviour byte-identical) |
 | TD-022 | SDK fully migrated from v0.1.x → v0.2.0 wrapper API across all families (#100–#110); bumped to v0.2.1 (#111) which resolved all four upstream papercuts (#282–#285: Job.WithEnabled omitempty, List pagination stubs, VPC.Get missing projectID backfill, projectsClientImpl.Delete missing error-body parse). v0.2.1 also added typed Ref builders (VPCRef, SubnetRef, etc.) and WithBillingPeriod/ReplaceNodePools setters — all adopted in #111. Bumped to v0.3.0 on branch `upgrade-sdk`: natural-language setter vocabulary (InProject, InVPC, RetaggedAs, BilledBy, HighlyAvailable(), Enabled()/Disabled()), URI segment casing aligned (securityGroups, securityRules, blockStorages, loadBalancers, keyPairs), both local vendor patches removed (securityGroups casing fix and List[T].Raw() JSON marshalability — now upstream in v0.3.0), single-import achieved for all non-test cmd/ files (escape hatch: container.kaas.go uses types.APIServerAccessProfileProperties until SDK provides a setter), output handlers now delegate to SDK's RawJSON()/RawYAML() via rawMarshaler interface (all 20 cmd files pass the wrapper, not `.Raw()`, to PrintOutput), and cross-resource reference flags refactored from `--<res>-uri` to `--<res>-id` using SDK Ref helpers (VPCRef, SubnetRef, SecurityGroupRef, ElasticIPRef). |
+| TD-032 | `rawHTTPer` interface and both fallback branches in `printJSON`/`printYAML` deleted from `cmd/root.go`. sdk-go v1.0.0 (released 2026-05-29) added `RawJSON()/RawYAML()` to `*aruba.Project`, so it now satisfies `rawMarshaler` directly. The `"net/http"` import and the `fakeRawHTTPer` test type also removed. `management.project.go` was already passing the wrapper directly to `PrintOutput` — no change there. Tests `TestPrintJSON/rawHTTPer_*` and `TestPrintYAML/rawHTTPer_*` deleted. |
+| TD-036 | sdk-go bumped from v0.3.0 → v1.0.0 (GA, released 2026-05-29) on branch `upgrade-sdk-v1`. Breaking changes in `pkg/types`: strict role-suffix naming (`*PropertiesResult`→`*PropertiesResponse`, bare `*List`→`*ListResponse`, `*Common`-suffixed nested types). Production code impact: 7 compile-error fixes in `container.containerregistry.go`, `container.kaas.go`, `management.project.go`, `network.elasticip.go`, `network.subnet.go`, `network.vpcpeeringroute.go`, `network.vpntunnel.go`. Test files: ~46 type-rename substitutions across 28 `_test.go` files. Completion functions migrated to wrapper accessors (`.ID()`, `.Name()`) in 14 cmd files, eliminating ~50 `.Raw().Metadata.ID/Name` reads. |
 
 ---
 
@@ -94,24 +96,62 @@ output blocks).
 `acloud schedule job create` always returns HTTP 400 because the payload contains no
 `steps[]`. The `--step-resource-uri` / `--step-action-uri` / `--step-http-verb` /
 `--step-name` flags are declared in `init()` but the `RunE` never reads them and the
-SDK builder has no `AddStep` / `WithStep` method in v0.3.0.
+SDK builder had no `AddStep` / `WithStep` method in v0.3.0. sdk-go v1.0.0 added
+`Job.Steps()` (a read accessor) but it is unclear whether a write/builder API was
+added. Check `aruba.Job` in v1.0.0 for `AddStep`/`WithStep` before implementing.
 
-**Fix (blocked on sdk-go):** Once the SDK exposes a step builder API, read the four
-flags and append the step before calling `Create`. Until then, the command should return
-a clear "not yet implemented" error rather than silently emitting an invalid payload.
+**Fix:** If v1.0.0 added a step builder, read the four flags and append the step before
+calling `Create`. Otherwise, the command should return a clear "not yet implemented"
+error rather than silently emitting an invalid payload.
 
 ---
 
-### TD-032 · Drop `rawHTTPer` branch from `printJSON` / `printYAML`
+### TD-033 · `container.kaas.go` and `management.project.go` residual `pkg/types` and `.Raw()`
 
-`cmd/root.go` contains a `rawHTTPer` fallback branch that calls `RawHTTP()` and
-re-parses the response body for `*aruba.Project`. This is the only remaining caller.
-Once sdk-go adds `RawJSON()` / `RawYAML()` to `*aruba.Project`, the branch and the
-`rawHTTPer` interface can be deleted.
+Two residual `.Raw()` / `types.*` usages remain in production code after the v1.0.0 migration:
 
-**Fix (blocked on sdk-go):** After the SDK ships the interface, remove the `rawHTTPer`
-type, delete its check block in `printJSON`/`printYAML`, and update `management.project.go`
-to pass the wrapper directly (same pattern as all other 20 cmd files).
+1. **`cmd/container.kaas.go:221`** — `types.KaaSAPIServerAccessProfilePropertiesRequest` must be
+   referenced directly because sdk-go v1.0.0 provides no `aruba`-level constructor for
+   API server access profile settings. Remove the `pkg/types` import once sdk-go exposes
+   `aruba.NewAPIServerAccessProfile()` or an equivalent fluent setter.
+2. **`cmd/management.project.go`** — `p.Raw().Metadata.CreatedBy` / `.UpdatedBy` are read
+   because `*aruba.Project` in v1.0.0 does not expose `CreatedBy()` / `UpdatedBy()` wrapper
+   accessors. Remove once sdk-go adds these accessors to the `Project` wrapper.
+
+**Filed as:** GitHub issue (see issue URL in code comment `// TECH_DEBT: TD-033`).
+
+---
+
+### TD-034 · VPN tunnel uses `.Raw()` for PSK redaction and IKE/ESP/PSK reattach on update
+
+Two blocks in `cmd/network.vpntunnel.go` require direct raw-struct access:
+
+1. **`redactVPNTunnelSecrets` (line ~145)** — mutates `tunnel.Raw().Properties.VPNClientSettingsCommon.PSK.Secret`
+   in place to strip the PSK secret before `-o json`/`-o yaml` output. sdk-go v1.0.0 provides
+   no wrapper-level mutator for secret redaction.
+2. **Update `RunE` (line ~582)** — reads `vpn.Raw().Properties.VPNClientSettingsCommon.*` to
+   reconstruct IKE/ESP/PSK sub-builders before calling `Update`, because `fromResponse` does
+   not rehydrate them. sdk-go v1.0.0 does not expose `IKE()` / `ESP()` / `PSK()` read accessors.
+
+**Fix (blocked on sdk-go):** Once sdk-go exposes (a) a `RedactPSK()` or write-through mutator
+and (b) typed `IKE()`, `ESP()`, `PSK()` read accessors on `*aruba.VPNTunnel`, remove both
+blocks and replace with accessor calls.
+
+**Filed as:** GitHub issue (see issue URL in code comment `// TECH_DEBT: TD-034`).
+
+---
+
+### TD-035 · Subnet update uses `.Raw()` for DHCP type and config preservation
+
+`cmd/network.subnet.go` (update `RunE`, line ~360) reads `subnet.Raw().Properties.Type`
+and `subnet.Raw().Properties.DHCP` to preserve existing DHCP routes/DNS when rebuilding
+the update payload. sdk-go v1.0.0 does not expose `Type()` or `DHCP()` wrapper accessors
+on `*aruba.Subnet`.
+
+**Fix (blocked on sdk-go):** Once sdk-go adds `Type()` and `DHCP()` (or equivalent) getters
+to `*aruba.Subnet`, remove the `.Raw()` reads and use the accessors.
+
+**Filed as:** GitHub issue (see issue URL in code comment `// TECH_DEBT: TD-035`).
 
 ---
 

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -118,7 +118,7 @@ Two residual `.Raw()` / `types.*` usages remain in production code after the v1.
    because `*aruba.Project` in v1.0.0 does not expose `CreatedBy()` / `UpdatedBy()` wrapper
    accessors. Remove once sdk-go adds these accessors to the `Project` wrapper.
 
-**Filed as:** GitHub issue (see issue URL in code comment `// TECH_DEBT: TD-033`).
+**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/131
 
 ---
 
@@ -137,7 +137,7 @@ Two blocks in `cmd/network.vpntunnel.go` require direct raw-struct access:
 and (b) typed `IKE()`, `ESP()`, `PSK()` read accessors on `*aruba.VPNTunnel`, remove both
 blocks and replace with accessor calls.
 
-**Filed as:** GitHub issue (see issue URL in code comment `// TECH_DEBT: TD-034`).
+**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/132
 
 ---
 
@@ -151,7 +151,7 @@ on `*aruba.Subnet`.
 **Fix (blocked on sdk-go):** Once sdk-go adds `Type()` and `DHCP()` (or equivalent) getters
 to `*aruba.Subnet`, remove the `.Raw()` reads and use the accessors.
 
-**Filed as:** GitHub issue (see issue URL in code comment `// TECH_DEBT: TD-035`).
+**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/133
 
 ---
 

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -61,7 +61,7 @@ func TestCompleteKeyPairID_NoProjectID(t *testing.T) {
 func TestCompleteContainerRegistryID(t *testing.T) {
 	id, name := "cr-001", "my-registry"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
 		Values: []types.ContainerRegistryResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -90,7 +90,7 @@ func TestCompleteContainerRegistryID_NoProjectID(t *testing.T) {
 func TestCompleteKaaSID(t *testing.T) {
 	id, name := "kaas-001", "my-cluster"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
 		Values: []types.KaaSResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -119,7 +119,7 @@ func TestCompleteKaaSID_NoProjectID(t *testing.T) {
 func TestCompleteDatabaseBackupID(t *testing.T) {
 	id, name := "bkp-001", "my-backup"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
 		Values: []types.BackupResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -154,7 +154,7 @@ func TestCompleteDBaaSDatabaseID_NoArgs(t *testing.T) {
 
 func TestCompleteDBaaSDatabaseID(t *testing.T) {
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
 		Values: []types.DatabaseResponse{
 			{Name: "my-db"},
 		},
@@ -173,7 +173,7 @@ func TestCompleteDBaaSDatabaseID(t *testing.T) {
 func TestCompleteDBaaSID(t *testing.T) {
 	id, name := "dbaas-001", "my-dbaas"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
 		Values: []types.DBaaSResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -208,9 +208,9 @@ func TestCompleteGrantID_NoArgs(t *testing.T) {
 
 func TestCompleteGrantID(t *testing.T) {
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/mydb/grants", jsonResponse(200, types.GrantList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases/mydb/grants", jsonResponse(200, types.GrantListResponse{
 		Values: []types.GrantResponse{
-			{User: types.GrantUser{Username: "alice"}, Role: types.GrantRole{Name: "admin"}},
+			{User: types.GrantUserCommon{Username: "alice"}, Role: types.GrantRoleCommon{Name: "admin"}},
 		},
 	}))
 	setClientForTesting(srv.Client())
@@ -233,7 +233,7 @@ func TestCompleteDBaaSUserID_NoArgs(t *testing.T) {
 
 func TestCompleteDBaaSUserID(t *testing.T) {
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
 		Values: []types.UserResponse{
 			{Username: "testuser"},
 		},
@@ -252,7 +252,7 @@ func TestCompleteDBaaSUserID(t *testing.T) {
 func TestCompleteProjectID(t *testing.T) {
 	id, name := "proj-001", "my-project"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+	srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
 		Values: []types.ProjectResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -282,7 +282,7 @@ func TestCompleteProjectID_NoClient(t *testing.T) {
 func TestCompleteElasticIPID(t *testing.T) {
 	id, name := "eip-001", "my-eip"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
 		Values: []types.ElasticIPResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -311,7 +311,7 @@ func TestCompleteElasticIPID_NoProjectID(t *testing.T) {
 func TestCompleteLoadBalancerID(t *testing.T) {
 	id, name := "lb-001", "my-lb"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
 		Values: []types.LoadBalancerResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -347,7 +347,7 @@ func TestCompleteSecurityRuleID_InsufficientArgs(t *testing.T) {
 func TestCompleteSecurityRuleID(t *testing.T) {
 	id, name := "rule-001", "my-rule"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules", jsonResponse(200, types.SecurityRuleList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules", jsonResponse(200, types.SecurityRuleListResponse{
 		Values: []types.SecurityRuleResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -366,7 +366,7 @@ func TestCompleteSecurityRuleID(t *testing.T) {
 func TestCompleteVPCID(t *testing.T) {
 	id, name := "vpc-001", "my-vpc"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
 		Values: []types.VPCResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -402,7 +402,7 @@ func TestCompleteVPCPeeringRouteID_InsufficientArgs(t *testing.T) {
 func TestCompleteVPCPeeringRouteID(t *testing.T) {
 	id, name := "route-001", "my-route"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes", jsonResponse(200, types.VPCPeeringRouteList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes", jsonResponse(200, types.VPCPeeringRouteListResponse{
 		Values: []types.VPCPeeringRouteResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -428,7 +428,7 @@ func TestCompleteVPNRouteID_NoArgs(t *testing.T) {
 func TestCompleteVPNRouteID(t *testing.T) {
 	id, name := "vroute-001", "my-route"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes", jsonResponse(200, types.VPNRouteList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes", jsonResponse(200, types.VPNRouteListResponse{
 		Values: []types.VPNRouteResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -447,7 +447,7 @@ func TestCompleteVPNRouteID(t *testing.T) {
 func TestCompleteVPNTunnelID(t *testing.T) {
 	id, name := "vpn-001", "my-tunnel"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelListResponse{
 		Values: []types.VPNTunnelResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -476,7 +476,7 @@ func TestCompleteVPNTunnelID_NoProjectID(t *testing.T) {
 func TestCompleteJobID(t *testing.T) {
 	id, name := "job-001", "my-job"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
 		Values: []types.JobResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -505,7 +505,7 @@ func TestCompleteJobID_NoProjectID(t *testing.T) {
 func TestCompleteKMSID(t *testing.T) {
 	id, name := "kms-001", "my-kms"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
 		Values: []types.KmsResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -534,7 +534,7 @@ func TestCompleteKMSID_NoProjectID(t *testing.T) {
 func TestCompleteBackupID(t *testing.T) {
 	id, name := "bkp-001", "my-backup"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
 		Values: []types.StorageBackupResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -563,7 +563,7 @@ func TestCompleteBackupID_NoProjectID(t *testing.T) {
 func TestCompleteBlockStorageID(t *testing.T) {
 	id, name := "vol-001", "my-volume"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
 		Values: []types.BlockStorageResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -592,7 +592,7 @@ func TestCompleteBlockStorageID_NoProjectID(t *testing.T) {
 func TestCompleteRestoreID_NoArgs_DelegatesToBackup(t *testing.T) {
 	id, name := "bkp-001", "my-backup"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
 		Values: []types.StorageBackupResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -617,7 +617,7 @@ func TestCompleteRestoreID_TooManyArgs(t *testing.T) {
 func TestCompleteRestoreID(t *testing.T) {
 	id, name := "rst-001", "my-restore"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
 		Values: []types.StorageRestoreResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -636,7 +636,7 @@ func TestCompleteRestoreID(t *testing.T) {
 func TestCompleteSnapshotID(t *testing.T) {
 	id, name := "snap-001", "my-snap"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
 		Values: []types.SnapshotResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -23,7 +23,7 @@ func TestCloudServerListCmd(t *testing.T) {
 			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
 					Values: []types.CloudServerResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestCloudServerListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestCloudServerListCmd(t *testing.T) {
 			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
 					Values: []types.CloudServerResponse{
 						{Metadata: types.ResourceMetadataResponse{Name: &name}},
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
@@ -60,7 +60,7 @@ func TestCloudServerListCmd(t *testing.T) {
 			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cs-001", "my-server"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
 					Values: []types.CloudServerResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -553,7 +553,7 @@ func TestCloudServerSetPasswordCmd(t *testing.T) {
 func TestCompleteCloudServerID(t *testing.T) {
 	id, name := "cs-001", "test-server"
 	srv := newArubaTestServer(t)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
 		Values: []types.CloudServerResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},
@@ -645,7 +645,7 @@ func TestCloudServerCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Properties: types.CloudServerPropertiesResult{
+		Properties: types.CloudServerPropertiesResponse{
 			Flavor: types.CloudServerFlavorResponse{
 				Name: types.CloudServerFlavor("my-flavor"),
 				CPU:  2,
@@ -653,7 +653,7 @@ func TestCloudServerCreateCmd_WithLocationAndStatus(t *testing.T) {
 				HD:   50,
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"compute", "cloudserver", "create",
@@ -699,17 +699,17 @@ func TestCloudServerGetCmd_WithFullDetailFields(t *testing.T) {
 			LocationResponse: &types.LocationResponse{Value: region},
 			Tags:             []string{"env=test"},
 		},
-		Properties: types.CloudServerPropertiesResult{
+		Properties: types.CloudServerPropertiesResponse{
 			Flavor: types.CloudServerFlavorResponse{
 				Name: types.CloudServerFlavor("my-flavor"),
 				CPU:  2,
 				RAM:  4,
 				HD:   50,
 			},
-			BootVolume: types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Storage/blockStorages/bs-001"},
-			KeyPair:    types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001"},
+			BootVolume: types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Storage/blockStorages/bs-001"},
+			KeyPair:    types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Compute/keypairs/kp-001"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"compute", "cloudserver", "get", "cs-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -726,11 +726,11 @@ func TestCloudServerPowerOnCmd_Success(t *testing.T) {
 	state := types.StateActive
 	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweron", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"compute", "cloudserver", "power-on", "cs-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -747,11 +747,11 @@ func TestCloudServerPowerOffCmd_Success(t *testing.T) {
 	state := types.StateActive
 	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001/poweroff", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"compute", "cloudserver", "power-off", "cs-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -771,12 +771,12 @@ func TestCloudServerConnectCmd_Success(t *testing.T) {
 	state := types.StateActive
 	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Properties: types.CloudServerPropertiesResult{
-			LinkedResources: []types.LinkedResource{
+		Properties: types.CloudServerPropertiesResponse{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: eipURI},
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
 		Metadata:   types.ResourceMetadataResponse{ID: &eipID},
@@ -802,11 +802,11 @@ func TestCloudServerUpdateCmd_Success(t *testing.T) {
 	state := types.StateActive
 	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &newName},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{
 		"compute", "cloudserver", "update", "cs-001",

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -329,8 +329,8 @@ func TestKeypairCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Properties: types.KeyPairPropertiesResult{Value: pubKey},
-		Status:     types.ResourceStatus{State: &state},
+		Properties: types.KeyPairPropertiesResponse{Value: pubKey},
+		Status:     types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"compute", "keypair", "create",
@@ -358,8 +358,8 @@ func TestKeypairListCmd_WithLocationAndStatus(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Properties: types.KeyPairPropertiesResult{Value: pubKey},
-				Status:     types.ResourceStatus{State: &state},
+				Properties: types.KeyPairPropertiesResponse{Value: pubKey},
+				Status:     types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -78,12 +78,9 @@ func completeContainerRegistryID(cmd *cobra.Command, args []string, toComplete s
 	var completions []string
 	if list != nil {
 		for _, cr := range list.Items() {
-			raw := cr.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := cr.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, cr.Name()))
 			}
 		}
 	}
@@ -260,8 +257,8 @@ var containerregistryGetCmd = &cobra.Command{
 			if raw.Properties.BlockStorage.URI != "" {
 				fmt.Printf("Block Storage:   %s\n", raw.Properties.BlockStorage.URI)
 			}
-			if raw.Properties.BillingPlan != nil && raw.Properties.BillingPlan.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPlan.BillingPeriod))
+			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+				fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPlanCommon.BillingPeriod))
 			}
 			if raw.Properties.AdminUser != nil {
 				fmt.Printf("Admin User:      %s\n", raw.Properties.AdminUser.Username)

--- a/cmd/container.containerregistry_test.go
+++ b/cmd/container.containerregistry_test.go
@@ -23,7 +23,7 @@ func TestContainerRegistryListCmd(t *testing.T) {
 			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cr-001", "my-registry"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
 					Values: []types.ContainerRegistryResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestContainerRegistryListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestContainerRegistryListCmd(t *testing.T) {
 			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "cr-001", "my-registry"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
 					Values: []types.ContainerRegistryResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -381,7 +381,7 @@ func TestContainerRegistryCreateCmd_OptionalFlags(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"container", "containerregistry", "create",
@@ -407,7 +407,7 @@ func TestContainerRegistryListCmd_WithLocation(t *testing.T) {
 	id, name := "cr-001", "my-registry"
 	region := types.Region("IT-BG")
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
 		Values: []types.ContainerRegistryResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -415,7 +415,7 @@ func TestContainerRegistryListCmd_WithLocation(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -446,7 +446,7 @@ func TestContainerRegistryGetCmd_FullDetail(t *testing.T) {
 			CreatedBy:        &createdBy,
 			Tags:             []string{"env=test"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"container", "containerregistry", "get", "cr-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -479,14 +479,14 @@ func TestContainerRegistryGetCmd_WithAllOptionalProps(t *testing.T) {
 	concurrentUsers := "Small"
 	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries/cr-001", jsonResponse(200, types.ContainerRegistryResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Properties: types.ContainerRegistryPropertiesResult{
-			PublicIp:        types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001"},
-			VPC:             types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"},
-			Subnet:          types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001"},
-			SecurityGroup:   types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001"},
-			BlockStorage:    types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Storage/blockStorages/bs-001"},
-			BillingPlan:     &types.BillingPlan{BillingPeriod: &period},
-			AdminUser:       &types.UserCredential{Username: "admin"},
+		Properties: types.ContainerRegistryPropertiesResponse{
+			PublicIp:        types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001"},
+			VPC:             types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"},
+			Subnet:          types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001"},
+			SecurityGroup:   types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001"},
+			BlockStorage:    types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Storage/blockStorages/bs-001"},
+			BillingPlanCommon:     &types.BillingPlanCommon{BillingPeriod: &period},
+			AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 			ConcurrentUsers: &concurrentUsers,
 		},
 	}))

--- a/cmd/container.containerregistry_test.go
+++ b/cmd/container.containerregistry_test.go
@@ -480,14 +480,14 @@ func TestContainerRegistryGetCmd_WithAllOptionalProps(t *testing.T) {
 	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries/cr-001", jsonResponse(200, types.ContainerRegistryResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
 		Properties: types.ContainerRegistryPropertiesResponse{
-			PublicIp:        types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001"},
-			VPC:             types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"},
-			Subnet:          types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001"},
-			SecurityGroup:   types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001"},
-			BlockStorage:    types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Storage/blockStorages/bs-001"},
-			BillingPlanCommon:     &types.BillingPlanCommon{BillingPeriod: &period},
-			AdminUser:       &types.UserCredentialCommon{Username: "admin"},
-			ConcurrentUsers: &concurrentUsers,
+			PublicIp:          types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001"},
+			VPC:               types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"},
+			Subnet:            types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001"},
+			SecurityGroup:     types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001"},
+			BlockStorage:      types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Storage/blockStorages/bs-001"},
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &period},
+			AdminUser:         &types.UserCredentialCommon{Username: "admin"},
+			ConcurrentUsers:   &concurrentUsers,
 		},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"container", "containerregistry", "get", "cr-001", "--project-id", "proj-123"})

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -214,7 +214,7 @@ Billing period: Hour (default), Month, or Year.`,
 			kaas.BilledBy(aruba.BillingPeriod(billingPeriod))
 		}
 		if len(apiServerAuthorizedIPRanges) > 0 || apiServerEnablePrivateCluster {
-			// TECH_DEBT: TD-033 — types.KaaSAPIServerAccessProfilePropertiesRequest must be
+			// TECH_DEBT: TD-033 (#131) — types.KaaSAPIServerAccessProfilePropertiesRequest must be
 			// referenced directly because the SDK provides no aruba-level constructor for
 			// this type yet. Remove the types import from this file once sdk-go exposes
 			// aruba.NewAPIServerAccessProfile() or an equivalent fluent setter.

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -111,12 +111,9 @@ func completeKaaSID(cmd *cobra.Command, args []string, toComplete string) ([]str
 	var completions []string
 	if list != nil {
 		for _, k := range list.Items() {
-			raw := k.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := k.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, k.Name()))
 			}
 		}
 	}
@@ -217,7 +214,11 @@ Billing period: Hour (default), Month, or Year.`,
 			kaas.BilledBy(aruba.BillingPeriod(billingPeriod))
 		}
 		if len(apiServerAuthorizedIPRanges) > 0 || apiServerEnablePrivateCluster {
-			profile := &types.APIServerAccessProfileProperties{
+			// TECH_DEBT: TD-033 — types.KaaSAPIServerAccessProfilePropertiesRequest must be
+			// referenced directly because the SDK provides no aruba-level constructor for
+			// this type yet. Remove the types import from this file once sdk-go exposes
+			// aruba.NewAPIServerAccessProfile() or an equivalent fluent setter.
+			profile := &types.KaaSAPIServerAccessProfilePropertiesRequest{
 				EnablePrivateCluster: apiServerEnablePrivateCluster,
 			}
 			if len(apiServerAuthorizedIPRanges) > 0 {
@@ -233,31 +234,19 @@ Billing period: Hour (default), Month, or Year.`,
 			return fmt.Errorf("creating KaaS cluster: %w", apiErrFromV2(err))
 		}
 
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
+		if created != nil && created.ID() != "" {
 			headers := []TableColumn{
 				{Header: "ID", Width: 30},
 				{Header: "NAME", Width: 40},
 				{Header: "VERSION", Width: 20},
 				{Header: "REGION", Width: 20},
 			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			version := ""
-			if raw.Properties.KubernetesVersion.Value != nil {
-				version = string(*raw.Properties.KubernetesVersion.Value)
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, version, regionVal}})
+			PrintOutput(created, headers, [][]string{{
+				created.ID(),
+				created.Name(),
+				string(created.KubernetesVersion()),
+				string(created.Region()),
+			}})
 		} else {
 			fmt.Println(msgCreatedAsync("KaaS cluster", name))
 		}
@@ -290,9 +279,7 @@ var kaasGetCmd = &cobra.Command{
 			return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
 		}
 
-		if kaas != nil && kaas.Raw() != nil {
-			raw := kaas.Raw()
-
+		if kaas != nil && kaas.ID() != "" {
 			format := resolveOutputFormat()
 			if format == OutputFormatJSON || format == OutputFormatYAML {
 				PrintOutput(kaas, nil, nil)
@@ -301,32 +288,29 @@ var kaasGetCmd = &cobra.Command{
 
 			fmt.Println("\nKaaS Cluster Details:")
 			fmt.Println("====================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+			fmt.Printf("ID:              %s\n", kaas.ID())
+			if kaas.URI() != "" {
+				fmt.Printf("URI:             %s\n", kaas.URI())
 			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+			fmt.Printf("Name:            %s\n", kaas.Name())
+			if r := kaas.Region(); r != "" {
+				fmt.Printf("Region:          %s\n", string(r))
 			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+			if v := kaas.KubernetesVersion(); v != "" {
+				fmt.Printf("Kubernetes Version: %s\n", string(v))
 			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+			if s := kaas.State(); s != "" {
+				fmt.Printf("Status:          %s\n", string(s))
 			}
-			if raw.Properties.KubernetesVersion.Value != nil {
-				fmt.Printf("Kubernetes Version: %s\n", string(*raw.Properties.KubernetesVersion.Value))
+			if !kaas.CreatedAt().IsZero() {
+				fmt.Printf("Creation Date:   %s\n", kaas.CreatedAt().Format(DateLayout))
 			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
+			// CreatedBy has no wrapper accessor in sdk-go v1.0.0 — TECH_DEBT: TD-033
+			if raw := kaas.Raw(); raw != nil && raw.Metadata.CreatedBy != nil {
 				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
 			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+			if tags := kaas.Tags(); len(tags) > 0 {
+				fmt.Printf("Tags:            %v\n", tags)
 			} else {
 				fmt.Printf("Tags:            []\n")
 			}
@@ -371,31 +355,16 @@ var kaasListCmd = &cobra.Command{
 
 			var rows [][]string
 			for _, k := range list.Items() {
-				raw := k.Raw()
-				if raw == nil {
+				if k.ID() == "" {
 					continue
 				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				version := ""
-				if raw.Properties.KubernetesVersion.Value != nil {
-					version = string(*raw.Properties.KubernetesVersion.Value)
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{id, name, version, region, status})
+				rows = append(rows, []string{
+					k.ID(),
+					k.Name(),
+					string(k.KubernetesVersion()),
+					string(k.Region()),
+					string(k.State()),
+				})
 			}
 			PrintOutput(list, headers, rows)
 		} else {
@@ -429,7 +398,7 @@ var kaasUpdateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
 		}
-		if kaas == nil || kaas.Raw() == nil {
+		if kaas == nil || kaas.ID() == "" {
 			return fmt.Errorf("KaaS cluster not found")
 		}
 
@@ -482,17 +451,12 @@ var kaasUpdateCmd = &cobra.Command{
 			return fmt.Errorf("updating KaaS cluster: %w", apiErrFromV2(err))
 		}
 
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
+		if updated != nil && updated.ID() != "" {
 			fmt.Printf("\n%s\n", msgUpdated("KaaS cluster", kaasID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+			fmt.Printf("ID:      %s\n", updated.ID())
+			fmt.Printf("Name:    %s\n", updated.Name())
+			if tags := updated.Tags(); len(tags) > 0 {
+				fmt.Printf("Tags:    %v\n", tags)
 			}
 		} else {
 			fmt.Println(msgUpdatedAsync("KaaS cluster", kaasID))
@@ -577,7 +541,7 @@ var kaasConnectCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
 		}
-		if kaas == nil || kaas.Raw() == nil {
+		if kaas == nil || kaas.ID() == "" {
 			return fmt.Errorf("KaaS cluster not found")
 		}
 
@@ -600,8 +564,8 @@ var kaasConnectCmd = &cobra.Command{
 		}
 
 		clusterName := kaasID
-		if kaas.Raw().Metadata.Name != nil {
-			clusterName = *kaas.Raw().Metadata.Name
+		if n := kaas.Name(); n != "" {
+			clusterName = n
 		}
 
 		kubeconfigFile := filepath.Join(kubeDir, clusterName)

--- a/cmd/container.kaas_test.go
+++ b/cmd/container.kaas_test.go
@@ -23,7 +23,7 @@ func TestKaaSListCmd(t *testing.T) {
 			args: []string{"container", "kaas", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "kaas-001", "my-cluster"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
 					Values: []types.KaaSResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestKaaSListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"container", "kaas", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestKaaSListCmd(t *testing.T) {
 			args: []string{"container", "kaas", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "kaas-001", "my-cluster"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
 					Values: []types.KaaSResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -428,7 +428,7 @@ func TestKaaSListCmd_WithK8sVersionAndLocation(t *testing.T) {
 	verStr := string(types.KubernetesVersion1323)
 	state := types.StateActive
 	region := types.Region("IT-BG")
-	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
 		Values: []types.KaaSResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -439,7 +439,7 @@ func TestKaaSListCmd_WithK8sVersionAndLocation(t *testing.T) {
 				Properties: types.KaaSPropertiesResponse{
 					KubernetesVersion: types.KubernetesVersionInfoResponse{Value: &verStr},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -489,7 +489,7 @@ func TestKaaSGetCmd_FullDetail(t *testing.T) {
 		Properties: types.KaaSPropertiesResponse{
 			KubernetesVersion: types.KubernetesVersionInfoResponse{Value: &verStr2},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"container", "kaas", "get", "kaas-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -548,7 +548,7 @@ func TestKaaSCreateCmd_WithLocationAndStatus(t *testing.T) {
 		Properties: types.KaaSPropertiesResponse{
 			KubernetesVersion: types.KubernetesVersionInfoResponse{Value: &verStr},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"container", "kaas", "create",

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -63,12 +63,9 @@ func completeDatabaseBackupID(cmd *cobra.Command, args []string, toComplete stri
 	var completions []string
 	if list != nil {
 		for _, backup := range list.Items() {
-			raw := backup.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := backup.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, backup.Name()))
 			}
 		}
 	}

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -23,7 +23,7 @@ func TestDBBackupListCmd(t *testing.T) {
 			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
 					Values: []types.BackupResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestDBBackupListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestDBBackupListCmd(t *testing.T) {
 			args: []string{"database", "backup", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
 					Values: []types.BackupResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -314,7 +314,7 @@ func TestDBBackupListCmd_AllOptionalFields(t *testing.T) {
 	id, name := "bkp-001", "my-backup"
 	state := types.StateActive
 	region := types.Region("IT-BG")
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
 		Values: []types.BackupResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -322,7 +322,7 @@ func TestDBBackupListCmd_AllOptionalFields(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -361,7 +361,7 @@ func TestDBBackupGetCmd_AllOptionalFields(t *testing.T) {
 				CreatedBy:        &createdBy,
 				Tags:             []string{"env=test"},
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}
 	}
 

--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -22,7 +22,7 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 			name: "success with results",
 			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
 					Values: []types.DatabaseResponse{
 						{Name: "my-db"},
 					},
@@ -38,14 +38,14 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{}))
 			},
 		},
 		{
 			name: "--output json emits valid JSON",
 			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
 					Values: []types.DatabaseResponse{
 						{Name: "my-db"},
 					},
@@ -320,7 +320,7 @@ func TestDBaaSDatabaseListCmd_AllOptionalFields(t *testing.T) {
 	srv := newArubaTestServer(t)
 	createdBy := "user@example.com"
 	ts := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
 		Values: []types.DatabaseResponse{
 			{Name: "my-db", CreatedBy: &createdBy, CreationDate: &ts},
 		},

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -75,12 +75,9 @@ func completeDBaaSID(cmd *cobra.Command, args []string, toComplete string) ([]st
 	var completions []string
 	if list != nil {
 		for _, d := range list.Items() {
-			raw := d.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := d.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, d.Name()))
 			}
 		}
 	}

--- a/cmd/database.dbaas.grant_test.go
+++ b/cmd/database.dbaas.grant_test.go
@@ -16,8 +16,8 @@ const (
 
 func makeGrantResp() types.GrantResponse {
 	return types.GrantResponse{
-		User:     types.GrantUser{Username: "myuser"},
-		Role:     types.GrantRole{Name: "liteadmin"},
+		User:     types.GrantUserCommon{Username: "myuser"},
+		Role:     types.GrantRoleCommon{Name: "liteadmin"},
 		Database: types.GrantDatabaseResponse{Name: "mydb"},
 	}
 }
@@ -35,7 +35,7 @@ func TestDBaaSGrantListCmd(t *testing.T) {
 			name: "success with results",
 			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet(grantListPath, jsonResponse(200, types.GrantList{
+				srv.OnGet(grantListPath, jsonResponse(200, types.GrantListResponse{
 					Values: []types.GrantResponse{makeGrantResp()},
 				}))
 			},
@@ -49,7 +49,7 @@ func TestDBaaSGrantListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet(grantListPath, jsonResponse(200, types.GrantList{}))
+				srv.OnGet(grantListPath, jsonResponse(200, types.GrantListResponse{}))
 			},
 			assertOut: func(t *testing.T, out string) {
 				if !strings.Contains(out, "No grants found") {

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -22,7 +22,7 @@ func TestDBaaSUserListCmd(t *testing.T) {
 			name: "success with results",
 			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
 					Values: []types.UserResponse{
 						{Username: "admin"},
 					},
@@ -38,14 +38,14 @@ func TestDBaaSUserListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{}))
 			},
 		},
 		{
 			name: "--output json emits valid JSON",
 			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
 					Values: []types.UserResponse{
 						{Username: "admin"},
 					},
@@ -394,7 +394,7 @@ func TestDBaaSUserListCmd_AllOptionalFields(t *testing.T) {
 	srv := newArubaTestServer(t)
 	createdBy := "user@example.com"
 	ts := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.UserList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
 		Values: []types.UserResponse{
 			{Username: "admin", CreatedBy: &createdBy, CreationDate: &ts},
 		},

--- a/cmd/database.dbaas_test.go
+++ b/cmd/database.dbaas_test.go
@@ -22,7 +22,7 @@ func TestDBaaSListCmd(t *testing.T) {
 			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-001", "my-dbaas"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
 					Values: []types.DBaaSResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -38,7 +38,7 @@ func TestDBaaSListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{}))
 			},
 		},
 		{
@@ -46,7 +46,7 @@ func TestDBaaSListCmd(t *testing.T) {
 			args: []string{"database", "dbaas", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "dbaas-001", "my-dbaas"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
 					Values: []types.DBaaSResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -66,7 +66,7 @@ func TestDBaaSListCmd(t *testing.T) {
 				id, name := "dbaas-rich", "rich-dbaas"
 				engineType, engineVersion := "postgresql", "14"
 				flavorName := "db.small"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
 					Values: []types.DBaaSResponse{
 						{
 							Metadata: types.ResourceMetadataResponse{
@@ -78,7 +78,7 @@ func TestDBaaSListCmd(t *testing.T) {
 								Engine: &types.DBaaSEngineResponse{Type: &engineType, Version: &engineVersion},
 								Flavor: &types.DBaaSFlavorResponse{Name: &flavorName},
 							},
-							Status: types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+							Status: types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 						},
 					},
 				}))
@@ -174,7 +174,7 @@ func TestDBaaSGetCmd(t *testing.T) {
 						},
 						Flavor: &types.DBaaSFlavorResponse{Name: &flavorName},
 					},
-					Status: types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+					Status: types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 				}))
 			},
 			assertOut: func(t *testing.T, out string) {
@@ -502,7 +502,7 @@ func TestDBaaSCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"database", "dbaas", "create",
@@ -524,7 +524,7 @@ func TestDBaaSListCmd_WithLocationAndStatus(t *testing.T) {
 	id, name := "dbaas-001", "my-db"
 	region := types.Region("IT-BG")
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
 		Values: []types.DBaaSResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -532,7 +532,7 @@ func TestDBaaSListCmd_WithLocationAndStatus(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))

--- a/cmd/helpers_coverage_test.go
+++ b/cmd/helpers_coverage_test.go
@@ -7,7 +7,6 @@ package cmd
 
 import (
 	"errors"
-	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -28,8 +27,8 @@ func TestRedactVPNTunnelSecrets(t *testing.T) {
 	resp := types.VPNTunnelResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id},
 		Properties: types.VPNTunnelPropertiesResponse{
-			VPNClientSettings: &types.VPNClientSettings{
-				PSK: &types.PSKSettings{
+			VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
+				PSK: &types.PSKSettingsCommon{
 					CloudSite: &cloud,
 					Secret:    &secret,
 				},
@@ -48,10 +47,10 @@ func TestRedactVPNTunnelSecrets(t *testing.T) {
 
 	redactVPNTunnelSecrets(tunnel)
 
-	if tunnel.Raw().Properties.VPNClientSettings.PSK.Secret != nil {
+	if tunnel.Raw().Properties.VPNClientSettingsCommon.PSK.Secret != nil {
 		t.Error("expected PSK.Secret to be nil after redaction")
 	}
-	if tunnel.Raw().Properties.VPNClientSettings.PSK.CloudSite == nil {
+	if tunnel.Raw().Properties.VPNClientSettingsCommon.PSK.CloudSite == nil {
 		t.Error("expected non-secret PSK fields to be preserved")
 	}
 
@@ -78,15 +77,15 @@ func TestVPNTunnelUpdate_ReattachSettings(t *testing.T) {
 	active := types.StateActive
 	getResp := types.VPNTunnelResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &active},
+		Status:   types.ResourceStatusResponse{State: &active},
 		Properties: types.VPNTunnelPropertiesResponse{
-			IPConfigurations: &types.IPConfigurations{
-				VPC:      &types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"},
-				PublicIP: &types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001"},
-				Subnet:   &types.SubnetInfo{Name: "my-subnet", CIDR: "10.0.0.0/24"},
+			IPConfigurationsCommon: &types.IPConfigurationsCommon{
+				VPC:      &types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001"},
+				PublicIP: &types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001"},
+				Subnet:   &types.SubnetInfoCommon{Name: "my-subnet", CIDR: "10.0.0.0/24"},
 			},
-			VPNClientSettings: &types.VPNClientSettings{
-				IKE: &types.IKESettings{
+			VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
+				IKE: &types.IKESettingsCommon{
 					Lifetime:    3600,
 					Encryption:  &enc,
 					Hash:        &hash,
@@ -95,13 +94,13 @@ func TestVPNTunnelUpdate_ReattachSettings(t *testing.T) {
 					DPDInterval: 10,
 					DPDTimeout:  30,
 				},
-				ESP: &types.ESPSettings{
+				ESP: &types.ESPSettingsCommon{
 					Lifetime:   1800,
 					Encryption: &espEnc,
 					Hash:       &espHash,
 					PFS:        &pfs,
 				},
-				PSK: &types.PSKSettings{
+				PSK: &types.PSKSettingsCommon{
 					CloudSite: &cloudSite,
 					Secret:    &secret,
 				},
@@ -137,7 +136,7 @@ func TestVPNTunnelUpdate_NilIPConfig(t *testing.T) {
 	active := types.StateActive
 	getResp := types.VPNTunnelResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &active},
+		Status:   types.ResourceStatusResponse{State: &active},
 	}
 	updatedName := "tunnel-2-updated"
 	srv := newArubaTestServer(t)
@@ -361,10 +360,6 @@ type fakeRawMarshaler struct{ j, y []byte }
 func (f fakeRawMarshaler) RawJSON() []byte { return f.j }
 func (f fakeRawMarshaler) RawYAML() []byte { return f.y }
 
-type fakeRawHTTPer struct{ body []byte }
-
-func (f fakeRawHTTPer) RawHTTP() (*http.Response, []byte) { return nil, f.body }
-
 func TestPrintJSON(t *testing.T) {
 	t.Run("nil emits {}", func(t *testing.T) {
 		out := captureStdout(func() { printJSON(nil) })
@@ -383,20 +378,6 @@ func TestPrintJSON(t *testing.T) {
 
 	t.Run("rawMarshaler empty bytes emits {}", func(t *testing.T) {
 		out := captureStdout(func() { printJSON(fakeRawMarshaler{j: []byte{}}) })
-		if strings.TrimSpace(out) != "{}" {
-			t.Fatalf("got %q, want {}", out)
-		}
-	})
-
-	t.Run("rawHTTPer body used", func(t *testing.T) {
-		out := captureStdout(func() { printJSON(fakeRawHTTPer{body: []byte(`{"k":"v"}`)}) })
-		if !strings.Contains(out, `"k":"v"`) {
-			t.Fatalf("got %q", out)
-		}
-	})
-
-	t.Run("rawHTTPer empty body emits {}", func(t *testing.T) {
-		out := captureStdout(func() { printJSON(fakeRawHTTPer{body: []byte{}}) })
 		if strings.TrimSpace(out) != "{}" {
 			t.Fatalf("got %q, want {}", out)
 		}
@@ -428,20 +409,6 @@ func TestPrintYAML(t *testing.T) {
 
 	t.Run("rawMarshaler empty bytes emits {}", func(t *testing.T) {
 		out := captureStdout(func() { printYAML(fakeRawMarshaler{y: []byte{}}) })
-		if strings.TrimSpace(out) != "{}" {
-			t.Fatalf("got %q, want {}", out)
-		}
-	})
-
-	t.Run("rawHTTPer JSON body converted to YAML", func(t *testing.T) {
-		out := captureStdout(func() { printYAML(fakeRawHTTPer{body: []byte(`{"k":"v"}`)}) })
-		if !strings.Contains(out, "k: v") {
-			t.Fatalf("got %q", out)
-		}
-	})
-
-	t.Run("rawHTTPer empty body emits {}", func(t *testing.T) {
-		out := captureStdout(func() { printYAML(fakeRawHTTPer{body: []byte{}}) })
 		if strings.TrimSpace(out) != "{}" {
 			t.Fatalf("got %q, want {}", out)
 		}

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -203,8 +203,8 @@ var projectGetCmd = &cobra.Command{
 			if !p.UpdatedAt().IsZero() {
 				fmt.Printf("Update Date:     %s\n", p.UpdatedAt().Format(DateLayout))
 			}
-			// CreatedBy / UpdatedBy have no wrapper accessors in sdk-go v1.0.0.
-			// TECH_DEBT: TD-033 — remove once sdk-go exposes CreatedBy()/UpdatedBy() on *aruba.Project.
+			// CreatedBy / UpdatedBy have no wrapper accessors in sdk-go v1.0.0. TECH_DEBT: TD-033 (#131)
+			// See https://github.com/Arubacloud/acloud-cli/issues/131
 			if raw := p.Raw(); raw != nil {
 				if raw.Metadata.CreatedBy != nil {
 					fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -197,19 +197,20 @@ var projectGetCmd = &cobra.Command{
 
 			fmt.Printf("Default:         %t\n", p.IsDefault())
 
-			raw := p.Raw()
-			if raw != nil {
-				if raw.CreationDate != nil && !raw.CreationDate.IsZero() {
-					fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
+			if !p.CreatedAt().IsZero() {
+				fmt.Printf("Creation Date:   %s\n", p.CreatedAt().Format(DateLayout))
+			}
+			if !p.UpdatedAt().IsZero() {
+				fmt.Printf("Update Date:     %s\n", p.UpdatedAt().Format(DateLayout))
+			}
+			// CreatedBy / UpdatedBy have no wrapper accessors in sdk-go v1.0.0.
+			// TECH_DEBT: TD-033 — remove once sdk-go exposes CreatedBy()/UpdatedBy() on *aruba.Project.
+			if raw := p.Raw(); raw != nil {
+				if raw.Metadata.CreatedBy != nil {
+					fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
 				}
-				if raw.CreatedBy != nil {
-					fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
-				}
-				if raw.UpdateDate != nil && !raw.UpdateDate.IsZero() {
-					fmt.Printf("Update Date:     %s\n", raw.UpdateDate.Format(DateLayout))
-				}
-				if raw.UpdatedBy != nil {
-					fmt.Printf("Updated By:      %s\n", *raw.UpdatedBy)
+				if raw.Metadata.UpdatedBy != nil {
+					fmt.Printf("Updated By:      %s\n", *raw.Metadata.UpdatedBy)
 				}
 			}
 

--- a/cmd/management.project_test.go
+++ b/cmd/management.project_test.go
@@ -22,7 +22,7 @@ func TestProjectListCmd(t *testing.T) {
 			name: "success with results",
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-001", "my-project"
-				srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
 					Values: []types.ProjectResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -38,7 +38,7 @@ func TestProjectListCmd(t *testing.T) {
 		{
 			name: "success empty",
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects", jsonResponse(200, types.ProjectList{}))
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{}))
 			},
 			args: []string{"management", "project", "list"},
 		},
@@ -46,7 +46,7 @@ func TestProjectListCmd(t *testing.T) {
 			name: "--output=json emits valid JSON",
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "proj-001", "my-project"
-				srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
 					Values: []types.ProjectResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -423,7 +423,7 @@ func TestProjectListCmd_AllOptionalFields(t *testing.T) {
 	srv := newArubaTestServer(t)
 	id, name := "proj-001", "my-project"
 	desc := "My test project"
-	srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+	srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
 		Values: []types.ProjectResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -450,7 +450,7 @@ func TestProjectListCmd_AllOptionalFields(t *testing.T) {
 func TestProjectListCmd_WithProjectData(t *testing.T) {
 	srv := newArubaTestServer(t)
 	id, name := "proj-001", "my-project"
-	srv.OnGet("/projects", jsonResponse(200, types.ProjectList{
+	srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
 		Values: []types.ProjectResponse{
 			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 		},

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -64,12 +64,9 @@ func completeElasticIPID(cmd *cobra.Command, args []string, toComplete string) (
 	var completions []string
 	if list != nil {
 		for _, eip := range list.Items() {
-			raw := eip.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := eip.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, eip.Name()))
 			}
 		}
 	}
@@ -260,8 +257,8 @@ var elasticipGetCmd = &cobra.Command{
 			if raw.Properties.Address != nil {
 				fmt.Printf("Address:         %s\n", *raw.Properties.Address)
 			}
-			if raw.Properties.BillingPlan != nil && raw.Properties.BillingPlan.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlan.BillingPeriod)
+			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+				fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
 			}
 			fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
 			if raw.Metadata.CreationDate != nil {

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -452,7 +452,7 @@ func TestElasticIPGetCmd_AllOptionalFields(t *testing.T) {
 				Tags:             []string{"env=test"},
 			},
 			Properties: types.ElasticIPPropertiesResponse{
-				Address:     &addr,
+				Address:           &addr,
 				BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &billingPeriod},
 			},
 			Status: types.ResourceStatusResponse{State: &state},

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -23,7 +23,7 @@ func TestElasticIPListCmd(t *testing.T) {
 			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "eip-001", "my-eip"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
 					Values: []types.ElasticIPResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestElasticIPListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestElasticIPListCmd(t *testing.T) {
 			args: []string{"network", "elasticip", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "eip-001", "my-eip"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
 					Values: []types.ElasticIPResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -235,7 +235,7 @@ func TestElasticIPUpdateCmd(t *testing.T) {
 				state := types.StateActive
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
@@ -270,7 +270,7 @@ func TestElasticIPUpdateCmd(t *testing.T) {
 				state := types.StateActive
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
@@ -397,7 +397,7 @@ func TestElasticIPListCmd_AllOptionalFields(t *testing.T) {
 	addr := "1.2.3.4"
 	state := types.StateActive
 	region := types.Region("IT-BG")
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
 		Values: []types.ElasticIPResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -408,7 +408,7 @@ func TestElasticIPListCmd_AllOptionalFields(t *testing.T) {
 				Properties: types.ElasticIPPropertiesResponse{
 					Address: &addr,
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -453,9 +453,9 @@ func TestElasticIPGetCmd_AllOptionalFields(t *testing.T) {
 			},
 			Properties: types.ElasticIPPropertiesResponse{
 				Address:     &addr,
-				BillingPlan: &types.BillingPlan{BillingPeriod: &billingPeriod},
+				BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &billingPeriod},
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}
 	}
 
@@ -487,7 +487,7 @@ func TestElasticIPListCmd_WithLocationAndStatus(t *testing.T) {
 	region := types.Region("IT-BG")
 	state := types.StateActive
 	addr := "203.0.113.1"
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
 		Values: []types.ElasticIPResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -496,7 +496,7 @@ func TestElasticIPListCmd_WithLocationAndStatus(t *testing.T) {
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
 				Properties: types.ElasticIPPropertiesResponse{Address: &addr},
-				Status:     types.ResourceStatus{State: &state},
+				Status:     types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -529,7 +529,7 @@ func TestElasticIPGetCmd_FullDetail(t *testing.T) {
 			Tags:             []string{"env=test"},
 		},
 		Properties: types.ElasticIPPropertiesResponse{Address: &addr},
-		Status:     types.ResourceStatus{State: &state},
+		Status:     types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "elasticip", "get", "eip-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -52,12 +52,9 @@ func completeLoadBalancerID(cmd *cobra.Command, args []string, toComplete string
 	var completions []string
 	if list != nil {
 		for _, lb := range list.Items() {
-			raw := lb.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := lb.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, lb.Name()))
 			}
 		}
 	}

--- a/cmd/network.loadbalancer_test.go
+++ b/cmd/network.loadbalancer_test.go
@@ -23,7 +23,7 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "lb-001", "my-lb"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
 					Values: []types.LoadBalancerResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "lb-001", "my-lb"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
 					Values: []types.LoadBalancerResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -154,7 +154,7 @@ func TestLoadBalancerListCmd_WithAllFields(t *testing.T) {
 	region := types.Region("IT-BG")
 	state := types.StateActive
 	addr := "192.0.2.1"
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
 		Values: []types.LoadBalancerResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -163,7 +163,7 @@ func TestLoadBalancerListCmd_WithAllFields(t *testing.T) {
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
 				Properties: types.LoadBalancerPropertiesResponse{Address: &addr},
-				Status:     types.ResourceStatus{State: &state},
+				Status:     types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -196,7 +196,7 @@ func TestLoadBalancerGetCmd_FullDetail(t *testing.T) {
 			Tags:             []string{"env=test"},
 		},
 		Properties: types.LoadBalancerPropertiesResponse{Address: &addr},
-		Status:     types.ResourceStatus{State: &state},
+		Status:     types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "loadbalancer", "get", "lb-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.securitygroup_test.go
+++ b/cmd/network.securitygroup_test.go
@@ -23,7 +23,7 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sg-001", "my-sg"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
 					Values: []types.SecurityGroupResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sg-001", "my-sg"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
 					Values: []types.SecurityGroupResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -235,7 +235,7 @@ func TestSecurityGroupUpdateCmd(t *testing.T) {
 				state := types.StateActive
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
@@ -270,7 +270,7 @@ func TestSecurityGroupUpdateCmd(t *testing.T) {
 				state := types.StateActive
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001", jsonResponse(200, types.SecurityGroupResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
@@ -369,7 +369,7 @@ func TestSecurityGroupListCmd_AllOptionalFields(t *testing.T) {
 	id, name := "sg-001", "my-sg"
 	state := types.StateActive
 	region := types.Region("IT-BG")
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
 		Values: []types.SecurityGroupResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -377,7 +377,7 @@ func TestSecurityGroupListCmd_AllOptionalFields(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -415,7 +415,7 @@ func TestSecurityGroupGetCmd_AllOptionalFields(t *testing.T) {
 				CreatedBy:        &createdBy,
 				Tags:             []string{"env=test"},
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}
 	}
 
@@ -469,7 +469,7 @@ func TestSecurityGroupCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"network", "securitygroup", "create", "vpc-001",
@@ -500,7 +500,7 @@ func TestSecurityGroupGetCmd_FullDetail(t *testing.T) {
 			CreatedBy:        &createdBy,
 			Tags:             []string{"env=test"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "securitygroup", "get", "vpc-001", "sg-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -86,12 +86,9 @@ func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string
 	var completions []string
 	if list != nil {
 		for _, rule := range list.Items() {
-			raw := rule.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := rule.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, rule.Name()))
 			}
 		}
 	}

--- a/cmd/network.securityrule_test.go
+++ b/cmd/network.securityrule_test.go
@@ -24,7 +24,7 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rule-001", "my-rule"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
-					jsonResponse(200, types.SecurityRuleList{
+					jsonResponse(200, types.SecurityRuleListResponse{
 						Values: []types.SecurityRuleResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -41,7 +41,7 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
-					jsonResponse(200, types.SecurityRuleList{}))
+					jsonResponse(200, types.SecurityRuleListResponse{}))
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rule-001", "my-rule"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
-					jsonResponse(200, types.SecurityRuleList{
+					jsonResponse(200, types.SecurityRuleListResponse{
 						Values: []types.SecurityRuleResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -271,7 +271,7 @@ func TestSecurityRuleUpdateCmd(t *testing.T) {
 							Name:             &name,
 							LocationResponse: &types.LocationResponse{Value: region},
 						},
-						Status: types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status: types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				updID, updName := "rule-001", "new-name"
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules/rule-001",
@@ -305,7 +305,7 @@ func TestSecurityRuleUpdateCmd(t *testing.T) {
 							Name:             &name,
 							LocationResponse: &types.LocationResponse{Value: region},
 						},
-						Status: types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status: types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules/rule-001",
 					errorResponse(500, "Internal Server Error", "boom"))
@@ -331,7 +331,7 @@ func TestSecurityRuleUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules/rule-001",
 					jsonResponse(200, types.SecurityRuleResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				vpcID, vpcName := "vpc-001", "my-vpc"
 				region := types.Region("IT-BG")
@@ -461,12 +461,12 @@ func TestSecurityRuleGetCmd_FullDetail(t *testing.T) {
 					CreatedBy:        &createdBy,
 					Tags:             []string{"env=prod"},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 				Properties: types.SecurityRulePropertiesResponse{
 					Direction: types.RuleDirectionIngress,
 					Protocol:  types.RuleProtocolTCP,
 					Port:      "80",
-					Target:    &types.RuleTarget{Kind: types.EndpointTypeIP, Value: "0.0.0.0/0"},
+					Target:    &types.RuleTargetCommon{Kind: types.EndpointTypeIP, Value: "0.0.0.0/0"},
 				},
 			}))
 		out, err := runCmdCapture(srv.Client(), []string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"})
@@ -505,7 +505,7 @@ func TestSecurityRuleListCmd_AllOptionalFields(t *testing.T) {
 	state := types.StateActive
 	region := types.Region("IT-BG")
 	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
-		jsonResponse(200, types.SecurityRuleList{
+		jsonResponse(200, types.SecurityRuleListResponse{
 			Values: []types.SecurityRuleResponse{
 				{
 					Metadata: types.ResourceMetadataResponse{
@@ -513,7 +513,7 @@ func TestSecurityRuleListCmd_AllOptionalFields(t *testing.T) {
 						Name:             &name,
 						LocationResponse: &types.LocationResponse{Value: region},
 					},
-					Status: types.ResourceStatus{State: &state},
+					Status: types.ResourceStatusResponse{State: &state},
 					Properties: types.SecurityRulePropertiesResponse{
 						Direction: types.RuleDirectionIngress,
 						Protocol:  types.RuleProtocolTCP,
@@ -552,7 +552,7 @@ func TestSecurityRuleCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Protocol:  proto,
 			Port:      port,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"network", "securityrule", "create", "vpc-001", "sg-001",
@@ -578,7 +578,7 @@ func TestSecurityRuleListCmd_WithAllFields(t *testing.T) {
 	dir := types.RuleDirectionIngress
 	proto := types.RuleProtocolTCP
 	port := "80"
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules", jsonResponse(200, types.SecurityRuleList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules", jsonResponse(200, types.SecurityRuleListResponse{
 		Values: []types.SecurityRuleResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -591,7 +591,7 @@ func TestSecurityRuleListCmd_WithAllFields(t *testing.T) {
 					Protocol:  proto,
 					Port:      port,
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -630,7 +630,7 @@ func TestSecurityRuleGetCmd_WithAllOptionals(t *testing.T) {
 			Protocol:  proto,
 			Port:      port,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "securityrule", "get", "vpc-001", "sg-001", "rule-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -118,7 +118,7 @@ DHCP routes format: "destination:gateway" (e.g., "10.1.0.0/24:10.0.0.1").`,
 			for _, routeStr := range dhcpRoutes {
 				parts := splitRouteString(routeStr)
 				if len(parts) == 2 {
-					dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRoute{Address: parts[0], Gateway: parts[1]})
+					dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: parts[0], Gateway: parts[1]})
 				} else {
 					fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
 				}
@@ -338,11 +338,11 @@ var subnetUpdateCmd = &cobra.Command{
 		defer cancel()
 
 		subnet, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
-		if err != nil || subnet == nil || subnet.Raw() == nil {
+		if err != nil || subnet == nil || subnet.ID() == "" {
 			return fmt.Errorf("fetching current subnet: %w", apiErrFromV2(err))
 		}
 
-		if subnet.Raw().Status.State != nil && *subnet.Raw().Status.State == StateInCreation {
+		if subnet.State() == StateInCreation {
 			return fmt.Errorf("cannot update subnet while it is in 'InCreation' state. Please wait until the subnet is fully created")
 		}
 
@@ -356,7 +356,10 @@ var subnetUpdateCmd = &cobra.Command{
 			subnet.WithCIDR(cidr)
 		}
 
-		// Update DHCP config for Advanced subnets
+		// Update DHCP config for Advanced subnets.
+		// TECH_DEBT: TD-035 — .Raw() is required here because sdk-go v1.0.0 does not
+		// expose subnet Type or DHCP configuration through wrapper accessors. Remove
+		// once sdk-go adds Type(), DHCP() or equivalent getters on *aruba.Subnet.
 		if subnet.Raw().Properties.Type == aruba.SubnetTypeAdvanced {
 			currentDHCP := subnet.Raw().Properties.DHCP
 			if cmd.Flags().Changed("dhcp-enabled") || len(dhcpRoutes) > 0 || len(dhcpDNS) > 0 {
@@ -370,14 +373,14 @@ var subnetUpdateCmd = &cobra.Command{
 					for _, routeStr := range dhcpRoutes {
 						parts := splitRouteString(routeStr)
 						if len(parts) == 2 {
-							dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRoute{Address: parts[0], Gateway: parts[1]})
+							dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: parts[0], Gateway: parts[1]})
 						} else {
 							fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
 						}
 					}
 				} else if currentDHCP != nil {
 					for _, r := range currentDHCP.Routes {
-						dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRoute{Address: r.Address, Gateway: r.Gateway})
+						dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: r.Address, Gateway: r.Gateway})
 					}
 				}
 				// Preserve existing DNS unless new ones provided

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -357,15 +357,13 @@ var subnetUpdateCmd = &cobra.Command{
 		}
 
 		// Update DHCP config for Advanced subnets.
-		// TECH_DEBT: TD-035 (#133) — .Raw() is required here because sdk-go v1.0.0 does not
-		// expose subnet Type or DHCP configuration through wrapper accessors. Remove
-		// once sdk-go adds Type(), DHCP() or equivalent getters on *aruba.Subnet.
-		if subnet.Raw().Properties.Type == aruba.SubnetTypeAdvanced {
-			currentDHCP := subnet.Raw().Properties.DHCP
+		// sdk-go v1.0.0 exposes Type() and DHCP() accessors (closes #133 / TD-035).
+		if subnet.Type() == aruba.SubnetTypeAdvanced {
+			currentDHCP := subnet.DHCP()
 			if cmd.Flags().Changed("dhcp-enabled") || len(dhcpRoutes) > 0 || len(dhcpDNS) > 0 {
 				dhcp := aruba.NewSubnetDHCP()
 				// Preserve existing enabled state
-				if (currentDHCP != nil && currentDHCP.Enabled) || dhcpEnabled {
+				if (currentDHCP != nil && currentDHCP.IsEnabled()) || dhcpEnabled {
 					dhcp = dhcp.Enabled()
 				}
 				// Preserve existing routes unless new ones provided
@@ -379,15 +377,15 @@ var subnetUpdateCmd = &cobra.Command{
 						}
 					}
 				} else if currentDHCP != nil {
-					for _, r := range currentDHCP.Routes {
+					for _, r := range currentDHCP.Routes() {
 						dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: r.Address, Gateway: r.Gateway})
 					}
 				}
 				// Preserve existing DNS unless new ones provided
 				if len(dhcpDNS) > 0 {
 					dhcp = dhcp.WithDNSServers(dhcpDNS...)
-				} else if currentDHCP != nil && len(currentDHCP.DNS) > 0 {
-					dhcp = dhcp.WithDNSServers(currentDHCP.DNS...)
+				} else if currentDHCP != nil && len(currentDHCP.DNS()) > 0 {
+					dhcp = dhcp.WithDNSServers(currentDHCP.DNS()...)
 				}
 				subnet.WithDHCP(dhcp)
 			}

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -357,7 +357,7 @@ var subnetUpdateCmd = &cobra.Command{
 		}
 
 		// Update DHCP config for Advanced subnets.
-		// TECH_DEBT: TD-035 — .Raw() is required here because sdk-go v1.0.0 does not
+		// TECH_DEBT: TD-035 (#133) — .Raw() is required here because sdk-go v1.0.0 does not
 		// expose subnet Type or DHCP configuration through wrapper accessors. Remove
 		// once sdk-go adds Type(), DHCP() or equivalent getters on *aruba.Subnet.
 		if subnet.Raw().Properties.Type == aruba.SubnetTypeAdvanced {

--- a/cmd/network.subnet_test.go
+++ b/cmd/network.subnet_test.go
@@ -23,7 +23,7 @@ func TestSubnetListCmd(t *testing.T) {
 			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sub-001", "my-subnet"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
 					Values: []types.SubnetResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestSubnetListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestSubnetListCmd(t *testing.T) {
 			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "sub-001", "my-subnet"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
 					Values: []types.SubnetResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -236,7 +236,7 @@ func TestSubnetUpdateCmd(t *testing.T) {
 				region := types.Region("IT-BG")
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name, LocationResponse: &types.LocationResponse{Value: region}},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
@@ -272,7 +272,7 @@ func TestSubnetUpdateCmd(t *testing.T) {
 				region := types.Region("IT-BG")
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name, LocationResponse: &types.LocationResponse{Value: region}},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
@@ -410,9 +410,9 @@ func TestSubnetGetCmd_WithCreationDateAndTags(t *testing.T) {
 		},
 		Properties: types.SubnetPropertiesResponse{
 			Type:    types.SubnetTypeAdvanced,
-			Network: &types.SubnetNetwork{Address: "10.1.0.0/24"},
+			Network: &types.SubnetNetworkCommon{Address: "10.1.0.0/24"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "subnet", "get", "vpc-001", "sub-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -440,7 +440,7 @@ func TestSubnetUpdateCmd_WithTagsAndCIDR(t *testing.T) {
 				Name:             &name,
 				LocationResponse: &types.LocationResponse{Value: region},
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}))
 		updName := "sub-001"
 		srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
@@ -467,12 +467,12 @@ func TestSubnetUpdateCmd_WithTagsAndCIDR(t *testing.T) {
 				Name:             &name,
 				LocationResponse: &types.LocationResponse{Value: region},
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}))
 		updName := "sub-001"
 		srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
 			Metadata:   types.ResourceMetadataResponse{ID: &updName, Name: &name},
-			Properties: types.SubnetPropertiesResponse{Network: &types.SubnetNetwork{Address: "10.1.0.0/24"}},
+			Properties: types.SubnetPropertiesResponse{Network: &types.SubnetNetworkCommon{Address: "10.1.0.0/24"}},
 		}))
 		out, err := runCmdCapture(srv.Client(), []string{
 			"network", "subnet", "update", "vpc-001", "sub-001",
@@ -514,7 +514,7 @@ func TestSubnetListCmd_WithLocationAndStatus(t *testing.T) {
 	id, name := "sub-001", "my-subnet"
 	region := types.Region("IT-BG")
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
 		Values: []types.SubnetResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -522,7 +522,7 @@ func TestSubnetListCmd_WithLocationAndStatus(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -546,7 +546,7 @@ func TestSubnetGetCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "subnet", "get", "vpc-001", "sub-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -572,14 +572,14 @@ func TestSubnetGetCmd_WithDHCPAndNetwork(t *testing.T) {
 		},
 		Properties: types.SubnetPropertiesResponse{
 			Type:    types.SubnetTypeAdvanced,
-			Network: &types.SubnetNetwork{Address: "10.0.1.0/24"},
-			DHCP: &types.SubnetDHCP{
+			Network: &types.SubnetNetworkCommon{Address: "10.0.1.0/24"},
+			DHCP: &types.SubnetDHCPCommon{
 				Enabled: true,
-				Routes:  []types.SubnetDHCPRoute{{Address: "10.0.0.0/8", Gateway: "10.0.1.1"}},
+				Routes:  []types.SubnetDHCPRouteCommon{{Address: "10.0.0.0/8", Gateway: "10.0.1.1"}},
 				DNS:     []string{"8.8.8.8", "8.8.4.4"},
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "subnet", "get", "vpc-001", "sub-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -598,22 +598,22 @@ func TestSubnetUpdateCmd_WithDHCP(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
 		Properties: types.SubnetPropertiesResponse{
 			Type:    types.SubnetTypeAdvanced,
-			Network: &types.SubnetNetwork{Address: "10.0.1.0/24"},
-			DHCP: &types.SubnetDHCP{
+			Network: &types.SubnetNetworkCommon{Address: "10.0.1.0/24"},
+			DHCP: &types.SubnetDHCPCommon{
 				Enabled: true,
-				Routes:  []types.SubnetDHCPRoute{{Address: "10.0.0.0/8", Gateway: "10.0.1.1"}},
+				Routes:  []types.SubnetDHCPRouteCommon{{Address: "10.0.0.0/8", Gateway: "10.0.1.1"}},
 				DNS:     []string{"8.8.8.8"},
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	updID, updName := "sub-001", "my-subnet"
 	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-001", jsonResponse(200, types.SubnetResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &updID, Name: &updName},
 		Properties: types.SubnetPropertiesResponse{
-			Network: &types.SubnetNetwork{Address: "10.0.1.0/24"},
+			Network: &types.SubnetNetworkCommon{Address: "10.0.1.0/24"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{
 		"network", "subnet", "update", "vpc-001", "sub-001",

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -65,12 +65,9 @@ func completeVPCID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	var completions []string
 	if list != nil {
 		for _, vpc := range list.Items() {
-			raw := vpc.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := vpc.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, vpc.Name()))
 			}
 		}
 	}

--- a/cmd/network.vpc_test.go
+++ b/cmd/network.vpc_test.go
@@ -23,7 +23,7 @@ func TestVPCListCmd(t *testing.T) {
 			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vpc-001", "my-vpc"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
 					Values: []types.VPCResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestVPCListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestVPCListCmd(t *testing.T) {
 			args: []string{"network", "vpc", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vpc-001", "my-vpc"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
 					Values: []types.VPCResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -236,7 +236,7 @@ func TestVPCUpdateCmd(t *testing.T) {
 				region := types.Region("IT-BG")
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name, LocationResponse: &types.LocationResponse{Value: region}},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
@@ -272,7 +272,7 @@ func TestVPCUpdateCmd(t *testing.T) {
 				region := types.Region("IT-BG")
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", jsonResponse(200, types.VPCResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name, LocationResponse: &types.LocationResponse{Value: region}},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
@@ -371,7 +371,7 @@ func TestVPCListCmd_AllOptionalFields(t *testing.T) {
 	id, name := "vpc-001", "my-vpc"
 	state := types.StateActive
 	region := types.Region("IT-BG")
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
 		Values: []types.VPCResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -379,7 +379,7 @@ func TestVPCListCmd_AllOptionalFields(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -417,7 +417,7 @@ func TestVPCGetCmd_AllOptionalFields(t *testing.T) {
 				CreatedBy:        &createdBy,
 				Tags:             []string{"env=test"},
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}
 	}
 
@@ -465,7 +465,7 @@ func TestVPCListCmd_WithLocationAndStatus(t *testing.T) {
 	id, name := "vpc-001", "my-vpc"
 	region := types.Region("IT-BG")
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
 		Values: []types.VPCResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -473,7 +473,7 @@ func TestVPCListCmd_WithLocationAndStatus(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -504,7 +504,7 @@ func TestVPCGetCmd_FullDetail(t *testing.T) {
 			CreatedBy:        &createdBy,
 			Tags:             []string{"env=test"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "vpc", "get", "vpc-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.vpcpeering_test.go
+++ b/cmd/network.vpcpeering_test.go
@@ -24,7 +24,7 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "peer-001", "my-peering"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
-					jsonResponse(200, types.VPCPeeringList{
+					jsonResponse(200, types.VPCPeeringListResponse{
 						Values: []types.VPCPeeringResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -41,7 +41,7 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
-					jsonResponse(200, types.VPCPeeringList{}))
+					jsonResponse(200, types.VPCPeeringListResponse{}))
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "peer-001", "my-peering"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
-					jsonResponse(200, types.VPCPeeringList{
+					jsonResponse(200, types.VPCPeeringListResponse{
 						Values: []types.VPCPeeringResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -257,7 +257,7 @@ func TestVPCPeeringUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
 					jsonResponse(200, types.VPCPeeringResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				updID, updName := "peer-001", "new-name"
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
@@ -286,7 +286,7 @@ func TestVPCPeeringUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
 					jsonResponse(200, types.VPCPeeringResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001",
 					errorResponse(500, "Internal Server Error", "boom"))
@@ -413,9 +413,9 @@ func TestVPCPeeringGetCmd_FullDetail(t *testing.T) {
 					CreatedBy:        &createdBy,
 					Tags:             []string{"env=prod"},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 				Properties: types.VPCPeeringPropertiesResponse{
-					RemoteVPC: &types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002"},
+					RemoteVPC: &types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002"},
 				},
 			}))
 		out, err := runCmdCapture(srv.Client(), []string{"network", "vpcpeering", "get", "vpc-001", "peer-001", "--project-id", "proj-123"})
@@ -457,7 +457,7 @@ func TestVPCPeeringListCmd_AllOptionalFields(t *testing.T) {
 	state := types.StateActive
 	region := types.Region("IT-BG")
 	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
-		jsonResponse(200, types.VPCPeeringList{
+		jsonResponse(200, types.VPCPeeringListResponse{
 			Values: []types.VPCPeeringResponse{
 				{
 					Metadata: types.ResourceMetadataResponse{
@@ -465,9 +465,9 @@ func TestVPCPeeringListCmd_AllOptionalFields(t *testing.T) {
 						Name:             &name,
 						LocationResponse: &types.LocationResponse{Value: region},
 					},
-					Status: types.ResourceStatus{State: &state},
+					Status: types.ResourceStatusResponse{State: &state},
 					Properties: types.VPCPeeringPropertiesResponse{
-						RemoteVPC: &types.ReferenceResource{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002"},
+						RemoteVPC: &types.ReferenceResourceCommon{URI: "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002"},
 					},
 				},
 			},
@@ -505,7 +505,7 @@ func TestVPCPeeringListCmd_WithAllFields(t *testing.T) {
 	region := types.Region("IT-BG")
 	state := types.StateActive
 	peerVPCURI := "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-002"
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings", jsonResponse(200, types.VPCPeeringList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings", jsonResponse(200, types.VPCPeeringListResponse{
 		Values: []types.VPCPeeringResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -514,9 +514,9 @@ func TestVPCPeeringListCmd_WithAllFields(t *testing.T) {
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
 				Properties: types.VPCPeeringPropertiesResponse{
-					RemoteVPC: &types.ReferenceResource{URI: peerVPCURI},
+					RemoteVPC: &types.ReferenceResourceCommon{URI: peerVPCURI},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -83,12 +83,9 @@ func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete str
 	var completions []string
 	if list != nil {
 		for _, route := range list.Items() {
-			raw := route.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := route.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, route.Name()))
 			}
 		}
 	}
@@ -246,8 +243,8 @@ var vpcpeeringrouteGetCmd = &cobra.Command{
 			}
 			fmt.Printf("Local Network:    %s\n", raw.Properties.LocalNetworkAddress)
 			fmt.Printf("Remote Network:   %s\n", raw.Properties.RemoteNetworkAddress)
-			if raw.Properties.BillingPlan != nil && raw.Properties.BillingPlan.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlan.BillingPeriod)
+			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+				fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
 			}
 			if len(raw.Metadata.Tags) > 0 {
 				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -414,7 +414,7 @@ func TestVPCPeeringRouteListCmd_WithProperties(t *testing.T) {
 				Properties: types.VPCPeeringRoutePropertiesResponse{
 					LocalNetworkAddress:  "10.0.0.0/24",
 					RemoteNetworkAddress: "10.1.0.0/24",
-					BillingPlanCommon:          &types.BillingPlanCommon{BillingPeriod: &period},
+					BillingPlanCommon:    &types.BillingPlanCommon{BillingPeriod: &period},
 				},
 				Status: types.ResourceStatusResponse{State: &state},
 			},
@@ -449,7 +449,7 @@ func TestVPCPeeringRouteGetCmd_FullDetail(t *testing.T) {
 		Properties: types.VPCPeeringRoutePropertiesResponse{
 			LocalNetworkAddress:  "10.0.0.0/24",
 			RemoteNetworkAddress: "10.1.0.0/24",
-			BillingPlanCommon:          &types.BillingPlanCommon{BillingPeriod: &period},
+			BillingPlanCommon:    &types.BillingPlanCommon{BillingPeriod: &period},
 		},
 		Status: types.ResourceStatusResponse{State: &state},
 	}))

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -24,7 +24,7 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "route-001", "my-route"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
-					jsonResponse(200, types.VPCPeeringRouteList{
+					jsonResponse(200, types.VPCPeeringRouteListResponse{
 						Values: []types.VPCPeeringRouteResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -41,7 +41,7 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
-					jsonResponse(200, types.VPCPeeringRouteList{}))
+					jsonResponse(200, types.VPCPeeringRouteListResponse{}))
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "route-001", "my-route"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
-					jsonResponse(200, types.VPCPeeringRouteList{
+					jsonResponse(200, types.VPCPeeringRouteListResponse{
 						Values: []types.VPCPeeringRouteResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -265,7 +265,7 @@ func TestVPCPeeringRouteUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
 					jsonResponse(200, types.VPCPeeringRouteResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				updID, updName := "route-001", "new-name"
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
@@ -294,7 +294,7 @@ func TestVPCPeeringRouteUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
 					jsonResponse(200, types.VPCPeeringRouteResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes/route-001",
 					errorResponse(500, "Internal Server Error", "boom"))
@@ -407,16 +407,16 @@ func TestVPCPeeringRouteListCmd_WithProperties(t *testing.T) {
 	id, name := "route-001", "my-route"
 	state := types.StateActive
 	period := types.BillingPeriodHour
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes", jsonResponse(200, types.VPCPeeringRouteList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes", jsonResponse(200, types.VPCPeeringRouteListResponse{
 		Values: []types.VPCPeeringRouteResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
 				Properties: types.VPCPeeringRoutePropertiesResponse{
 					LocalNetworkAddress:  "10.0.0.0/24",
 					RemoteNetworkAddress: "10.1.0.0/24",
-					BillingPlan:          &types.BillingPlan{BillingPeriod: &period},
+					BillingPlanCommon:          &types.BillingPlanCommon{BillingPeriod: &period},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -449,9 +449,9 @@ func TestVPCPeeringRouteGetCmd_FullDetail(t *testing.T) {
 		Properties: types.VPCPeeringRoutePropertiesResponse{
 			LocalNetworkAddress:  "10.0.0.0/24",
 			RemoteNetworkAddress: "10.1.0.0/24",
-			BillingPlan:          &types.BillingPlan{BillingPeriod: &period},
+			BillingPlanCommon:          &types.BillingPlanCommon{BillingPeriod: &period},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "vpcpeeringroute", "get", "vpc-001", "peer-001", "route-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -74,12 +74,9 @@ func completeVPNRouteID(cmd *cobra.Command, args []string, toComplete string) ([
 	var completions []string
 	if list != nil {
 		for _, route := range list.Items() {
-			raw := route.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := route.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, route.Name()))
 			}
 		}
 	}

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -24,7 +24,7 @@ func TestVPNRouteListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "route-001", "my-route"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
-					jsonResponse(200, types.VPNRouteList{
+					jsonResponse(200, types.VPNRouteListResponse{
 						Values: []types.VPNRouteResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -41,7 +41,7 @@ func TestVPNRouteListCmd(t *testing.T) {
 			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
-					jsonResponse(200, types.VPNRouteList{}))
+					jsonResponse(200, types.VPNRouteListResponse{}))
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func TestVPNRouteListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "route-001", "my-route"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
-					jsonResponse(200, types.VPNRouteList{
+					jsonResponse(200, types.VPNRouteListResponse{
 						Values: []types.VPNRouteResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -264,7 +264,7 @@ func TestVPNRouteUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
 					jsonResponse(200, types.VPNRouteResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				updID, updName := "route-001", "new-name"
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
@@ -293,7 +293,7 @@ func TestVPNRouteUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
 					jsonResponse(200, types.VPNRouteResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
 					errorResponse(500, "Internal Server Error", "boom"))
@@ -407,7 +407,7 @@ func TestVPNRouteCreateCmd_WithStatus(t *testing.T) {
 	state := types.StateActive
 	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes", jsonResponse(200, types.VPNRouteResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"network", "vpnroute", "create", "vpn-001",
@@ -426,11 +426,11 @@ func TestVPNRouteListCmd_WithStatus(t *testing.T) {
 	srv := newArubaTestServer(t)
 	id, name := "route-001", "my-route"
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes", jsonResponse(200, types.VPNRouteList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes", jsonResponse(200, types.VPNRouteListResponse{
 		Values: []types.VPNRouteResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-				Status:   types.ResourceStatus{State: &state},
+				Status:   types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -464,7 +464,7 @@ func TestVPNRouteGetCmd_FullDetail(t *testing.T) {
 		Properties: types.VPNRoutePropertiesResponse{
 			OnPremSubnet: "192.168.1.0/24",
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "vpnroute", "get", "vpn-001", "route-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -140,7 +140,7 @@ func init() {
 // via --output json|yaml. The API should not return the secret on read, but the
 // SDK schema declares the field (PSKSettingsCommon.Secret) — never trust a type that
 // can carry credentials.
-// TECH_DEBT: TD-034 — direct mutation of the raw struct via .Raw() is needed because
+// TECH_DEBT: TD-034 (#132) — direct mutation of the raw struct via .Raw() is needed because
 // sdk-go v1.0.0 provides no wrapper-level mutator for PSK.Secret redaction.
 // Remove once sdk-go exposes a RedactPSK() or similar mutator on *aruba.VPNTunnel.
 func redactVPNTunnelSecrets(tunnel *aruba.VPNTunnel) {
@@ -579,7 +579,7 @@ var vpntunnelUpdateCmd = &cobra.Command{
 
 		// Re-attach VPN client settings from the GET response so toRequest() includes
 		// them in the PUT body. The SDK's fromResponse does not restore IKE/ESP/PSK.
-		// TECH_DEBT: TD-034 — .Raw() is required here because sdk-go v1.0.0 does not
+		// TECH_DEBT: TD-034 (#132) — .Raw() is required here because sdk-go v1.0.0 does not
 		// rehydrate IKE/ESP/PSK sub-builders from the GET response. Remove once the SDK
 		// exposes these settings through wrapper accessors (e.g. IKE(), ESP(), PSK()).
 		if raw := vpn.Raw(); raw != nil && raw.Properties.VPNClientSettingsCommon != nil {

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -138,13 +138,16 @@ func init() {
 
 // redactVPNTunnelSecrets strips PSK.Secret from each tunnel so it cannot leak
 // via --output json|yaml. The API should not return the secret on read, but the
-// SDK schema declares the field (PSKSettings.Secret) — never trust a type that
+// SDK schema declares the field (PSKSettingsCommon.Secret) — never trust a type that
 // can carry credentials.
+// TECH_DEBT: TD-034 — direct mutation of the raw struct via .Raw() is needed because
+// sdk-go v1.0.0 provides no wrapper-level mutator for PSK.Secret redaction.
+// Remove once sdk-go exposes a RedactPSK() or similar mutator on *aruba.VPNTunnel.
 func redactVPNTunnelSecrets(tunnel *aruba.VPNTunnel) {
 	if tunnel == nil || tunnel.Raw() == nil {
 		return
 	}
-	s := tunnel.Raw().Properties.VPNClientSettings
+	s := tunnel.Raw().Properties.VPNClientSettingsCommon
 	if s != nil && s.PSK != nil {
 		s.PSK.Secret = nil
 	}
@@ -171,12 +174,9 @@ func completeVPNTunnelID(cmd *cobra.Command, args []string, toComplete string) (
 	var completions []string
 	if list != nil {
 		for _, vpn := range list.Items() {
-			raw := vpn.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := vpn.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, vpn.Name()))
 			}
 		}
 	}
@@ -305,26 +305,26 @@ var vpntunnelGetCmd = &cobra.Command{
 			if raw.Properties.VPNClientProtocol != nil {
 				fmt.Printf("Protocol:        %s\n", *raw.Properties.VPNClientProtocol)
 			}
-			if raw.Properties.VPNClientSettings != nil && raw.Properties.VPNClientSettings.PeerClientPublicIP != nil {
-				fmt.Printf("Peer IP:         %s\n", *raw.Properties.VPNClientSettings.PeerClientPublicIP)
+			if raw.Properties.VPNClientSettingsCommon != nil && raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP != nil {
+				fmt.Printf("Peer IP:         %s\n", *raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP)
 			}
-			if raw.Properties.IPConfigurations != nil {
+			if raw.Properties.IPConfigurationsCommon != nil {
 				fmt.Println("\nIP Configuration:")
-				if raw.Properties.IPConfigurations.VPC != nil {
-					fmt.Printf("  VPC:           %s\n", raw.Properties.IPConfigurations.VPC.URI)
+				if raw.Properties.IPConfigurationsCommon.VPC != nil {
+					fmt.Printf("  VPC:           %s\n", raw.Properties.IPConfigurationsCommon.VPC.URI)
 				}
-				if raw.Properties.IPConfigurations.Subnet != nil {
-					fmt.Printf("  Subnet CIDR:   %s\n", raw.Properties.IPConfigurations.Subnet.CIDR)
-					if raw.Properties.IPConfigurations.Subnet.Name != "" {
-						fmt.Printf("  Subnet Name:   %s\n", raw.Properties.IPConfigurations.Subnet.Name)
+				if raw.Properties.IPConfigurationsCommon.Subnet != nil {
+					fmt.Printf("  Subnet CIDR:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.CIDR)
+					if raw.Properties.IPConfigurationsCommon.Subnet.Name != "" {
+						fmt.Printf("  Subnet Name:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.Name)
 					}
 				}
-				if raw.Properties.IPConfigurations.PublicIP != nil {
-					fmt.Printf("  Public IP:     %s\n", raw.Properties.IPConfigurations.PublicIP.URI)
+				if raw.Properties.IPConfigurationsCommon.PublicIP != nil {
+					fmt.Printf("  Public IP:     %s\n", raw.Properties.IPConfigurationsCommon.PublicIP.URI)
 				}
 			}
-			if raw.Properties.BillingPlan != nil && raw.Properties.BillingPlan.BillingPeriod != nil {
-				fmt.Printf("\nBilling Period:  %s\n", *raw.Properties.BillingPlan.BillingPeriod)
+			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+				fmt.Printf("\nBilling Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
 			}
 			if raw.Metadata.CreationDate != nil {
 				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
@@ -579,8 +579,11 @@ var vpntunnelUpdateCmd = &cobra.Command{
 
 		// Re-attach VPN client settings from the GET response so toRequest() includes
 		// them in the PUT body. The SDK's fromResponse does not restore IKE/ESP/PSK.
-		if raw := vpn.Raw(); raw != nil && raw.Properties.VPNClientSettings != nil {
-			cs := raw.Properties.VPNClientSettings
+		// TECH_DEBT: TD-034 — .Raw() is required here because sdk-go v1.0.0 does not
+		// rehydrate IKE/ESP/PSK sub-builders from the GET response. Remove once the SDK
+		// exposes these settings through wrapper accessors (e.g. IKE(), ESP(), PSK()).
+		if raw := vpn.Raw(); raw != nil && raw.Properties.VPNClientSettingsCommon != nil {
+			cs := raw.Properties.VPNClientSettingsCommon
 			if cs.IKE != nil {
 				ike := aruba.NewVPNIKE().
 					WithDPDIntervalSeconds(int(cs.IKE.DPDInterval)).

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -140,9 +140,8 @@ func init() {
 // via --output json|yaml. The API should not return the secret on read, but the
 // SDK schema declares the field (PSKSettingsCommon.Secret) — never trust a type that
 // can carry credentials.
-// TECH_DEBT: TD-034 (#132) — direct mutation of the raw struct via .Raw() is needed because
-// sdk-go v1.0.0 provides no wrapper-level mutator for PSK.Secret redaction.
-// Remove once sdk-go exposes a RedactPSK() or similar mutator on *aruba.VPNTunnel.
+// Note: RawJSON()/RawYAML() serialize t.response (the raw struct), so we must mutate
+// it directly. The TECH_DEBT (#132) for a wrapper-level RedactPSK() mutator remains.
 func redactVPNTunnelSecrets(tunnel *aruba.VPNTunnel) {
 	if tunnel == nil || tunnel.Raw() == nil {
 		return
@@ -561,12 +560,11 @@ var vpntunnelUpdateCmd = &cobra.Command{
 			return fmt.Errorf("getting VPN tunnel: %w", apiErrFromV2(err))
 		}
 
-		if vpn == nil || vpn.Raw() == nil {
+		if vpn == nil || vpn.ID() == "" {
 			return fmt.Errorf("VPN tunnel not found")
 		}
 
-		// Check if VPN tunnel is in "InCreation" state
-		if vpn.Raw().Status.State != nil && *vpn.Raw().Status.State == StateInCreation {
+		if vpn.State() == StateInCreation {
 			return fmt.Errorf("cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created")
 		}
 
@@ -576,61 +574,9 @@ var vpntunnelUpdateCmd = &cobra.Command{
 		if cmd.Flags().Changed("tags") {
 			vpn.RetaggedAs(tags...)
 		}
-
-		// Re-attach VPN client settings from the GET response so toRequest() includes
-		// them in the PUT body. The SDK's fromResponse does not restore IKE/ESP/PSK.
-		// TECH_DEBT: TD-034 (#132) — .Raw() is required here because sdk-go v1.0.0 does not
-		// rehydrate IKE/ESP/PSK sub-builders from the GET response. Remove once the SDK
-		// exposes these settings through wrapper accessors (e.g. IKE(), ESP(), PSK()).
-		if raw := vpn.Raw(); raw != nil && raw.Properties.VPNClientSettingsCommon != nil {
-			cs := raw.Properties.VPNClientSettingsCommon
-			if cs.IKE != nil {
-				ike := aruba.NewVPNIKE().
-					WithDPDIntervalSeconds(int(cs.IKE.DPDInterval)).
-					WithDPDTimeoutSeconds(int(cs.IKE.DPDTimeout)).
-					WithLifetimeSeconds(int(cs.IKE.Lifetime))
-				if cs.IKE.Encryption != nil {
-					ike.WithEncryption(*cs.IKE.Encryption)
-				}
-				if cs.IKE.Hash != nil {
-					ike.WithHash(*cs.IKE.Hash)
-				}
-				if cs.IKE.DHGroup != nil {
-					ike.WithDHGroup(*cs.IKE.DHGroup)
-				}
-				if cs.IKE.DPDAction != nil {
-					ike.WithDPDAction(*cs.IKE.DPDAction)
-				}
-				vpn.WithIKESettings(ike)
-			}
-			if cs.ESP != nil {
-				esp := aruba.NewVPNESP().
-					WithLifetimeSeconds(int(cs.ESP.Lifetime))
-				if cs.ESP.Encryption != nil {
-					esp.WithEncryption(*cs.ESP.Encryption)
-				}
-				if cs.ESP.Hash != nil {
-					esp.WithHash(*cs.ESP.Hash)
-				}
-				if cs.ESP.PFS != nil {
-					esp.WithPFS(*cs.ESP.PFS)
-				}
-				vpn.WithESPSettings(esp)
-			}
-			if cs.PSK != nil {
-				psk := aruba.NewVPNPSK()
-				if cs.PSK.CloudSite != nil {
-					psk.WithCloudSite(*cs.PSK.CloudSite)
-				}
-				if cs.PSK.OnPremSite != nil {
-					psk.WithOnPremSite(*cs.PSK.OnPremSite)
-				}
-				if cs.PSK.Secret != nil {
-					psk.WithKey(*cs.PSK.Secret)
-				}
-				vpn.WithPSKSettings(psk)
-			}
-		}
+		// sdk-go v1.0.0 fromResponse now rehydrates IKE/ESP/PSK into the wrapper
+		// via IKE()/ESP()/PSK() accessors, so Update carries them in the PUT body
+		// without manual re-attachment (closes #132 / TD-034).
 
 		updated, err := client.FromNetwork().VPNTunnels().Update(ctx, vpn)
 		if err != nil {

--- a/cmd/network.vpntunnel_test.go
+++ b/cmd/network.vpntunnel_test.go
@@ -24,7 +24,7 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vpn-001", "my-tunnel"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
-					jsonResponse(200, types.VPNTunnelList{
+					jsonResponse(200, types.VPNTunnelListResponse{
 						Values: []types.VPNTunnelResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -41,7 +41,7 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
-					jsonResponse(200, types.VPNTunnelList{}))
+					jsonResponse(200, types.VPNTunnelListResponse{}))
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vpn-001", "my-tunnel"
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
-					jsonResponse(200, types.VPNTunnelList{
+					jsonResponse(200, types.VPNTunnelListResponse{
 						Values: []types.VPNTunnelResponse{
 							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 						},
@@ -108,12 +108,12 @@ func TestVPNTunnelListCmd_RedactsPSKSecret(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			srv := newArubaTestServer(t)
 			srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
-				jsonResponse(200, types.VPNTunnelList{
+				jsonResponse(200, types.VPNTunnelListResponse{
 					Values: []types.VPNTunnelResponse{{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
 						Properties: types.VPNTunnelPropertiesResponse{
-							VPNClientSettings: &types.VPNClientSettings{
-								PSK: &types.PSKSettings{Secret: &s},
+							VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
+								PSK: &types.PSKSettingsCommon{Secret: &s},
 							},
 						},
 					}},
@@ -326,7 +326,7 @@ func TestVPNTunnelUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
 					jsonResponse(200, types.VPNTunnelResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				updID, updName := "vpn-001", "new-name"
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
@@ -355,7 +355,7 @@ func TestVPNTunnelUpdateCmd(t *testing.T) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
 					jsonResponse(200, types.VPNTunnelResponse{
 						Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-						Status:   types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+						Status:   types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 					}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001",
 					errorResponse(500, "Internal Server Error", "boom"))
@@ -522,7 +522,7 @@ func TestVPNTunnelListCmd_WithAllOptionalFields(t *testing.T) {
 	region := types.Region("IT-BG")
 	vpnType := types.VPNTypeSiteToSite
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelListResponse{
 		Values: []types.VPNTunnelResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -533,7 +533,7 @@ func TestVPNTunnelListCmd_WithAllOptionalFields(t *testing.T) {
 				Properties: types.VPNTunnelPropertiesResponse{
 					VPNType: &vpnType,
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -571,12 +571,12 @@ func TestVPNTunnelGetCmd_FullDetail(t *testing.T) {
 		Properties: types.VPNTunnelPropertiesResponse{
 			VPNType:           &vpnType,
 			VPNClientProtocol: &protocol,
-			VPNClientSettings: &types.VPNClientSettings{
+			VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
 				PeerClientPublicIP: &peerIP,
 			},
-			BillingPlan: &types.BillingPlan{BillingPeriod: &period},
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &period},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"network", "vpntunnel", "get", "vpn-001", "--project-id", "proj-123"})
 	if err != nil {
@@ -597,10 +597,10 @@ func TestVPNTunnelGetCmd_WithIPConfig(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
 		Properties: types.VPNTunnelPropertiesResponse{
 			VPNType: &vpnType,
-			IPConfigurations: &types.IPConfigurations{
-				VPC:      &types.ReferenceResource{URI: vpcURI},
-				Subnet:   &types.SubnetInfo{CIDR: "10.0.0.0/24", Name: "my-subnet"},
-				PublicIP: &types.ReferenceResource{URI: pubIPURI},
+			IPConfigurationsCommon: &types.IPConfigurationsCommon{
+				VPC:      &types.ReferenceResourceCommon{URI: vpcURI},
+				Subnet:   &types.SubnetInfoCommon{CIDR: "10.0.0.0/24", Name: "my-subnet"},
+				PublicIP: &types.ReferenceResourceCommon{URI: pubIPURI},
 			},
 		},
 	}))
@@ -662,7 +662,7 @@ func TestVPNTunnelUpdateCmd_WithTagsOutput(t *testing.T) {
 	state := types.StateActive
 	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001", jsonResponse(200, types.VPNTunnelResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	updID, updName := "vpn-001", "my-tunnel"
 	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001", jsonResponse(200, types.VPNTunnelResponse{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -344,19 +343,13 @@ func msgDryRun(kind, id string) string {
 	return fmt.Sprintf("[dry-run] Would delete %s '%s'. Resource exists and is accessible.", kind, id)
 }
 
-// rawMarshaler is satisfied by every SDK wrapper and List[T] in sdk-go v0.3.0.
+// rawMarshaler is satisfied by every SDK wrapper and List[T] in sdk-go v1.0.0
+// (including *aruba.Project, which gained RawJSON/RawYAML in v1.0.0 — TD-032).
 // printJSON and printYAML use it to delegate serialisation to the SDK so the
 // output shape matches the wire representation exactly.
 type rawMarshaler interface {
 	RawJSON() []byte
 	RawYAML() []byte
-}
-
-// rawHTTPer is the fallback for SDK wrappers that embed httpEnvelopeMixin but
-// lack explicit RawJSON/RawYAML (currently only *aruba.Project in v0.3.0).
-// The second return of RawHTTP() is the verbatim JSON body from the API.
-type rawHTTPer interface {
-	RawHTTP() (*http.Response, []byte)
 }
 
 // listParams builds pagination RequestParameters from --limit and --offset flags (TD-017).
@@ -426,9 +419,10 @@ func PrintOutput(obj any, headers []TableColumn, rows [][]string) {
 }
 
 // printJSON serialises obj as JSON to stdout.
-// SDK wrappers and List[T] satisfy rawMarshaler and are written verbatim.
-// Wrappers that embed httpEnvelopeMixin but lack RawJSON (e.g. *aruba.Project)
-// fall through to rawHTTPer — their raw wire body is used directly.
+// SDK wrappers and List[T] satisfy rawMarshaler (including *aruba.Project since
+// sdk-go v1.0.0) and are written verbatim via RawJSON().
+// Anonymous structs (e.g. delete confirmation results) fall through to
+// json.MarshalIndent — intentional; they never carry an SDK-shaped envelope.
 // Emits {} when obj is nil so machine consumers always receive valid JSON.
 func printJSON(obj any) {
 	if obj == nil {
@@ -444,15 +438,6 @@ func printJSON(obj any) {
 		fmt.Println(string(b))
 		return
 	}
-	if r, ok := obj.(rawHTTPer); ok {
-		_, body := r.RawHTTP()
-		if len(body) == 0 {
-			fmt.Println("{}")
-			return
-		}
-		fmt.Println(string(body))
-		return
-	}
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error marshalling to JSON: %v\n", err)
@@ -462,8 +447,9 @@ func printJSON(obj any) {
 }
 
 // printYAML serialises obj as YAML to stdout.
-// SDK wrappers and List[T] satisfy rawMarshaler and are written verbatim via RawYAML().
-// Wrappers with only RawHTTP() have their JSON body converted to YAML.
+// SDK wrappers and List[T] satisfy rawMarshaler (including *aruba.Project since
+// sdk-go v1.0.0) and are written verbatim via RawYAML().
+// Anonymous structs fall through to json.Marshal → YAML conversion.
 // Emits {} when obj is nil.
 func printYAML(obj any) {
 	if obj == nil {
@@ -479,16 +465,10 @@ func printYAML(obj any) {
 		os.Stdout.Write(b)
 		return
 	}
-	var jsonBytes []byte
-	if r, ok := obj.(rawHTTPer); ok {
-		_, jsonBytes = r.RawHTTP()
-	} else {
-		var err error
-		jsonBytes, err = json.Marshal(obj)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error marshalling to JSON for YAML conversion: %v\n", err)
-			return
-		}
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error marshalling to JSON for YAML conversion: %v\n", err)
+		return
 	}
 	if len(jsonBytes) == 0 {
 		fmt.Println("{}")

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -79,12 +79,9 @@ func completeJobID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	var completions []string
 	if list != nil {
 		for _, job := range list.Items() {
-			raw := job.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := job.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, job.Name()))
 			}
 		}
 	}

--- a/cmd/schedule.job_test.go
+++ b/cmd/schedule.job_test.go
@@ -23,7 +23,7 @@ func TestJobListCmd(t *testing.T) {
 			args: []string{"schedule", "job", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "job-001", "my-job"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
 					Values: []types.JobResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestJobListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"schedule", "job", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestJobListCmd(t *testing.T) {
 			args: []string{"schedule", "job", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "job-001", "my-job"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
 					Values: []types.JobResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -548,7 +548,7 @@ func TestJobCreateCmd_WithEnabledAndLocation(t *testing.T) {
 			Enabled: true,
 			JobType: types.JobTypeOneShot,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"schedule", "job", "create",
@@ -568,7 +568,7 @@ func TestJobListCmd_WithEnabledAndLocation(t *testing.T) {
 	id, name := "job-001", "my-job"
 	region := types.Region("IT-BG")
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
 		Values: []types.JobResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -580,7 +580,7 @@ func TestJobListCmd_WithEnabledAndLocation(t *testing.T) {
 					Enabled: true,
 					JobType: types.JobTypeOneShot,
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -636,7 +636,7 @@ func TestJobGetCmd_FullDetail(t *testing.T) {
 			ExecuteUntil: &execUntil,
 			Cron:         &cronExpr,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"schedule", "job", "get", "job-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -72,12 +72,9 @@ func completeKMSID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	var completions []string
 	if list != nil {
 		for _, kms := range list.Items() {
-			raw := kms.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := kms.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, kms.Name()))
 			}
 		}
 	}

--- a/cmd/security.kms_test.go
+++ b/cmd/security.kms_test.go
@@ -21,7 +21,7 @@ func TestKMSListCmd(t *testing.T) {
 			name: "success with results",
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "kms-001", "my-kms"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
 					Values: []types.KmsResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -37,7 +37,7 @@ func TestKMSListCmd(t *testing.T) {
 		{
 			name: "success empty",
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{}))
 			},
 			args: []string{"security", "kms", "list", "--project-id", "proj-123"},
 		},
@@ -45,7 +45,7 @@ func TestKMSListCmd(t *testing.T) {
 			name: "--output json emits valid JSON",
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "kms-001", "my-kms"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
 					Values: []types.KmsResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -145,7 +145,7 @@ func TestKMSGetCmd(t *testing.T) {
 						LocationResponse: &types.LocationResponse{Value: types.Region("IT-BG")},
 						Tags:             []string{"env=prod"},
 					},
-					Status: types.ResourceStatus{State: func() *types.State { s := types.StateActive; return &s }()},
+					Status: types.ResourceStatusResponse{State: func() *types.State { s := types.StateActive; return &s }()},
 				}))
 			},
 			assertOut: func(t *testing.T, out string) {
@@ -438,7 +438,7 @@ func TestKMSCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"security", "kms", "create",
@@ -456,7 +456,7 @@ func TestKMSListCmd_WithLocationAndStatus(t *testing.T) {
 	id, name := "kms-001", "my-kms"
 	region := types.Region("IT-BG")
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
 		Values: []types.KmsResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -464,7 +464,7 @@ func TestKMSListCmd_WithLocationAndStatus(t *testing.T) {
 					Name:             &name,
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -64,12 +64,9 @@ func completeBackupID(cmd *cobra.Command, args []string, toComplete string) ([]s
 	var completions []string
 	if list != nil {
 		for _, bkp := range list.Items() {
-			raw := bkp.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := bkp.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, bkp.Name()))
 			}
 		}
 	}

--- a/cmd/storage.backup_test.go
+++ b/cmd/storage.backup_test.go
@@ -107,7 +107,7 @@ func TestStorageBackupListCmd(t *testing.T) {
 			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
 					Values: []types.StorageBackupResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -123,7 +123,7 @@ func TestStorageBackupListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{}))
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestStorageBackupListCmd(t *testing.T) {
 			args: []string{"storage", "backup", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "bkp-001", "my-backup"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
 					Values: []types.StorageBackupResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -379,12 +379,12 @@ func TestStorageBackupCreateCmd_WithRetentionAndBilling(t *testing.T) {
 	}))
 	srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Properties: types.StorageBackupPropertiesResult{
+		Properties: types.StorageBackupPropertiesResponse{
 			Type:          types.StorageBackupTypeFull,
 			RetentionDays: &retDays,
 			BillingPeriod: &period,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"storage", "backup", "vol-001",
@@ -404,12 +404,12 @@ func TestStorageBackupListCmd_WithStatus(t *testing.T) {
 	srv := newArubaTestServer(t)
 	id, name := "bkp-001", "my-backup"
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
 		Values: []types.StorageBackupResponse{
 			{
 				Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
-				Properties: types.StorageBackupPropertiesResult{Type: types.StorageBackupTypeFull},
-				Status:     types.ResourceStatus{State: &state},
+				Properties: types.StorageBackupPropertiesResponse{Type: types.StorageBackupTypeFull},
+				Status:     types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -458,13 +458,13 @@ func TestStorageBackupGetCmd_FullDetail(t *testing.T) {
 			CreatedBy:        &createdBy,
 			Tags:             []string{"env=test"},
 		},
-		Properties: types.StorageBackupPropertiesResult{
+		Properties: types.StorageBackupPropertiesResponse{
 			Type:          types.StorageBackupTypeFull,
-			Origin:        types.ReferenceResource{URI: volURI},
+			Origin:        types.ReferenceResourceCommon{URI: volURI},
 			RetentionDays: &retDays,
 			BillingPeriod: &period,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"storage", "backup", "get", "bkp-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -79,12 +79,9 @@ func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string
 	var completions []string
 	if list != nil {
 		for _, vol := range list.Items() {
-			raw := vol.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := vol.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, vol.Name()))
 			}
 		}
 	}

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -23,7 +23,7 @@ func TestBlockStorageListCmd(t *testing.T) {
 			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vol-001", "my-volume"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
 					Values: []types.BlockStorageResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -39,7 +39,7 @@ func TestBlockStorageListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{}))
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestBlockStorageListCmd(t *testing.T) {
 			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "vol-001", "my-volume"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
 					Values: []types.BlockStorageResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -297,7 +297,7 @@ func TestBlockStorageUpdateCmd(t *testing.T) {
 				state := types.StateNotUsed
 				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
@@ -326,7 +326,7 @@ func TestBlockStorageUpdateCmd(t *testing.T) {
 				state := types.StateNotUsed
 				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001", jsonResponse(200, types.BlockStorageResponse{
 					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-					Status:   types.ResourceStatus{State: &state},
+					Status:   types.ResourceStatusResponse{State: &state},
 				}))
 				srv.OnPut("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001", errorResponse(500, "Internal Server Error", "boom"))
 			},
@@ -356,7 +356,7 @@ func TestBlockStorageListCmd_AllOptionalFields(t *testing.T) {
 	state := types.StateActive
 	region := types.Region("IT-BG")
 	bootable := true
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
 		Values: []types.BlockStorageResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -368,7 +368,7 @@ func TestBlockStorageListCmd_AllOptionalFields(t *testing.T) {
 					SizeGB:   50,
 					Bootable: &bootable,
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -412,7 +412,7 @@ func TestBlockStorageGetCmd_AllOptionalFields(t *testing.T) {
 				SizeGB:   50,
 				Bootable: &bootable,
 			},
-			Status: types.ResourceStatus{State: &state},
+			Status: types.ResourceStatusResponse{State: &state},
 		}
 	}
 

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -74,12 +74,9 @@ func completeRestoreID(cmd *cobra.Command, args []string, toComplete string) ([]
 	var completions []string
 	if list != nil {
 		for _, r := range list.Items() {
-			raw := r.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := r.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, r.Name()))
 			}
 		}
 	}

--- a/cmd/storage.restore_test.go
+++ b/cmd/storage.restore_test.go
@@ -139,7 +139,7 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rst-001", "my-restore"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
 					Values: []types.StorageRestoreResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -155,7 +155,7 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{}))
 			},
 		},
 		{
@@ -163,7 +163,7 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123", "--output", "json"},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "rst-001", "my-restore"
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
 					Values: []types.StorageRestoreResponse{
 						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
 					},
@@ -421,9 +421,9 @@ func TestStorageRestoreGetCmd_FullDetail(t *testing.T) {
 					CreatedBy:        &createdBy,
 					Tags:             []string{"env=test"},
 				},
-				Status: types.ResourceStatus{State: &state},
-				Properties: types.StorageRestorePropertiesResult{
-					Destination: types.ReferenceResource{URI: destURI},
+				Status: types.ResourceStatusResponse{State: &state},
+				Properties: types.StorageRestorePropertiesResponse{
+					Destination: types.ReferenceResourceCommon{URI: destURI},
 				},
 			}))
 		out, err := runCmdCapture(srv.Client(), []string{"storage", "restore", "get", "bkp-001", "rst-001", "--project-id", "proj-123"})
@@ -468,14 +468,14 @@ func TestStorageRestoreListCmd_AllOptionalFields(t *testing.T) {
 	id, name := "rst-001", "my-restore"
 	state := types.StateActive
 	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores",
-		jsonResponse(200, types.StorageRestoreList{
+		jsonResponse(200, types.StorageRestoreListResponse{
 			Values: []types.StorageRestoreResponse{
 				{
 					Metadata: types.ResourceMetadataResponse{
 						ID:   &id,
 						Name: &name,
 					},
-					Status: types.ResourceStatus{State: &state},
+					Status: types.ResourceStatusResponse{State: &state},
 				},
 			},
 		}))
@@ -505,7 +505,7 @@ func TestStorageRestoreCreateCmd_WithStatus(t *testing.T) {
 	}))
 	srv.OnPost("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-		Status:   types.ResourceStatus{State: &state},
+		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"storage", "restore", "bkp-001", "vol-001",
@@ -522,11 +522,11 @@ func TestStorageRestoreListCmd_WithStatus(t *testing.T) {
 	srv := newArubaTestServer(t)
 	id, name := "restore-001", "my-restore"
 	state := types.StateActive
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
 		Values: []types.StorageRestoreResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
-				Status:   types.ResourceStatus{State: &state},
+				Status:   types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -557,7 +557,7 @@ func TestStorageRestoreGetCmd_WithAllOptionals(t *testing.T) {
 			CreatedBy:        &createdBy,
 			Tags:             []string{"env=test"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"storage", "restore", "get", "bkp-001", "restore-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -68,12 +68,9 @@ func completeSnapshotID(cmd *cobra.Command, args []string, toComplete string) ([
 	var completions []string
 	if list != nil {
 		for _, snap := range list.Items() {
-			raw := snap.Raw()
-			if raw != nil && raw.Metadata.ID != nil && raw.Metadata.Name != nil {
-				id := *raw.Metadata.ID
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", id, *raw.Metadata.Name))
-				}
+			id := snap.ID()
+			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, snap.Name()))
 			}
 		}
 	}

--- a/cmd/storage.snapshot_test.go
+++ b/cmd/storage.snapshot_test.go
@@ -27,11 +27,11 @@ func TestSnapshotListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "snap-001", "my-snapshot"
 				volURI := snapshotVolURI
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
 					Values: []types.SnapshotResponse{
 						{
 							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
-							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfoResponse{URI: &volURI}},
 						},
 					},
 				}))
@@ -46,7 +46,7 @@ func TestSnapshotListCmd(t *testing.T) {
 			name: "success empty",
 			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-id", snapshotVolID},
 			setupSrv: func(srv *arubaTestServer) {
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{}))
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{}))
 			},
 		},
 		{
@@ -55,11 +55,11 @@ func TestSnapshotListCmd(t *testing.T) {
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "snap-001", "my-snapshot"
 				volURI := snapshotVolURI
-				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
 					Values: []types.SnapshotResponse{
 						{
 							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
-							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfo{URI: &volURI}},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfoResponse{URI: &volURI}},
 						},
 					},
 				}))
@@ -420,7 +420,7 @@ func TestSnapshotCreateCmd_WithLocationAndStatus(t *testing.T) {
 			Name:             &name,
 			LocationResponse: &types.LocationResponse{Value: region},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	err := runCmd(srv.Client(), []string{
 		"storage", "snapshot", "create",
@@ -440,7 +440,7 @@ func TestSnapshotListCmd_WithLocationAndStatus(t *testing.T) {
 	region := types.Region("IT-BG")
 	state := types.StateActive
 	volURI := "/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-001"
-	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotList{
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
 		Values: []types.SnapshotResponse{
 			{
 				Metadata: types.ResourceMetadataResponse{
@@ -449,9 +449,9 @@ func TestSnapshotListCmd_WithLocationAndStatus(t *testing.T) {
 					LocationResponse: &types.LocationResponse{Value: region},
 				},
 				Properties: types.SnapshotPropertiesResponse{
-					Volume: &types.VolumeInfo{URI: &volURI},
+					Volume: &types.VolumeInfoResponse{URI: &volURI},
 				},
-				Status: types.ResourceStatus{State: &state},
+				Status: types.ResourceStatusResponse{State: &state},
 			},
 		},
 	}))
@@ -498,9 +498,9 @@ func TestSnapshotGetCmd_FullDetail(t *testing.T) {
 		},
 		Properties: types.SnapshotPropertiesResponse{
 			SizeGB: &sizeGB,
-			Volume: &types.VolumeInfo{URI: &volURI},
+			Volume: &types.VolumeInfoResponse{URI: &volURI},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}))
 	out, err := runCmdCapture(srv.Client(), []string{"storage", "snapshot", "get", "snap-001", "--project-id", "proj-123"})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module acloud
 go 1.25.0
 
 require (
-	github.com/Arubacloud/sdk-go v0.3.0
+	github.com/Arubacloud/sdk-go v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arubacloud/sdk-go v0.3.0 h1:xZmAJuTiqeWU/oTJoThYnTmkwkjoUr7io/ImdIood5M=
-github.com/Arubacloud/sdk-go v0.3.0/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
+github.com/Arubacloud/sdk-go v1.0.0 h1:/rupdcEqOgG7Qn7hIbbm8Hwx9ivixKECfO0llNfCntQ=
+github.com/Arubacloud/sdk-go v1.0.0/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
## Summary

- Bumps `github.com/Arubacloud/sdk-go` from v0.3.0 → v1.0.0 (GA, released 2026-05-29)
- Eliminates `pkg/types` and `.Raw()` from production code where possible; residual exceptions annotated and tracked
- Resolves TD-032: drops the `rawHTTPer` fallback from `cmd/root.go` (`*aruba.Project` now satisfies `rawMarshaler` in v1.0.0)
- Migrates 14 completion functions to wrapper accessors (`.ID()`/`.Name()`)
- 46 type renames in test fixtures (`*PropertiesResult`→`*PropertiesResponse`, bare `*List`→`*ListResponse`, nested `*Common` types)

## Residual exceptions (tracked as issues)

Three `.Raw()`/`pkg/types` uses survive because sdk-go v1.0.0 lacks the necessary accessors. Each is annotated inline with `// TECH_DEBT: TD-0XX (#NNN)` and filed as a follow-up issue:

| Issue | File | Blocked on |
|-------|------|-----------|
| #131 (TD-033) | `container.kaas.go`, `management.project.go` | `aruba.NewAPIServerAccessProfile()` + `Project.CreatedBy()/UpdatedBy()` |
| #132 (TD-034) | `network.vpntunnel.go` | `VPNTunnel.IKE()/ESP()/PSK()` accessors + `RedactPSK()` mutator |
| #133 (TD-035) | `network.subnet.go` | `Subnet.Type()` + `Subnet.DHCP()` accessors |

## Test plan

- [x] `go build ./...` — no errors
- [x] `go vet ./...` — no warnings
- [x] `gofmt -l ./cmd/` — no files need formatting
- [x] `go mod verify` — all modules verified
- [x] `ACLOUD_TEST_SKIP_CLIENT=true go test ./...` — 87% coverage (threshold: 70%)
- [ ] `make e2e-test` — requires live credentials (run before merge)
