### PR TITLE
refactor: extract anonymous RunE functions to named functions across …

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%   # allow up to 1% drop before failing
+    patch:
+      default:
+        target: 75%     # realistic target for refactoring patches
+        threshold: 1%

--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -153,599 +153,617 @@ Billing period: Hour (default), Month, or Year.`,
     --subnet-id <subnet-id> \
     --security-group-id <sg-id>`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID, _ := cmd.Flags().GetString("vpc-id")
-		subnetIDs, _ := cmd.Flags().GetStringSlice("subnet-id")
-		sgIDs, _ := cmd.Flags().GetStringSlice("security-group-id")
-		elasticIPID, _ := cmd.Flags().GetString("elasticip-id")
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		zone, _ := cmd.Flags().GetString("zone")
-		flavor, _ := cmd.Flags().GetString("flavor")
-		bootDiskID, _ := cmd.Flags().GetString("boot-disk-id")
-		keypairID, _ := cmd.Flags().GetString("keypair-id")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		userDataFile, _ := cmd.Flags().GetString("user-data-file")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		subnetRefs := make([]aruba.Ref, len(subnetIDs))
-		for i, s := range subnetIDs {
-			subnetRefs[i] = aruba.SubnetRef(projectID, vpcID, s)
-		}
-		sgRefs := make([]aruba.Ref, len(sgIDs))
-		for i, sg := range sgIDs {
-			sgRefs[i] = aruba.SecurityGroupRef(projectID, vpcID, sg)
-		}
-		server := aruba.NewCloudServer().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			InZone(aruba.Zone(zone)).
-			OfFlavor(aruba.CloudServerFlavor(flavor)).
-			BootingFrom(volumeRef(projectID, bootDiskID)).
-			WithVPC(aruba.VPCRef(projectID, vpcID)).
-			OnSubnets(subnetRefs...).
-			WithSecurityGroups(sgRefs...).
-			RetaggedAs(tags...).
-			BilledBy(aruba.BillingPeriod(billingPeriod))
-
-		if elasticIPID != "" {
-			server.WithElasticIP(aruba.ElasticIPRef(projectID, elasticIPID))
-		}
-		if keypairID != "" {
-			server.UsingKeyPair(keypairRef(projectID, keypairID))
-		}
-		if userDataFile != "" {
-			fileContent, err := os.ReadFile(userDataFile)
-			if err != nil {
-				return fmt.Errorf("reading user-data file: %w", err)
-			}
-			userDataBase64 := base64.StdEncoding.EncodeToString(fileContent)
-			server.WithUserData(userDataBase64)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		resp, err := client.FromCompute().CloudServers().Create(ctx, server)
-		if err != nil {
-			return fmt.Errorf("creating cloud server: %w", apiErrFromV2(err))
-		}
-
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "FLAVOR", Width: 20},
-				{Header: "CPU", Width: 10},
-				{Header: "RAM(GB)", Width: 15},
-				{Header: "HD(GB)", Width: 15},
-				{Header: "REGION", Width: 20},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			flavorName := raw.Properties.Flavor.Name
-			cpu := raw.Properties.Flavor.CPU
-			ram := raw.Properties.Flavor.RAM
-			hd := raw.Properties.Flavor.HD
-			regionValue := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionValue = string(raw.Metadata.LocationResponse.Value)
-			}
-			row := []string{
-				id,
-				nameVal,
-				string(flavorName),
-				fmt.Sprintf("%d", cpu),
-				fmt.Sprintf("%d", ram),
-				fmt.Sprintf("%d", hd),
-				regionValue,
-			}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("Cloud server", name))
-		}
-		return nil
-	},
+	RunE: runCloudServerCreate,
 }
 
 var cloudserverGetCmd = &cobra.Command{
 	Use:   "get [cloudserver-id]",
 	Short: "Get cloud server details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
-		}
-
-		if server != nil && server.Raw() != nil {
-			raw := server.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(server, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nCloud Server Details:")
-			fmt.Println("====================")
-
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-
-			if raw.Properties.Flavor.Name != "" {
-				fmt.Printf("Flavor:          %s\n", raw.Properties.Flavor.Name)
-			}
-			fmt.Printf("CPU:             %d\n", raw.Properties.Flavor.CPU)
-			fmt.Printf("RAM:             %d GB\n", raw.Properties.Flavor.RAM)
-			fmt.Printf("HD:              %d GB\n", raw.Properties.Flavor.HD)
-
-			if raw.Properties.BootVolume.URI != "" {
-				fmt.Printf("Boot Volume URI: %s\n", raw.Properties.BootVolume.URI)
-			}
-
-			if raw.Properties.KeyPair.URI != "" {
-				fmt.Printf("Keypair URI:     %s\n", raw.Properties.KeyPair.URI)
-			}
-
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-
-			verbose, _ := cmd.Flags().GetBool("verbose")
-			if verbose {
-				jsonData, _ := json.MarshalIndent(raw, "", "  ")
-				fmt.Println("\nFull JSON Response:")
-				fmt.Println("==================")
-				fmt.Println(string(jsonData))
-			}
-		} else {
-			fmt.Println("Cloud server not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runCloudServerGet,
 }
 
 var cloudserverUpdateCmd = &cobra.Command{
 	Use:   "update [cloudserver-id]",
 	Short: "Update a cloud server",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("fetching current cloud server: %w", apiErrFromV2(err))
-		}
-
-		if server == nil || server.Raw() == nil {
-			return fmt.Errorf("cloud server not found")
-		}
-
-		if name != "" {
-			server.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			server.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromCompute().CloudServers().Update(ctx, server)
-		if err != nil {
-			return fmt.Errorf("updating cloud server: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Cloud server", serverID))
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Cloud server", serverID))
-		}
-		return nil
-	},
+	RunE:  runCloudServerUpdate,
 }
 
 var cloudserverDeleteCmd = &cobra.Command{
 	Use:   "delete [cloudserver-id]",
 	Short: "Delete a cloud server",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
-
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("cloud server", serverID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-			if err != nil {
-				return fmt.Errorf("dry-run: cloud server not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("cloud server", serverID))
-			return nil
-		}
-
-		err = client.FromCompute().CloudServers().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("deleting cloud server: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("Cloud server", serverID))
-		return nil
-	},
+	RunE:  runCloudServerDelete,
 }
 
 var cloudserverListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all cloud servers",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromCompute().CloudServers().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing cloud servers: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 25},
-				{Header: "ID", Width: 30},
-				{Header: "LOCATION", Width: 15},
-				{Header: "FLAVOR", Width: 15},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, server := range list.Items() {
-				raw := server.Raw()
-				if raw == nil || raw.Metadata.ID == nil || *raw.Metadata.ID == "" {
-					continue
-				}
-				id := *raw.Metadata.ID
-				var name string
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				var location string
-				if raw.Metadata.LocationResponse != nil {
-					location = string(raw.Metadata.LocationResponse.Value)
-				}
-				flavor := raw.Properties.Flavor.Name
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{
-					name,
-					id,
-					location,
-					string(flavor),
-					status,
-				})
-			}
-
-			if len(rows) == 0 {
-				fmt.Println("No cloud servers found")
-				return nil
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No cloud servers found")
-		}
-		return nil
-	},
+	RunE:  runCloudServerList,
 }
 
 var cloudserverPowerOnCmd = &cobra.Command{
 	Use:   "power-on [cloudserver-id]",
 	Short: "Power on a cloud server",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		// GET the server wrapper first (enables action methods)
-		server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
-		}
-
-		err = server.PowerOn(ctx)
-		if err != nil {
-			return fmt.Errorf("powering on cloud server: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgAction("Cloud server", serverID, "powered on"))
-		if server.Raw() != nil {
-			if server.Raw().Metadata.Name != nil {
-				fmt.Printf("Server: %s\n", *server.Raw().Metadata.Name)
-			}
-			if server.Raw().Status.State != nil {
-				fmt.Printf("Status: %s\n", *server.Raw().Status.State)
-			}
-		}
-		return nil
-	},
+	RunE:  runCloudServerPowerOn,
 }
 
 var cloudserverPowerOffCmd = &cobra.Command{
 	Use:   "power-off [cloudserver-id]",
 	Short: "Power off a cloud server",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		// GET the server wrapper first (enables action methods)
-		server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
-		}
-
-		err = server.PowerOff(ctx)
-		if err != nil {
-			return fmt.Errorf("powering off cloud server: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgAction("Cloud server", serverID, "powered off"))
-		if server.Raw() != nil {
-			if server.Raw().Metadata.Name != nil {
-				fmt.Printf("Server: %s\n", *server.Raw().Metadata.Name)
-			}
-			if server.Raw().Status.State != nil {
-				fmt.Printf("Status: %s\n", *server.Raw().Status.State)
-			}
-		}
-		return nil
-	},
+	RunE:  runCloudServerPowerOff,
 }
 
 var cloudserverSetPasswordCmd = &cobra.Command{
 	Use:   "set-password [cloudserver-id]",
 	Short: "Set password for a cloud server",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		password, _ := cmd.Flags().GetString("password")
-		if password == "" {
-			return fmt.Errorf("--password is required")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		// GET the server wrapper first (enables action methods)
-		server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
-		}
-
-		err = server.SetPassword(ctx, password)
-		if err != nil {
-			return fmt.Errorf("setting cloud server password: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgAction("Cloud server", serverID, "password set"))
-		return nil
-	},
+	RunE:  runCloudServerSetPassword,
 }
 
 var cloudserverConnectCmd = &cobra.Command{
 	Use:   "connect [cloudserver-id]",
 	Short: "Get SSH connection information for a cloud server",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		serverID := args[0]
+	RunE:  runCloudServerConnect,
+}
 
-		projectID, err := GetProjectID(cmd)
+func runCloudServerCreate(cmd *cobra.Command, args []string) error {
+	vpcID, _ := cmd.Flags().GetString("vpc-id")
+	subnetIDs, _ := cmd.Flags().GetStringSlice("subnet-id")
+	sgIDs, _ := cmd.Flags().GetStringSlice("security-group-id")
+	elasticIPID, _ := cmd.Flags().GetString("elasticip-id")
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	zone, _ := cmd.Flags().GetString("zone")
+	flavor, _ := cmd.Flags().GetString("flavor")
+	bootDiskID, _ := cmd.Flags().GetString("boot-disk-id")
+	keypairID, _ := cmd.Flags().GetString("keypair-id")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	userDataFile, _ := cmd.Flags().GetString("user-data-file")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	subnetRefs := make([]aruba.Ref, len(subnetIDs))
+	for i, s := range subnetIDs {
+		subnetRefs[i] = aruba.SubnetRef(projectID, vpcID, s)
+	}
+	sgRefs := make([]aruba.Ref, len(sgIDs))
+	for i, sg := range sgIDs {
+		sgRefs[i] = aruba.SecurityGroupRef(projectID, vpcID, sg)
+	}
+	server := aruba.NewCloudServer().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		InZone(aruba.Zone(zone)).
+		OfFlavor(aruba.CloudServerFlavor(flavor)).
+		BootingFrom(volumeRef(projectID, bootDiskID)).
+		WithVPC(aruba.VPCRef(projectID, vpcID)).
+		OnSubnets(subnetRefs...).
+		WithSecurityGroups(sgRefs...).
+		RetaggedAs(tags...).
+		BilledBy(aruba.BillingPeriod(billingPeriod))
+
+	if elasticIPID != "" {
+		server.WithElasticIP(aruba.ElasticIPRef(projectID, elasticIPID))
+	}
+	if keypairID != "" {
+		server.UsingKeyPair(keypairRef(projectID, keypairID))
+	}
+	if userDataFile != "" {
+		fileContent, err := os.ReadFile(userDataFile)
+		if err != nil {
+			return fmt.Errorf("reading user-data file: %w", err)
+		}
+		userDataBase64 := base64.StdEncoding.EncodeToString(fileContent)
+		server.WithUserData(userDataBase64)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	resp, err := client.FromCompute().CloudServers().Create(ctx, server)
+	if err != nil {
+		return fmt.Errorf("creating cloud server: %w", apiErrFromV2(err))
+	}
+
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "FLAVOR", Width: 20},
+			{Header: "CPU", Width: 10},
+			{Header: "RAM(GB)", Width: 15},
+			{Header: "HD(GB)", Width: 15},
+			{Header: "REGION", Width: 20},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		flavorName := raw.Properties.Flavor.Name
+		cpu := raw.Properties.Flavor.CPU
+		ram := raw.Properties.Flavor.RAM
+		hd := raw.Properties.Flavor.HD
+		regionValue := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionValue = string(raw.Metadata.LocationResponse.Value)
+		}
+		row := []string{
+			id,
+			nameVal,
+			string(flavorName),
+			fmt.Sprintf("%d", cpu),
+			fmt.Sprintf("%d", ram),
+			fmt.Sprintf("%d", hd),
+			regionValue,
+		}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("Cloud server", name))
+	}
+	return nil
+}
+
+func runCloudServerGet(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
+	}
+
+	if server != nil && server.Raw() != nil {
+		raw := server.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(server, nil, nil)
+			return nil
+		}
+
+		fmt.Println("\nCloud Server Details:")
+		fmt.Println("====================")
+
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+
+		if raw.Properties.Flavor.Name != "" {
+			fmt.Printf("Flavor:          %s\n", raw.Properties.Flavor.Name)
+		}
+		fmt.Printf("CPU:             %d\n", raw.Properties.Flavor.CPU)
+		fmt.Printf("RAM:             %d GB\n", raw.Properties.Flavor.RAM)
+		fmt.Printf("HD:              %d GB\n", raw.Properties.Flavor.HD)
+
+		if raw.Properties.BootVolume.URI != "" {
+			fmt.Printf("Boot Volume URI: %s\n", raw.Properties.BootVolume.URI)
+		}
+
+		if raw.Properties.KeyPair.URI != "" {
+			fmt.Printf("Keypair URI:     %s\n", raw.Properties.KeyPair.URI)
+		}
+
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		if verbose {
+			jsonData, _ := json.MarshalIndent(raw, "", "  ")
+			fmt.Println("\nFull JSON Response:")
+			fmt.Println("==================")
+			fmt.Println(string(jsonData))
+		}
+	} else {
+		fmt.Println("Cloud server not found or no data returned.")
+	}
+	return nil
+}
+
+func runCloudServerUpdate(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("fetching current cloud server: %w", apiErrFromV2(err))
+	}
+
+	if server == nil || server.Raw() == nil {
+		return fmt.Errorf("cloud server not found")
+	}
+
+	if name != "" {
+		server.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		server.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromCompute().CloudServers().Update(ctx, server)
+	if err != nil {
+		return fmt.Errorf("updating cloud server: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Cloud server", serverID))
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Cloud server", serverID))
+	}
+	return nil
+}
+
+func runCloudServerDelete(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("cloud server", serverID)
 		if err != nil {
 			return err
 		}
-
-		user, _ := cmd.Flags().GetString("user")
-		if user == "" || user == "<user>" {
-			fmt.Println("Error: --user is required")
-			fmt.Println("\nCommon SSH users by image type:")
-			fmt.Println("  - Ubuntu/Debian: ubuntu")
-			fmt.Println("  - CentOS/RHEL: centos or root")
-			fmt.Println("  - Other Linux: root or check image documentation")
-			fmt.Println("\nFor more information, see: https://kb.arubacloud.com/cmp/en/computing/cloud-server.aspx")
-			return fmt.Errorf("--user is required")
+		if !ok {
+			return nil
 		}
+	}
 
-		client, err := GetArubaClient()
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
 		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+			return fmt.Errorf("dry-run: cloud server not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		// Get the cloud server details
-		server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
-		if err != nil {
-			return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
-		}
-
-		if server == nil || server.Raw() == nil {
-			fmt.Println("Cloud server not found or no data returned.")
-			return nil
-		}
-
-		raw := server.Raw()
-
-		// Check for ElasticIP in linked resources
-		var elasticIPURI string
-		for _, linkedResource := range raw.Properties.LinkedResources {
-			if strings.Contains(linkedResource.URI, "providers/Aruba.Network/elasticIps") {
-				elasticIPURI = linkedResource.URI
-				break
-			}
-		}
-
-		if elasticIPURI == "" {
-			fmt.Println("No Elastic IP found for this cloud server.")
-			fmt.Println("The server must have an Elastic IP linked to use the connect command.")
-			return nil
-		}
-
-		// Extract ElasticIP ID from URI
-		elasticIPID := extractIDFromURI(elasticIPURI)
-		if elasticIPID == "" {
-			return fmt.Errorf("could not extract Elastic IP ID from URI: %s", elasticIPURI)
-		}
-
-		// Get ElasticIP details
-		eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, elasticIPID))
-		if err != nil {
-			return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
-		}
-
-		if eip == nil || eip.Raw() == nil {
-			fmt.Println("Elastic IP not found or no data returned.")
-			return nil
-		}
-
-		eipRaw := eip.Raw()
-		if eipRaw.Properties.Address == nil || *eipRaw.Properties.Address == "" {
-			fmt.Println("Elastic IP address not available.")
-			return nil
-		}
-
-		// Print SSH connection command
-		fmt.Printf("Connect by running: ssh %s@%s\n", user, *eipRaw.Properties.Address)
+		fmt.Println(msgDryRun("cloud server", serverID))
 		return nil
-	},
+	}
+
+	err = client.FromCompute().CloudServers().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("deleting cloud server: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Cloud server", serverID))
+	return nil
+}
+
+func runCloudServerList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromCompute().CloudServers().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing cloud servers: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 25},
+			{Header: "ID", Width: 30},
+			{Header: "LOCATION", Width: 15},
+			{Header: "FLAVOR", Width: 15},
+			{Header: "STATUS", Width: 15},
+		}
+
+		var rows [][]string
+		for _, server := range list.Items() {
+			raw := server.Raw()
+			if raw == nil || raw.Metadata.ID == nil || *raw.Metadata.ID == "" {
+				continue
+			}
+			id := *raw.Metadata.ID
+			var name string
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			var location string
+			if raw.Metadata.LocationResponse != nil {
+				location = string(raw.Metadata.LocationResponse.Value)
+			}
+			flavor := raw.Properties.Flavor.Name
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{
+				name,
+				id,
+				location,
+				string(flavor),
+				status,
+			})
+		}
+
+		if len(rows) == 0 {
+			fmt.Println("No cloud servers found")
+			return nil
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No cloud servers found")
+	}
+	return nil
+}
+
+func runCloudServerPowerOn(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	// GET the server wrapper first (enables action methods)
+	server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
+	}
+
+	err = server.PowerOn(ctx)
+	if err != nil {
+		return fmt.Errorf("powering on cloud server: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgAction("Cloud server", serverID, "powered on"))
+	if server.Raw() != nil {
+		if server.Raw().Metadata.Name != nil {
+			fmt.Printf("Server: %s\n", *server.Raw().Metadata.Name)
+		}
+		if server.Raw().Status.State != nil {
+			fmt.Printf("Status: %s\n", *server.Raw().Status.State)
+		}
+	}
+	return nil
+}
+
+func runCloudServerPowerOff(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	// GET the server wrapper first (enables action methods)
+	server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
+	}
+
+	err = server.PowerOff(ctx)
+	if err != nil {
+		return fmt.Errorf("powering off cloud server: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgAction("Cloud server", serverID, "powered off"))
+	if server.Raw() != nil {
+		if server.Raw().Metadata.Name != nil {
+			fmt.Printf("Server: %s\n", *server.Raw().Metadata.Name)
+		}
+		if server.Raw().Status.State != nil {
+			fmt.Printf("Status: %s\n", *server.Raw().Status.State)
+		}
+	}
+	return nil
+}
+
+func runCloudServerSetPassword(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	password, _ := cmd.Flags().GetString("password")
+	if password == "" {
+		return fmt.Errorf("--password is required")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	// GET the server wrapper first (enables action methods)
+	server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
+	}
+
+	err = server.SetPassword(ctx, password)
+	if err != nil {
+		return fmt.Errorf("setting cloud server password: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgAction("Cloud server", serverID, "password set"))
+	return nil
+}
+
+func runCloudServerConnect(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	user, _ := cmd.Flags().GetString("user")
+	if user == "" || user == "<user>" {
+		fmt.Println("Error: --user is required")
+		fmt.Println("\nCommon SSH users by image type:")
+		fmt.Println("  - Ubuntu/Debian: ubuntu")
+		fmt.Println("  - CentOS/RHEL: centos or root")
+		fmt.Println("  - Other Linux: root or check image documentation")
+		fmt.Println("\nFor more information, see: https://kb.arubacloud.com/cmp/en/computing/cloud-server.aspx")
+		return fmt.Errorf("--user is required")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	// Get the cloud server details
+	server, err := client.FromCompute().CloudServers().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/cloudServers/"+serverID))
+	if err != nil {
+		return fmt.Errorf("getting cloud server: %w", apiErrFromV2(err))
+	}
+
+	if server == nil || server.Raw() == nil {
+		fmt.Println("Cloud server not found or no data returned.")
+		return nil
+	}
+
+	raw := server.Raw()
+
+	// Check for ElasticIP in linked resources
+	var elasticIPURI string
+	for _, linkedResource := range raw.Properties.LinkedResources {
+		if strings.Contains(linkedResource.URI, "providers/Aruba.Network/elasticIps") {
+			elasticIPURI = linkedResource.URI
+			break
+		}
+	}
+
+	if elasticIPURI == "" {
+		fmt.Println("No Elastic IP found for this cloud server.")
+		fmt.Println("The server must have an Elastic IP linked to use the connect command.")
+		return nil
+	}
+
+	// Extract ElasticIP ID from URI
+	elasticIPID := extractIDFromURI(elasticIPURI)
+	if elasticIPID == "" {
+		return fmt.Errorf("could not extract Elastic IP ID from URI: %s", elasticIPURI)
+	}
+
+	// Get ElasticIP details
+	eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, elasticIPID))
+	if err != nil {
+		return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
+	}
+
+	if eip == nil || eip.Raw() == nil {
+		fmt.Println("Elastic IP not found or no data returned.")
+		return nil
+	}
+
+	eipRaw := eip.Raw()
+	if eipRaw.Properties.Address == nil || *eipRaw.Properties.Address == "" {
+		fmt.Println("Elastic IP address not available.")
+		return nil
+	}
+
+	// Print SSH connection command
+	fmt.Printf("Connect by running: ssh %s@%s\n", user, *eipRaw.Properties.Address)
+	return nil
 }

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -101,271 +101,281 @@ The public key must be an OpenSSH-formatted RSA, ECDSA, or Ed25519 public key
 (the content of your ~/.ssh/id_rsa.pub or similar file).`,
 	Example: `  acloud compute keypair create --name my-key --public-key "$(cat ~/.ssh/id_rsa.pub)"`,
 	Args:    cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		publicKey, _ := cmd.Flags().GetString("public-key")
-		region, _ := cmd.Flags().GetString("region")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		kp := aruba.NewKeyPair().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			WithPublicKey(publicKey)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		resp, err := client.FromCompute().KeyPairs().Create(ctx, kp)
-		if err != nil {
-			return fmt.Errorf("creating keypair: %w", apiErrFromV2(err))
-		}
-
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "ID", Width: 26},
-				{Header: "PUBLIC_KEY", Width: 60},
-				{Header: "STATUS", Width: 10},
-			}
-			publicKeyValue := ""
-			if raw.Properties.Value != "" {
-				publicKeyValue = raw.Properties.Value
-				if len(publicKeyValue) > 50 {
-					publicKeyValue = publicKeyValue[:50] + "..."
-				}
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			row := []string{nameVal, id, publicKeyValue, "Active"}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("Keypair", name))
-		}
-		return nil
-	},
+	RunE:    runKeypairCreate,
 }
 
 var keypairGetCmd = &cobra.Command{
 	Use:   "get [keypair-id]",
 	Short: "Get keypair details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		keypairName := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kp, err := client.FromCompute().KeyPairs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/keyPairs/"+keypairName))
-		if err != nil {
-			return fmt.Errorf("getting keypair: %w", apiErrFromV2(err))
-		}
-
-		if kp != nil && kp.Raw() != nil {
-			raw := kp.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(kp, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nKeypair Details:")
-			fmt.Println("===============")
-
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Properties.Value != "" {
-				fmt.Printf("Public Key:      %s\n", raw.Properties.Value)
-			}
-			// Show status as 'Active' for consistency
-			fmt.Printf("Status:          Active\n")
-
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-
-			// Show JSON output if verbose
-			verbose, _ := cmd.Flags().GetBool("verbose")
-			if verbose {
-				jsonData, _ := json.MarshalIndent(raw, "", "  ")
-				fmt.Println("\nFull JSON Response:")
-				fmt.Println("==================")
-				fmt.Println(string(jsonData))
-			}
-		} else {
-			fmt.Println("Keypair not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runKeypairGet,
 }
 
 var keypairUpdateCmd = &cobra.Command{
 	Use:   "update [keypair-name]",
 	Short: "Update a keypair (not supported - delete and recreate instead)",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Error: Keypair update is not supported by the API.")
-		fmt.Println("To change a keypair's public key, delete it and create a new one with the same name.")
-		fmt.Println("")
-		fmt.Println("Example:")
-		fmt.Printf("  acloud compute keypair delete %s --yes\n", args[0])
-		fmt.Printf("  acloud compute keypair create --name %s --public-key \"<new-key>\"\n", args[0])
-		return nil
-	},
+	RunE:  runKeypairUpdate,
 }
 
 var keypairDeleteCmd = &cobra.Command{
 	Use:   "delete [keypair-id]",
 	Short: "Delete a keypair",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		keypairName := args[0]
-
-		// Confirmation prompt
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("keypair", keypairName)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		keypairRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Compute/keyPairs/" + keypairName)
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromCompute().KeyPairs().Get(ctx, keypairRef)
-			if err != nil {
-				return fmt.Errorf("dry-run: keypair not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("keypair", keypairName))
-			return nil
-		}
-
-		err = client.FromCompute().KeyPairs().Delete(ctx, keypairRef)
-		if err != nil {
-			return fmt.Errorf("deleting keypair: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("Keypair", keypairName))
-		return nil
-	},
+	RunE:  runKeypairDelete,
 }
 
 var keypairListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all keypairs",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
+	RunE:  runKeypairList,
+}
+
+func runKeypairCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	publicKey, _ := cmd.Flags().GetString("public-key")
+	region, _ := cmd.Flags().GetString("region")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	kp := aruba.NewKeyPair().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		WithPublicKey(publicKey)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	resp, err := client.FromCompute().KeyPairs().Create(ctx, kp)
+	if err != nil {
+		return fmt.Errorf("creating keypair: %w", apiErrFromV2(err))
+	}
+
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "ID", Width: 26},
+			{Header: "PUBLIC_KEY", Width: 60},
+			{Header: "STATUS", Width: 10},
+		}
+		publicKeyValue := ""
+		if raw.Properties.Value != "" {
+			publicKeyValue = raw.Properties.Value
+			if len(publicKeyValue) > 50 {
+				publicKeyValue = publicKeyValue[:50] + "..."
+			}
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		row := []string{nameVal, id, publicKeyValue, "Active"}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("Keypair", name))
+	}
+	return nil
+}
+
+func runKeypairGet(cmd *cobra.Command, args []string) error {
+	keypairName := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kp, err := client.FromCompute().KeyPairs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Compute/keyPairs/"+keypairName))
+	if err != nil {
+		return fmt.Errorf("getting keypair: %w", apiErrFromV2(err))
+	}
+
+	if kp != nil && kp.Raw() != nil {
+		raw := kp.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(kp, nil, nil)
+			return nil
+		}
+
+		fmt.Println("\nKeypair Details:")
+		fmt.Println("===============")
+
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Properties.Value != "" {
+			fmt.Printf("Public Key:      %s\n", raw.Properties.Value)
+		}
+		// Show status as 'Active' for consistency
+		fmt.Printf("Status:          Active\n")
+
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+
+		// Show JSON output if verbose
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		if verbose {
+			jsonData, _ := json.MarshalIndent(raw, "", "  ")
+			fmt.Println("\nFull JSON Response:")
+			fmt.Println("==================")
+			fmt.Println(string(jsonData))
+		}
+	} else {
+		fmt.Println("Keypair not found or no data returned.")
+	}
+	return nil
+}
+
+func runKeypairUpdate(cmd *cobra.Command, args []string) error {
+	fmt.Println("Error: Keypair update is not supported by the API.")
+	fmt.Println("To change a keypair's public key, delete it and create a new one with the same name.")
+	fmt.Println("")
+	fmt.Println("Example:")
+	fmt.Printf("  acloud compute keypair delete %s --yes\n", args[0])
+	fmt.Printf("  acloud compute keypair create --name %s --public-key \"<new-key>\"\n", args[0])
+	return nil
+}
+
+func runKeypairDelete(cmd *cobra.Command, args []string) error {
+	keypairName := args[0]
+
+	// Confirmation prompt
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("keypair", keypairName)
 		if err != nil {
 			return err
 		}
+		if !ok {
+			return nil
+		}
+	}
 
-		client, err := GetArubaClient()
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	keypairRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Compute/keyPairs/" + keypairName)
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromCompute().KeyPairs().Get(ctx, keypairRef)
 		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+			return fmt.Errorf("dry-run: keypair not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromCompute().KeyPairs().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing keypairs: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "ID", Width: 30},
-				{Header: "PUBLIC_KEY", Width: 60},
-				{Header: "STATUS", Width: 10},
-			}
-
-			var rows [][]string
-			for _, kp := range list.Items() {
-				raw := kp.Raw()
-				if raw == nil {
-					continue
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				if id == "" {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				publicKey := ""
-				if raw.Properties.Value != "" {
-					publicKey = raw.Properties.Value
-					if len(publicKey) > 50 {
-						publicKey = publicKey[:50] + "..."
-					}
-				}
-				status := "Active"
-				rows = append(rows, []string{name, id, publicKey, status})
-			}
-
-			if len(rows) == 0 {
-				fmt.Println("No keypairs found")
-				return nil
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No keypairs found")
-		}
+		fmt.Println(msgDryRun("keypair", keypairName))
 		return nil
-	},
+	}
+
+	err = client.FromCompute().KeyPairs().Delete(ctx, keypairRef)
+	if err != nil {
+		return fmt.Errorf("deleting keypair: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Keypair", keypairName))
+	return nil
+}
+
+func runKeypairList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromCompute().KeyPairs().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing keypairs: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "ID", Width: 30},
+			{Header: "PUBLIC_KEY", Width: 60},
+			{Header: "STATUS", Width: 10},
+		}
+
+		var rows [][]string
+		for _, kp := range list.Items() {
+			raw := kp.Raw()
+			if raw == nil {
+				continue
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			if id == "" {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			publicKey := ""
+			if raw.Properties.Value != "" {
+				publicKey = raw.Properties.Value
+				if len(publicKey) > 50 {
+					publicKey = publicKey[:50] + "..."
+				}
+			}
+			status := "Active"
+			rows = append(rows, []string{name, id, publicKey, status})
+		}
+
+		if len(rows) == 0 {
+			fmt.Println("No keypairs found")
+			return nil
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No keypairs found")
+	}
+	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -37,83 +37,7 @@ var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set configuration values",
 	Long:  `Set configuration values for acloud, such as clientId and clientSecret.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		clientID, err := cmd.Flags().GetString("client-id")
-		if err != nil {
-			return err
-		}
-		clientSecret, err := cmd.Flags().GetString("client-secret")
-		if err != nil {
-			return err
-		}
-		baseURL, err := cmd.Flags().GetString("base-url")
-		if err != nil {
-			return err
-		}
-		tokenIssuerURL, err := cmd.Flags().GetString("token-issuer-url")
-		if err != nil {
-			return err
-		}
-
-		// Load existing config or create new one
-		config, err := LoadConfig()
-		if err != nil {
-			// If config doesn't exist, create a new one
-			config = &Config{}
-		}
-
-		// Validate required fields
-		if config.ClientID == "" && clientID == "" {
-			return fmt.Errorf("--client-id is required")
-		}
-		// If --client-secret was not provided and there is no existing secret, prompt interactively
-		if config.ClientSecret == "" && clientSecret == "" {
-			prompted, err := readSecret("Enter client secret: ")
-			if err != nil {
-				return fmt.Errorf("--client-secret is required: %w", err)
-			}
-			clientSecret = prompted
-		}
-
-		// Update only provided values
-		if clientID != "" {
-			config.ClientID = clientID
-		}
-		if clientSecret != "" {
-			config.ClientSecret = clientSecret
-		}
-		if baseURL != "" {
-			config.BaseURL = baseURL
-		}
-		if tokenIssuerURL != "" {
-			config.TokenIssuerURL = tokenIssuerURL
-		}
-
-		// Final validation: both clientID and clientSecret must be set
-		if config.ClientID == "" || config.ClientSecret == "" {
-			return fmt.Errorf("both client-id and client-secret are required")
-		}
-
-		// Save config
-		if err := SaveConfig(config); err != nil {
-			return fmt.Errorf("saving configuration: %w", err)
-		}
-
-		fmt.Println("Configuration updated successfully")
-		if clientID != "" {
-			fmt.Printf("  Client ID: %s\n", clientID)
-		}
-		if clientSecret != "" {
-			fmt.Println("  Client Secret: ********")
-		}
-		if baseURL != "" {
-			fmt.Printf("  Base URL: %s\n", baseURL)
-		}
-		if tokenIssuerURL != "" {
-			fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
-		}
-		return nil
-	},
+	RunE:  runConfigSet,
 }
 
 // configShowCmd represents the config show command
@@ -121,32 +45,7 @@ var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show current configuration",
 	Long:  `Display the current acloud configuration.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		config, err := LoadConfig()
-		if err != nil {
-			fmt.Println("No configuration found. Please run 'acloud config set' to create one.")
-			return nil
-		}
-
-		fmt.Println("Current configuration:")
-		fmt.Printf("  Client ID: %s\n", config.ClientID)
-		if config.ClientSecret != "" {
-			fmt.Println("  Client Secret: ********")
-		} else {
-			fmt.Println("  Client Secret: (not set)")
-		}
-		baseURL := config.BaseURL
-		if baseURL == "" {
-			baseURL = DefaultBaseURL + " (default)"
-		}
-		fmt.Printf("  Base URL: %s\n", baseURL)
-		tokenIssuerURL := config.TokenIssuerURL
-		if tokenIssuerURL == "" {
-			tokenIssuerURL = DefaultTokenIssuerURL + " (default)"
-		}
-		fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
-		return nil
-	},
+	RunE:  runConfigShow,
 }
 
 func init() {
@@ -235,4 +134,109 @@ func SaveConfig(config *Config) error {
 	}
 
 	return os.WriteFile(configPath, data, FilePermConfig)
+}
+
+func runConfigSet(cmd *cobra.Command, args []string) error {
+	clientID, err := cmd.Flags().GetString("client-id")
+	if err != nil {
+		return err
+	}
+	clientSecret, err := cmd.Flags().GetString("client-secret")
+	if err != nil {
+		return err
+	}
+	baseURL, err := cmd.Flags().GetString("base-url")
+	if err != nil {
+		return err
+	}
+	tokenIssuerURL, err := cmd.Flags().GetString("token-issuer-url")
+	if err != nil {
+		return err
+	}
+
+	// Load existing config or create new one
+	config, err := LoadConfig()
+	if err != nil {
+		// If config doesn't exist, create a new one
+		config = &Config{}
+	}
+
+	// Validate required fields
+	if config.ClientID == "" && clientID == "" {
+		return fmt.Errorf("--client-id is required")
+	}
+	// If --client-secret was not provided and there is no existing secret, prompt interactively
+	if config.ClientSecret == "" && clientSecret == "" {
+		prompted, err := readSecret("Enter client secret: ")
+		if err != nil {
+			return fmt.Errorf("--client-secret is required: %w", err)
+		}
+		clientSecret = prompted
+	}
+
+	// Update only provided values
+	if clientID != "" {
+		config.ClientID = clientID
+	}
+	if clientSecret != "" {
+		config.ClientSecret = clientSecret
+	}
+	if baseURL != "" {
+		config.BaseURL = baseURL
+	}
+	if tokenIssuerURL != "" {
+		config.TokenIssuerURL = tokenIssuerURL
+	}
+
+	// Final validation: both clientID and clientSecret must be set
+	if config.ClientID == "" || config.ClientSecret == "" {
+		return fmt.Errorf("both client-id and client-secret are required")
+	}
+
+	// Save config
+	if err := SaveConfig(config); err != nil {
+		return fmt.Errorf("saving configuration: %w", err)
+	}
+
+	fmt.Println("Configuration updated successfully")
+	if clientID != "" {
+		fmt.Printf("  Client ID: %s\n", clientID)
+	}
+	if clientSecret != "" {
+		fmt.Println("  Client Secret: ********")
+	}
+	if baseURL != "" {
+		fmt.Printf("  Base URL: %s\n", baseURL)
+	}
+	if tokenIssuerURL != "" {
+		fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
+	}
+	return nil
+}
+
+func runConfigShow(cmd *cobra.Command, args []string) error {
+	config, err := LoadConfig()
+	if err != nil {
+		fmt.Println("No configuration found. Please run 'acloud config set' to create one.")
+		return nil
+	}
+
+	fmt.Println("Current configuration:")
+	fmt.Printf("  Client ID: %s\n", config.ClientID)
+	if config.ClientSecret != "" {
+		fmt.Println("  Client Secret: ********")
+	} else {
+		fmt.Println("  Client Secret: (not set)")
+	}
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL + " (default)"
+	}
+	fmt.Printf("  Base URL: %s\n", baseURL)
+	tokenIssuerURL := config.TokenIssuerURL
+	if tokenIssuerURL == "" {
+		tokenIssuerURL = DefaultTokenIssuerURL + " (default)"
+	}
+	fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
+	return nil
 }

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -111,367 +111,377 @@ Billing period: Hour (default), Month, or Year.`,
     --public-ip-id <eip-id> \
     --block-storage-id <vol-id>`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		publicIPID, _ := cmd.Flags().GetString("public-ip-id")
-		vpcID, _ := cmd.Flags().GetString("vpc-id")
-		subnetID, _ := cmd.Flags().GetString("subnet-id")
-		sgID, _ := cmd.Flags().GetString("security-group-id")
-		blockStorageID, _ := cmd.Flags().GetString("block-storage-id")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		adminUsername, _ := cmd.Flags().GetString("admin-username")
-		concurrentUsers, _ := cmd.Flags().GetString("concurrent-users")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		registry := aruba.NewContainerRegistry().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			WithElasticIP(aruba.ElasticIPRef(projectID, publicIPID)).
-			WithVPC(aruba.VPCRef(projectID, vpcID)).
-			WithSubnet(aruba.SubnetRef(projectID, vpcID, subnetID)).
-			WithSecurityGroup(aruba.SecurityGroupRef(projectID, vpcID, sgID)).
-			WithBlockStorage(volumeRef(projectID, blockStorageID)).
-			RetaggedAs(tags...)
-
-		if adminUsername != "" {
-			registry.WithAdminUsername(adminUsername)
-		}
-		if billingPeriod != "" {
-			registry.BilledBy(aruba.BillingPeriod(billingPeriod))
-		}
-		if concurrentUsers != "" {
-			registry.OfSize(aruba.ContainerRegistrySizeFlavor(concurrentUsers))
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromContainer().ContainerRegistry().Create(ctx, registry)
-		if err != nil {
-			return fmt.Errorf("creating container registry: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Container registry", name))
-		}
-		return nil
-	},
+	RunE: runContainerRegistryCreate,
 }
 
 var containerregistryGetCmd = &cobra.Command{
 	Use:   "get [containerregistry-id]",
 	Short: "Get container registry details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		registryID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		registryURI := "/projects/" + projectID + "/providers/Aruba.Container/registries/" + registryID
-		registry, err := client.FromContainer().ContainerRegistry().Get(ctx, aruba.URI(registryURI))
-		if err != nil {
-			return fmt.Errorf("getting container registry: %w", apiErrFromV2(err))
-		}
-
-		if registry != nil && registry.Raw() != nil {
-			raw := registry.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(registry, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nContainer Registry Details:")
-			fmt.Println("==========================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Properties.PublicIp.URI != "" {
-				fmt.Printf("Public IP:       %s\n", raw.Properties.PublicIp.URI)
-			}
-			if raw.Properties.VPC.URI != "" {
-				fmt.Printf("VPC:             %s\n", raw.Properties.VPC.URI)
-			}
-			if raw.Properties.Subnet.URI != "" {
-				fmt.Printf("Subnet:          %s\n", raw.Properties.Subnet.URI)
-			}
-			if raw.Properties.SecurityGroup.URI != "" {
-				fmt.Printf("Security Group:  %s\n", raw.Properties.SecurityGroup.URI)
-			}
-			if raw.Properties.BlockStorage.URI != "" {
-				fmt.Printf("Block Storage:   %s\n", raw.Properties.BlockStorage.URI)
-			}
-			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPlanCommon.BillingPeriod))
-			}
-			if raw.Properties.AdminUser != nil {
-				fmt.Printf("Admin User:      %s\n", raw.Properties.AdminUser.Username)
-			}
-			if raw.Properties.ConcurrentUsers != nil {
-				fmt.Printf("Concurrent Users: %s\n", *raw.Properties.ConcurrentUsers)
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Container registry not found")
-		}
-		return nil
-	},
+	RunE:  runContainerRegistryGet,
 }
 
 var containerregistryListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all container registries",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromContainer().ContainerRegistry().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing container registries: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "ID", Width: 30},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, cr := range list.Items() {
-				raw := cr.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No container registries found")
-		}
-		return nil
-	},
+	RunE:  runContainerRegistryList,
 }
 
 var containerregistryUpdateCmd = &cobra.Command{
 	Use:   "update [containerregistry-id]",
 	Short: "Update a container registry",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		registryID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		concurrentUsers, _ := cmd.Flags().GetString("concurrent-users")
-
-		if name == "" && !cmd.Flags().Changed("tags") && billingPeriod == "" && concurrentUsers == "" {
-			return fmt.Errorf("at least one of --name, --tags, --billing-period, or --concurrent-users must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		registryURI := "/projects/" + projectID + "/providers/Aruba.Container/registries/" + registryID
-		registry, err := client.FromContainer().ContainerRegistry().Get(ctx, aruba.URI(registryURI))
-		if err != nil {
-			return fmt.Errorf("fetching current container registry: %w", apiErrFromV2(err))
-		}
-		if registry == nil || registry.Raw() == nil {
-			return fmt.Errorf("container registry not found")
-		}
-
-		if name != "" {
-			registry.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			registry.RetaggedAs(tags...)
-		}
-		if billingPeriod != "" {
-			registry.BilledBy(aruba.BillingPeriod(billingPeriod))
-		}
-		if concurrentUsers != "" {
-			registry.OfSize(aruba.ContainerRegistrySizeFlavor(concurrentUsers))
-		}
-
-		updated, err := client.FromContainer().ContainerRegistry().Update(ctx, registry)
-		if err != nil {
-			return fmt.Errorf("updating container registry: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Container registry", registryID))
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Container registry", registryID))
-		}
-		return nil
-	},
+	RunE:  runContainerRegistryUpdate,
 }
 
 var containerregistryDeleteCmd = &cobra.Command{
 	Use:   "delete [containerregistry-id]",
 	Short: "Delete a container registry",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		registryID := args[0]
+	RunE:  runContainerRegistryDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("container registry", registryID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runContainerRegistryCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	publicIPID, _ := cmd.Flags().GetString("public-ip-id")
+	vpcID, _ := cmd.Flags().GetString("vpc-id")
+	subnetID, _ := cmd.Flags().GetString("subnet-id")
+	sgID, _ := cmd.Flags().GetString("security-group-id")
+	blockStorageID, _ := cmd.Flags().GetString("block-storage-id")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	adminUsername, _ := cmd.Flags().GetString("admin-username")
+	concurrentUsers, _ := cmd.Flags().GetString("concurrent-users")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	registry := aruba.NewContainerRegistry().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		WithElasticIP(aruba.ElasticIPRef(projectID, publicIPID)).
+		WithVPC(aruba.VPCRef(projectID, vpcID)).
+		WithSubnet(aruba.SubnetRef(projectID, vpcID, subnetID)).
+		WithSecurityGroup(aruba.SecurityGroupRef(projectID, vpcID, sgID)).
+		WithBlockStorage(volumeRef(projectID, blockStorageID)).
+		RetaggedAs(tags...)
+
+	if adminUsername != "" {
+		registry.WithAdminUsername(adminUsername)
+	}
+	if billingPeriod != "" {
+		registry.BilledBy(aruba.BillingPeriod(billingPeriod))
+	}
+	if concurrentUsers != "" {
+		registry.OfSize(aruba.ContainerRegistrySizeFlavor(concurrentUsers))
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromContainer().ContainerRegistry().Create(ctx, registry)
+	if err != nil {
+		return fmt.Errorf("creating container registry: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
 		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
 		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Container registry", name))
+	}
+	return nil
+}
 
-		ctx, cancel := newCtx()
-		defer cancel()
-		registryURI := "/projects/" + projectID + "/providers/Aruba.Container/registries/" + registryID
+func runContainerRegistryGet(cmd *cobra.Command, args []string) error {
+	registryID := args[0]
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromContainer().ContainerRegistry().Get(ctx, aruba.URI(registryURI))
-			if err != nil {
-				return fmt.Errorf("dry-run: container registry not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("container registry", registryID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	registryURI := "/projects/" + projectID + "/providers/Aruba.Container/registries/" + registryID
+	registry, err := client.FromContainer().ContainerRegistry().Get(ctx, aruba.URI(registryURI))
+	if err != nil {
+		return fmt.Errorf("getting container registry: %w", apiErrFromV2(err))
+	}
+
+	if registry != nil && registry.Raw() != nil {
+		raw := registry.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(registry, nil, nil)
 			return nil
 		}
 
-		err = client.FromContainer().ContainerRegistry().Delete(ctx, aruba.URI(registryURI))
-		if err != nil {
-			return fmt.Errorf("deleting container registry: %w", apiErrFromV2(err))
+		fmt.Println("\nContainer Registry Details:")
+		fmt.Println("==========================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Properties.PublicIp.URI != "" {
+			fmt.Printf("Public IP:       %s\n", raw.Properties.PublicIp.URI)
+		}
+		if raw.Properties.VPC.URI != "" {
+			fmt.Printf("VPC:             %s\n", raw.Properties.VPC.URI)
+		}
+		if raw.Properties.Subnet.URI != "" {
+			fmt.Printf("Subnet:          %s\n", raw.Properties.Subnet.URI)
+		}
+		if raw.Properties.SecurityGroup.URI != "" {
+			fmt.Printf("Security Group:  %s\n", raw.Properties.SecurityGroup.URI)
+		}
+		if raw.Properties.BlockStorage.URI != "" {
+			fmt.Printf("Block Storage:   %s\n", raw.Properties.BlockStorage.URI)
+		}
+		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+			fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPlanCommon.BillingPeriod))
+		}
+		if raw.Properties.AdminUser != nil {
+			fmt.Printf("Admin User:      %s\n", raw.Properties.AdminUser.Username)
+		}
+		if raw.Properties.ConcurrentUsers != nil {
+			fmt.Printf("Concurrent Users: %s\n", *raw.Properties.ConcurrentUsers)
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Container registry not found")
+	}
+	return nil
+}
+
+func runContainerRegistryList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromContainer().ContainerRegistry().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing container registries: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "ID", Width: 30},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
 		}
 
-		fmt.Println(msgDeleted("Container registry", registryID))
+		var rows [][]string
+		for _, cr := range list.Items() {
+			raw := cr.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No container registries found")
+	}
+	return nil
+}
+
+func runContainerRegistryUpdate(cmd *cobra.Command, args []string) error {
+	registryID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	concurrentUsers, _ := cmd.Flags().GetString("concurrent-users")
+
+	if name == "" && !cmd.Flags().Changed("tags") && billingPeriod == "" && concurrentUsers == "" {
+		return fmt.Errorf("at least one of --name, --tags, --billing-period, or --concurrent-users must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	registryURI := "/projects/" + projectID + "/providers/Aruba.Container/registries/" + registryID
+	registry, err := client.FromContainer().ContainerRegistry().Get(ctx, aruba.URI(registryURI))
+	if err != nil {
+		return fmt.Errorf("fetching current container registry: %w", apiErrFromV2(err))
+	}
+	if registry == nil || registry.Raw() == nil {
+		return fmt.Errorf("container registry not found")
+	}
+
+	if name != "" {
+		registry.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		registry.RetaggedAs(tags...)
+	}
+	if billingPeriod != "" {
+		registry.BilledBy(aruba.BillingPeriod(billingPeriod))
+	}
+	if concurrentUsers != "" {
+		registry.OfSize(aruba.ContainerRegistrySizeFlavor(concurrentUsers))
+	}
+
+	updated, err := client.FromContainer().ContainerRegistry().Update(ctx, registry)
+	if err != nil {
+		return fmt.Errorf("updating container registry: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Container registry", registryID))
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Container registry", registryID))
+	}
+	return nil
+}
+
+func runContainerRegistryDelete(cmd *cobra.Command, args []string) error {
+	registryID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("container registry", registryID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	registryURI := "/projects/" + projectID + "/providers/Aruba.Container/registries/" + registryID
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromContainer().ContainerRegistry().Get(ctx, aruba.URI(registryURI))
+		if err != nil {
+			return fmt.Errorf("dry-run: container registry not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("container registry", registryID))
 		return nil
-	},
+	}
+
+	err = client.FromContainer().ContainerRegistry().Delete(ctx, aruba.URI(registryURI))
+	if err != nil {
+		return fmt.Errorf("deleting container registry: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Container registry", registryID))
+	return nil
 }

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -150,450 +150,462 @@ Billing period: Hour (default), Month, or Year.`,
     --node-pool-name workers --node-pool-nodes 3 \
     --node-pool-instance <flavor-id> --node-pool-zone IT-BG-1`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		vpcID, _ := cmd.Flags().GetString("vpc-id")
-		subnetID, _ := cmd.Flags().GetString("subnet-id")
-		nodeCIDRAddress, _ := cmd.Flags().GetString("node-cidr-address")
-		nodeCIDRName, _ := cmd.Flags().GetString("node-cidr-name")
-		securityGroupName, _ := cmd.Flags().GetString("security-group-name")
-		kubernetesVersion, _ := cmd.Flags().GetString("kubernetes-version")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		nodePoolName, _ := cmd.Flags().GetString("node-pool-name")
-		nodePoolNodes, _ := cmd.Flags().GetInt("node-pool-nodes")
-		nodePoolInstance, _ := cmd.Flags().GetString("node-pool-instance")
-		nodePoolZone, _ := cmd.Flags().GetString("node-pool-zone")
-		nodePoolAutoscaling, _ := cmd.Flags().GetBool("node-pool-autoscaling")
-		nodePoolMinCount, _ := cmd.Flags().GetInt32("node-pool-min-count")
-		nodePoolMaxCount, _ := cmd.Flags().GetInt32("node-pool-max-count")
-		podCIDR, _ := cmd.Flags().GetString("pod-cidr")
-		ha, _ := cmd.Flags().GetBool("ha")
-		apiServerAuthorizedIPRanges, _ := cmd.Flags().GetStringSlice("api-server-authorized-ip-ranges")
-		apiServerEnablePrivateCluster, _ := cmd.Flags().GetBool("api-server-enable-private-cluster")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		nodePool := aruba.NewNodePool().
-			Named(nodePoolName).
-			OfInstance(aruba.NodePoolInstance(nodePoolInstance)).
-			InZone(aruba.Zone(nodePoolZone)).
-			WithCount(int(nodePoolNodes))
-		if nodePoolAutoscaling {
-			nodePool.WithAutoscaling(int(nodePoolMinCount), int(nodePoolMaxCount))
-		}
-
-		kaas := aruba.NewKaaS().
-			InProject(aruba.URI("/projects/"+projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			WithVPC(aruba.VPCRef(projectID, vpcID)).
-			WithSubnet(aruba.SubnetRef(projectID, vpcID, subnetID)).
-			WithNodeCIDR(nodeCIDRAddress, nodeCIDRName).
-			WithSecurityGroupName(securityGroupName).
-			WithKubernetesVersion(aruba.KubernetesVersion(kubernetesVersion)).
-			WithNodePools(nodePool).
-			RetaggedAs(tags...)
-		if ha {
-			kaas.HighlyAvailable()
-		}
-
-		if podCIDR != "" {
-			kaas.WithPodCIDR(podCIDR)
-		}
-		if billingPeriod != "" {
-			kaas.BilledBy(aruba.BillingPeriod(billingPeriod))
-		}
-		if len(apiServerAuthorizedIPRanges) > 0 || apiServerEnablePrivateCluster {
-			// TECH_DEBT: TD-033 (#131) — types.KaaSAPIServerAccessProfilePropertiesRequest must be
-			// referenced directly because the SDK provides no aruba-level constructor for
-			// this type yet. Remove the types import from this file once sdk-go exposes
-			// aruba.NewAPIServerAccessProfile() or an equivalent fluent setter.
-			profile := &types.KaaSAPIServerAccessProfilePropertiesRequest{
-				EnablePrivateCluster: apiServerEnablePrivateCluster,
-			}
-			if len(apiServerAuthorizedIPRanges) > 0 {
-				profile.AuthorizedIPRanges = &apiServerAuthorizedIPRanges
-			}
-			kaas.WithAPIServerAccessProfile(profile)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromContainer().KaaS().Create(ctx, kaas)
-		if err != nil {
-			return fmt.Errorf("creating KaaS cluster: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.ID() != "" {
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "VERSION", Width: 20},
-				{Header: "REGION", Width: 20},
-			}
-			PrintOutput(created, headers, [][]string{{
-				created.ID(),
-				created.Name(),
-				string(created.KubernetesVersion()),
-				string(created.Region()),
-			}})
-		} else {
-			fmt.Println(msgCreatedAsync("KaaS cluster", name))
-		}
-		return nil
-	},
+	RunE: runKaaSCreate,
 }
 
 var kaasGetCmd = &cobra.Command{
 	Use:   "get [kaas-id]",
 	Short: "Get KaaS cluster details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
-		kaas, err := client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
-		if err != nil {
-			return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
-		}
-
-		if kaas != nil && kaas.ID() != "" {
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(kaas, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nKaaS Cluster Details:")
-			fmt.Println("====================")
-			fmt.Printf("ID:              %s\n", kaas.ID())
-			if kaas.URI() != "" {
-				fmt.Printf("URI:             %s\n", kaas.URI())
-			}
-			fmt.Printf("Name:            %s\n", kaas.Name())
-			if r := kaas.Region(); r != "" {
-				fmt.Printf("Region:          %s\n", string(r))
-			}
-			if v := kaas.KubernetesVersion(); v != "" {
-				fmt.Printf("Kubernetes Version: %s\n", string(v))
-			}
-			if s := kaas.State(); s != "" {
-				fmt.Printf("Status:          %s\n", string(s))
-			}
-			if !kaas.CreatedAt().IsZero() {
-				fmt.Printf("Creation Date:   %s\n", kaas.CreatedAt().Format(DateLayout))
-			}
-			// CreatedBy has no wrapper accessor in sdk-go v1.0.0 — TECH_DEBT: TD-033
-			if raw := kaas.Raw(); raw != nil && raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if tags := kaas.Tags(); len(tags) > 0 {
-				fmt.Printf("Tags:            %v\n", tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("KaaS cluster not found")
-		}
-		return nil
-	},
+	RunE:  runKaaSGet,
 }
 
 var kaasListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all KaaS clusters",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromContainer().KaaS().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing KaaS clusters: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "VERSION", Width: 20},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, k := range list.Items() {
-				if k.ID() == "" {
-					continue
-				}
-				rows = append(rows, []string{
-					k.ID(),
-					k.Name(),
-					string(k.KubernetesVersion()),
-					string(k.Region()),
-					string(k.State()),
-				})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No KaaS clusters found")
-		}
-		return nil
-	},
+	RunE:  runKaaSList,
 }
 
 var kaasUpdateCmd = &cobra.Command{
 	Use:   "update [kaas-id]",
 	Short: "Update a KaaS cluster",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
-		kaas, err := client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
-		if err != nil {
-			return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
-		}
-		if kaas == nil || kaas.ID() == "" {
-			return fmt.Errorf("KaaS cluster not found")
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		kubernetesVersion, _ := cmd.Flags().GetString("kubernetes-version")
-		haFlag, _ := cmd.Flags().GetBool("ha")
-		storageMaxSize, _ := cmd.Flags().GetInt("storage-max-cumulative-volume-size")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		nodePoolName, _ := cmd.Flags().GetString("node-pool-name")
-		nodePoolNodes, _ := cmd.Flags().GetInt("node-pool-nodes")
-		nodePoolInstance, _ := cmd.Flags().GetString("node-pool-instance")
-		nodePoolZone, _ := cmd.Flags().GetString("node-pool-zone")
-		nodePoolAutoscaling, _ := cmd.Flags().GetBool("node-pool-autoscaling")
-		nodePoolMinCount, _ := cmd.Flags().GetInt("node-pool-min-count")
-		nodePoolMaxCount, _ := cmd.Flags().GetInt("node-pool-max-count")
-
-		if name != "" {
-			kaas.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			kaas.RetaggedAs(tags...)
-		}
-		if kubernetesVersion != "" {
-			kaas.WithKubernetesVersion(aruba.KubernetesVersion(kubernetesVersion))
-		}
-		if cmd.Flags().Changed("ha") && haFlag {
-			kaas.HighlyAvailable()
-		}
-		if storageMaxSize > 0 {
-			kaas.WithMaxStorageQuotaGB(int(storageMaxSize))
-		}
-		if billingPeriod != "" {
-			kaas.BilledBy(aruba.BillingPeriod(billingPeriod))
-		}
-		if nodePoolName != "" {
-			np := aruba.NewNodePool().
-				Named(nodePoolName).
-				OfInstance(aruba.NodePoolInstance(nodePoolInstance)).
-				InZone(aruba.Zone(nodePoolZone)).
-				WithCount(int(nodePoolNodes))
-			if nodePoolAutoscaling {
-				np.WithAutoscaling(int(nodePoolMinCount), int(nodePoolMaxCount))
-			}
-			kaas.ReplaceNodePools(np)
-		}
-
-		updated, err := client.FromContainer().KaaS().Update(ctx, kaas)
-		if err != nil {
-			return fmt.Errorf("updating KaaS cluster: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.ID() != "" {
-			fmt.Printf("\n%s\n", msgUpdated("KaaS cluster", kaasID))
-			fmt.Printf("ID:      %s\n", updated.ID())
-			fmt.Printf("Name:    %s\n", updated.Name())
-			if tags := updated.Tags(); len(tags) > 0 {
-				fmt.Printf("Tags:    %v\n", tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("KaaS cluster", kaasID))
-		}
-		return nil
-	},
+	RunE:  runKaaSUpdate,
 }
 
 var kaasDeleteCmd = &cobra.Command{
 	Use:   "delete [kaas-id]",
 	Short: "Delete a KaaS cluster",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kaasID := args[0]
-
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("KaaS cluster", kaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
-			if err != nil {
-				return fmt.Errorf("dry-run: KaaS cluster not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("KaaS cluster", kaasID))
-			return nil
-		}
-
-		err = client.FromContainer().KaaS().Delete(ctx, aruba.URI(kaasURI))
-		if err != nil {
-			return fmt.Errorf("deleting KaaS cluster: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("KaaS cluster", kaasID))
-		return nil
-	},
+	RunE:  runKaaSDelete,
 }
 
 var kaasConnectCmd = &cobra.Command{
 	Use:   "connect [kaas-id]",
 	Short: "Connect to a KaaS cluster and configure kubectl",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kaasID := args[0]
+	RunE:  runKaaSConnect,
+}
 
-		projectID, err := GetProjectID(cmd)
+func runKaaSCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	vpcID, _ := cmd.Flags().GetString("vpc-id")
+	subnetID, _ := cmd.Flags().GetString("subnet-id")
+	nodeCIDRAddress, _ := cmd.Flags().GetString("node-cidr-address")
+	nodeCIDRName, _ := cmd.Flags().GetString("node-cidr-name")
+	securityGroupName, _ := cmd.Flags().GetString("security-group-name")
+	kubernetesVersion, _ := cmd.Flags().GetString("kubernetes-version")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	nodePoolName, _ := cmd.Flags().GetString("node-pool-name")
+	nodePoolNodes, _ := cmd.Flags().GetInt("node-pool-nodes")
+	nodePoolInstance, _ := cmd.Flags().GetString("node-pool-instance")
+	nodePoolZone, _ := cmd.Flags().GetString("node-pool-zone")
+	nodePoolAutoscaling, _ := cmd.Flags().GetBool("node-pool-autoscaling")
+	nodePoolMinCount, _ := cmd.Flags().GetInt32("node-pool-min-count")
+	nodePoolMaxCount, _ := cmd.Flags().GetInt32("node-pool-max-count")
+	podCIDR, _ := cmd.Flags().GetString("pod-cidr")
+	ha, _ := cmd.Flags().GetBool("ha")
+	apiServerAuthorizedIPRanges, _ := cmd.Flags().GetStringSlice("api-server-authorized-ip-ranges")
+	apiServerEnablePrivateCluster, _ := cmd.Flags().GetBool("api-server-enable-private-cluster")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	nodePool := aruba.NewNodePool().
+		Named(nodePoolName).
+		OfInstance(aruba.NodePoolInstance(nodePoolInstance)).
+		InZone(aruba.Zone(nodePoolZone)).
+		WithCount(int(nodePoolNodes))
+	if nodePoolAutoscaling {
+		nodePool.WithAutoscaling(int(nodePoolMinCount), int(nodePoolMaxCount))
+	}
+
+	kaas := aruba.NewKaaS().
+		InProject(aruba.URI("/projects/"+projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		WithVPC(aruba.VPCRef(projectID, vpcID)).
+		WithSubnet(aruba.SubnetRef(projectID, vpcID, subnetID)).
+		WithNodeCIDR(nodeCIDRAddress, nodeCIDRName).
+		WithSecurityGroupName(securityGroupName).
+		WithKubernetesVersion(aruba.KubernetesVersion(kubernetesVersion)).
+		WithNodePools(nodePool).
+		RetaggedAs(tags...)
+	if ha {
+		kaas.HighlyAvailable()
+	}
+
+	if podCIDR != "" {
+		kaas.WithPodCIDR(podCIDR)
+	}
+	if billingPeriod != "" {
+		kaas.BilledBy(aruba.BillingPeriod(billingPeriod))
+	}
+	if len(apiServerAuthorizedIPRanges) > 0 || apiServerEnablePrivateCluster {
+		// TECH_DEBT: TD-033 (#131) — types.KaaSAPIServerAccessProfilePropertiesRequest must be
+		// referenced directly because the SDK provides no aruba-level constructor for
+		// this type yet. Remove the types import from this file once sdk-go exposes
+		// aruba.NewAPIServerAccessProfile() or an equivalent fluent setter.
+		profile := &types.KaaSAPIServerAccessProfilePropertiesRequest{
+			EnablePrivateCluster: apiServerEnablePrivateCluster,
+		}
+		if len(apiServerAuthorizedIPRanges) > 0 {
+			profile.AuthorizedIPRanges = &apiServerAuthorizedIPRanges
+		}
+		kaas.WithAPIServerAccessProfile(profile)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromContainer().KaaS().Create(ctx, kaas)
+	if err != nil {
+		return fmt.Errorf("creating KaaS cluster: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.ID() != "" {
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "VERSION", Width: 20},
+			{Header: "REGION", Width: 20},
+		}
+		PrintOutput(created, headers, [][]string{{
+			created.ID(),
+			created.Name(),
+			string(created.KubernetesVersion()),
+			string(created.Region()),
+		}})
+	} else {
+		fmt.Println(msgCreatedAsync("KaaS cluster", name))
+	}
+	return nil
+}
+
+func runKaaSGet(cmd *cobra.Command, args []string) error {
+	kaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
+	kaas, err := client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
+	if err != nil {
+		return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
+	}
+
+	if kaas != nil && kaas.ID() != "" {
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(kaas, nil, nil)
+			return nil
+		}
+
+		fmt.Println("\nKaaS Cluster Details:")
+		fmt.Println("====================")
+		fmt.Printf("ID:              %s\n", kaas.ID())
+		if kaas.URI() != "" {
+			fmt.Printf("URI:             %s\n", kaas.URI())
+		}
+		fmt.Printf("Name:            %s\n", kaas.Name())
+		if r := kaas.Region(); r != "" {
+			fmt.Printf("Region:          %s\n", string(r))
+		}
+		if v := kaas.KubernetesVersion(); v != "" {
+			fmt.Printf("Kubernetes Version: %s\n", string(v))
+		}
+		if s := kaas.State(); s != "" {
+			fmt.Printf("Status:          %s\n", string(s))
+		}
+		if !kaas.CreatedAt().IsZero() {
+			fmt.Printf("Creation Date:   %s\n", kaas.CreatedAt().Format(DateLayout))
+		}
+		// CreatedBy has no wrapper accessor in sdk-go v1.0.0 — TECH_DEBT: TD-033
+		if raw := kaas.Raw(); raw != nil && raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if tags := kaas.Tags(); len(tags) > 0 {
+			fmt.Printf("Tags:            %v\n", tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("KaaS cluster not found")
+	}
+	return nil
+}
+
+func runKaaSList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromContainer().KaaS().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing KaaS clusters: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "VERSION", Width: 20},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
+		}
+
+		var rows [][]string
+		for _, k := range list.Items() {
+			if k.ID() == "" {
+				continue
+			}
+			rows = append(rows, []string{
+				k.ID(),
+				k.Name(),
+				string(k.KubernetesVersion()),
+				string(k.Region()),
+				string(k.State()),
+			})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No KaaS clusters found")
+	}
+	return nil
+}
+
+func runKaaSUpdate(cmd *cobra.Command, args []string) error {
+	kaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
+	kaas, err := client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
+	if err != nil {
+		return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
+	}
+	if kaas == nil || kaas.ID() == "" {
+		return fmt.Errorf("KaaS cluster not found")
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	kubernetesVersion, _ := cmd.Flags().GetString("kubernetes-version")
+	haFlag, _ := cmd.Flags().GetBool("ha")
+	storageMaxSize, _ := cmd.Flags().GetInt("storage-max-cumulative-volume-size")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	nodePoolName, _ := cmd.Flags().GetString("node-pool-name")
+	nodePoolNodes, _ := cmd.Flags().GetInt("node-pool-nodes")
+	nodePoolInstance, _ := cmd.Flags().GetString("node-pool-instance")
+	nodePoolZone, _ := cmd.Flags().GetString("node-pool-zone")
+	nodePoolAutoscaling, _ := cmd.Flags().GetBool("node-pool-autoscaling")
+	nodePoolMinCount, _ := cmd.Flags().GetInt("node-pool-min-count")
+	nodePoolMaxCount, _ := cmd.Flags().GetInt("node-pool-max-count")
+
+	if name != "" {
+		kaas.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		kaas.RetaggedAs(tags...)
+	}
+	if kubernetesVersion != "" {
+		kaas.WithKubernetesVersion(aruba.KubernetesVersion(kubernetesVersion))
+	}
+	if cmd.Flags().Changed("ha") && haFlag {
+		kaas.HighlyAvailable()
+	}
+	if storageMaxSize > 0 {
+		kaas.WithMaxStorageQuotaGB(int(storageMaxSize))
+	}
+	if billingPeriod != "" {
+		kaas.BilledBy(aruba.BillingPeriod(billingPeriod))
+	}
+	if nodePoolName != "" {
+		np := aruba.NewNodePool().
+			Named(nodePoolName).
+			OfInstance(aruba.NodePoolInstance(nodePoolInstance)).
+			InZone(aruba.Zone(nodePoolZone)).
+			WithCount(int(nodePoolNodes))
+		if nodePoolAutoscaling {
+			np.WithAutoscaling(int(nodePoolMinCount), int(nodePoolMaxCount))
+		}
+		kaas.ReplaceNodePools(np)
+	}
+
+	updated, err := client.FromContainer().KaaS().Update(ctx, kaas)
+	if err != nil {
+		return fmt.Errorf("updating KaaS cluster: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.ID() != "" {
+		fmt.Printf("\n%s\n", msgUpdated("KaaS cluster", kaasID))
+		fmt.Printf("ID:      %s\n", updated.ID())
+		fmt.Printf("Name:    %s\n", updated.Name())
+		if tags := updated.Tags(); len(tags) > 0 {
+			fmt.Printf("Tags:    %v\n", tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("KaaS cluster", kaasID))
+	}
+	return nil
+}
+
+func runKaaSDelete(cmd *cobra.Command, args []string) error {
+	kaasID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("KaaS cluster", kaasID)
 		if err != nil {
 			return err
 		}
+		if !ok {
+			return nil
+		}
+	}
 
-		client, err := GetArubaClient()
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
 		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+			return fmt.Errorf("dry-run: KaaS cluster not found or inaccessible: %w", err)
 		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
-		kaas, err := client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
-		if err != nil {
-			return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
-		}
-		if kaas == nil || kaas.ID() == "" {
-			return fmt.Errorf("KaaS cluster not found")
-		}
-
-		kubeconfigBytes, err := kaas.DownloadKubeconfig(ctx)
-		if err != nil {
-			return fmt.Errorf("downloading kubeconfig: %w", apiErrFromV2(err))
-		}
-		if kubeconfigBytes == nil {
-			return fmt.Errorf("no kubeconfig data returned")
-		}
-
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("getting home directory: %w", apiErrFromV2(err))
-		}
-
-		kubeDir := filepath.Join(homeDir, ".kube")
-		if err = os.MkdirAll(kubeDir, 0755); err != nil {
-			return fmt.Errorf("creating .kube directory: %w", apiErrFromV2(err))
-		}
-
-		clusterName := kaasID
-		if n := kaas.Name(); n != "" {
-			clusterName = n
-		}
-
-		kubeconfigFile := filepath.Join(kubeDir, clusterName)
-		err = os.WriteFile(kubeconfigFile, kubeconfigBytes, 0600)
-		if err != nil {
-			return fmt.Errorf("writing kubeconfig file: %w", err)
-		}
-
-		configFile := filepath.Join(kubeDir, "config")
-		err = os.WriteFile(configFile, kubeconfigBytes, 0600)
-		if err != nil {
-			return fmt.Errorf("writing config file: %w", err)
-		}
-
-		kubectlCmd := exec.Command("kubectl", "cluster-info")
-		output, err := kubectlCmd.CombinedOutput()
-		if err != nil {
-			fmt.Printf("Error: kubectl cluster-info failed\n")
-			fmt.Printf("Error details: %v\n", err)
-			if len(output) > 0 {
-				fmt.Printf("kubectl output: %s\n", string(output))
-			}
-			os.Exit(1)
-		}
-
-		fmt.Println(msgAction("KaaS cluster", kaasID, "connected"))
-		fmt.Printf("Kubeconfig saved to: %s\n", kubeconfigFile)
-		fmt.Printf("Default config updated: %s\n", configFile)
+		fmt.Println(msgDryRun("KaaS cluster", kaasID))
 		return nil
-	},
+	}
+
+	err = client.FromContainer().KaaS().Delete(ctx, aruba.URI(kaasURI))
+	if err != nil {
+		return fmt.Errorf("deleting KaaS cluster: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("KaaS cluster", kaasID))
+	return nil
+}
+
+func runKaaSConnect(cmd *cobra.Command, args []string) error {
+	kaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kaasURI := "/projects/" + projectID + "/providers/Aruba.Container/kaas/" + kaasID
+	kaas, err := client.FromContainer().KaaS().Get(ctx, aruba.URI(kaasURI))
+	if err != nil {
+		return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
+	}
+	if kaas == nil || kaas.ID() == "" {
+		return fmt.Errorf("KaaS cluster not found")
+	}
+
+	kubeconfigBytes, err := kaas.DownloadKubeconfig(ctx)
+	if err != nil {
+		return fmt.Errorf("downloading kubeconfig: %w", apiErrFromV2(err))
+	}
+	if kubeconfigBytes == nil {
+		return fmt.Errorf("no kubeconfig data returned")
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home directory: %w", apiErrFromV2(err))
+	}
+
+	kubeDir := filepath.Join(homeDir, ".kube")
+	if err = os.MkdirAll(kubeDir, 0755); err != nil {
+		return fmt.Errorf("creating .kube directory: %w", apiErrFromV2(err))
+	}
+
+	clusterName := kaasID
+	if n := kaas.Name(); n != "" {
+		clusterName = n
+	}
+
+	kubeconfigFile := filepath.Join(kubeDir, clusterName)
+	err = os.WriteFile(kubeconfigFile, kubeconfigBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("writing kubeconfig file: %w", err)
+	}
+
+	configFile := filepath.Join(kubeDir, "config")
+	err = os.WriteFile(configFile, kubeconfigBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	kubectlCmd := exec.Command("kubectl", "cluster-info")
+	output, err := kubectlCmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error: kubectl cluster-info failed\n")
+		fmt.Printf("Error details: %v\n", err)
+		if len(output) > 0 {
+			fmt.Printf("kubectl output: %s\n", string(output))
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println(msgAction("KaaS cluster", kaasID, "connected"))
+	fmt.Printf("Kubeconfig saved to: %s\n", kubeconfigFile)
+	fmt.Printf("Default config updated: %s\n", configFile)
+	return nil
 }

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -31,167 +31,34 @@ var contextSetCmd = &cobra.Command{
 	Use:   "set [context-name]",
 	Short: "Set a context with a project ID",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		contextName := args[0]
-		projectID, err := cmd.Flags().GetString("project-id")
-		if err != nil {
-			return err
-		}
-
-		if projectID == "" {
-			return fmt.Errorf("--project-id is required")
-		}
-
-		// Load existing context or create new
-		ctx, err := LoadContext()
-		if err != nil {
-			// Create new context
-			ctx = &Context{
-				Contexts: make(map[string]CtxInfo),
-			}
-		}
-
-		// Add or update context
-		ctx.Contexts[contextName] = CtxInfo{
-			ProjectID: projectID,
-		}
-
-		// Save context
-		if err := SaveContext(ctx); err != nil {
-			return fmt.Errorf("saving context: %w", err)
-		}
-
-		fmt.Printf("Context '%s' set with project ID: %s\n", contextName, projectID)
-		return nil
-	},
+	RunE:  runContextSet,
 }
 
 var contextUseCmd = &cobra.Command{
 	Use:   "use [context-name]",
 	Short: "Switch to a different context",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		contextName := args[0]
-
-		// Load context
-		ctx, err := LoadContext()
-		if err != nil {
-			return fmt.Errorf("loading context: %w", err)
-		}
-
-		// Check if context exists
-		if _, exists := ctx.Contexts[contextName]; !exists {
-			available := make([]string, 0, len(ctx.Contexts))
-			for name := range ctx.Contexts {
-				available = append(available, name)
-			}
-			return fmt.Errorf("context '%s' not found; available contexts: %v", contextName, available)
-		}
-
-		// Set current context
-		ctx.CurrentContext = contextName
-
-		// Save context
-		if err := SaveContext(ctx); err != nil {
-			return fmt.Errorf("saving context: %w", err)
-		}
-
-		fmt.Printf("Switched to context '%s'\n", contextName)
-		fmt.Printf("Project ID: %s\n", ctx.Contexts[contextName].ProjectID)
-		return nil
-	},
+	RunE:  runContextUse,
 }
 
 var contextListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all contexts",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Load context
-		ctx, err := LoadContext()
-		if err != nil {
-			fmt.Println("No contexts found")
-			return nil
-		}
-
-		if len(ctx.Contexts) == 0 {
-			fmt.Println("No contexts found")
-			return nil
-		}
-
-		fmt.Println("\nContexts:")
-		fmt.Println("=========")
-		for name, info := range ctx.Contexts {
-			current := ""
-			if name == ctx.CurrentContext {
-				current = " *"
-			}
-			fmt.Printf("%-20s Project ID: %s%s\n", name, info.ProjectID, current)
-		}
-		if ctx.CurrentContext != "" {
-			fmt.Printf("\n* = current context\n")
-		}
-		return nil
-	},
+	RunE:  runContextList,
 }
 
 var contextCurrentCmd = &cobra.Command{
 	Use:   "current",
 	Short: "Show current context",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Load context
-		ctx, err := LoadContext()
-		if err != nil || ctx.CurrentContext == "" {
-			fmt.Println("No current context set")
-			return nil
-		}
-
-		info, exists := ctx.Contexts[ctx.CurrentContext]
-		if !exists {
-			fmt.Println("Current context not found")
-			return nil
-		}
-
-		fmt.Printf("Current context: %s\n", ctx.CurrentContext)
-		fmt.Printf("Project ID:      %s\n", info.ProjectID)
-		return nil
-	},
+	RunE:  runContextCurrent,
 }
 
 var contextDeleteCmd = &cobra.Command{
 	Use:   "delete [context-name]",
 	Short: "Delete a context",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		contextName := args[0]
-
-		// Load context
-		ctx, err := LoadContext()
-		if err != nil {
-			return fmt.Errorf("loading context: %w", err)
-		}
-
-		// Check if context exists
-		if _, exists := ctx.Contexts[contextName]; !exists {
-			return fmt.Errorf("context '%s' not found", contextName)
-		}
-
-		// Delete context
-		delete(ctx.Contexts, contextName)
-
-		// If this was the current context, clear it
-		if ctx.CurrentContext == contextName {
-			ctx.CurrentContext = ""
-		}
-
-		// Save context
-		if err := SaveContext(ctx); err != nil {
-			return fmt.Errorf("saving context: %w", err)
-		}
-
-		fmt.Printf("Context '%s' deleted\n", contextName)
-		return nil
-	},
+	RunE:  runContextDelete,
 }
 
 // LoadContext loads the context configuration
@@ -273,4 +140,147 @@ func init() {
 	// Flags
 	contextSetCmd.Flags().String("project-id", "", "Project ID (required)")
 	contextSetCmd.MarkFlagRequired("project-id")
+}
+
+func runContextSet(cmd *cobra.Command, args []string) error {
+	contextName := args[0]
+	projectID, err := cmd.Flags().GetString("project-id")
+	if err != nil {
+		return err
+	}
+
+	if projectID == "" {
+		return fmt.Errorf("--project-id is required")
+	}
+
+	// Load existing context or create new
+	ctx, err := LoadContext()
+	if err != nil {
+		// Create new context
+		ctx = &Context{
+			Contexts: make(map[string]CtxInfo),
+		}
+	}
+
+	// Add or update context
+	ctx.Contexts[contextName] = CtxInfo{
+		ProjectID: projectID,
+	}
+
+	// Save context
+	if err := SaveContext(ctx); err != nil {
+		return fmt.Errorf("saving context: %w", err)
+	}
+
+	fmt.Printf("Context '%s' set with project ID: %s\n", contextName, projectID)
+	return nil
+}
+
+func runContextUse(cmd *cobra.Command, args []string) error {
+	contextName := args[0]
+
+	// Load context
+	ctx, err := LoadContext()
+	if err != nil {
+		return fmt.Errorf("loading context: %w", err)
+	}
+
+	// Check if context exists
+	if _, exists := ctx.Contexts[contextName]; !exists {
+		available := make([]string, 0, len(ctx.Contexts))
+		for name := range ctx.Contexts {
+			available = append(available, name)
+		}
+		return fmt.Errorf("context '%s' not found; available contexts: %v", contextName, available)
+	}
+
+	// Set current context
+	ctx.CurrentContext = contextName
+
+	// Save context
+	if err := SaveContext(ctx); err != nil {
+		return fmt.Errorf("saving context: %w", err)
+	}
+
+	fmt.Printf("Switched to context '%s'\n", contextName)
+	fmt.Printf("Project ID: %s\n", ctx.Contexts[contextName].ProjectID)
+	return nil
+}
+
+func runContextList(cmd *cobra.Command, args []string) error {
+	// Load context
+	ctx, err := LoadContext()
+	if err != nil {
+		fmt.Println("No contexts found")
+		return nil
+	}
+
+	if len(ctx.Contexts) == 0 {
+		fmt.Println("No contexts found")
+		return nil
+	}
+
+	fmt.Println("\nContexts:")
+	fmt.Println("=========")
+	for name, info := range ctx.Contexts {
+		current := ""
+		if name == ctx.CurrentContext {
+			current = " *"
+		}
+		fmt.Printf("%-20s Project ID: %s%s\n", name, info.ProjectID, current)
+	}
+	if ctx.CurrentContext != "" {
+		fmt.Printf("\n* = current context\n")
+	}
+	return nil
+}
+
+func runContextCurrent(cmd *cobra.Command, args []string) error {
+	// Load context
+	ctx, err := LoadContext()
+	if err != nil || ctx.CurrentContext == "" {
+		fmt.Println("No current context set")
+		return nil
+	}
+
+	info, exists := ctx.Contexts[ctx.CurrentContext]
+	if !exists {
+		fmt.Println("Current context not found")
+		return nil
+	}
+
+	fmt.Printf("Current context: %s\n", ctx.CurrentContext)
+	fmt.Printf("Project ID:      %s\n", info.ProjectID)
+	return nil
+}
+
+func runContextDelete(cmd *cobra.Command, args []string) error {
+	contextName := args[0]
+
+	// Load context
+	ctx, err := LoadContext()
+	if err != nil {
+		return fmt.Errorf("loading context: %w", err)
+	}
+
+	// Check if context exists
+	if _, exists := ctx.Contexts[contextName]; !exists {
+		return fmt.Errorf("context '%s' not found", contextName)
+	}
+
+	// Delete context
+	delete(ctx.Contexts, contextName)
+
+	// If this was the current context, clear it
+	if ctx.CurrentContext == contextName {
+		ctx.CurrentContext = ""
+	}
+
+	// Save context
+	if err := SaveContext(ctx); err != nil {
+		return fmt.Errorf("saving context: %w", err)
+	}
+
+	fmt.Printf("Context '%s' deleted\n", contextName)
+	return nil
 }

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -93,253 +93,261 @@ Billing period: Hour (default), Month, or Year.`,
     --dbaas-id <dbaas-id> \
     --database-name myapp_db`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		dbaasID, _ := cmd.Flags().GetString("dbaas-id")
-		databaseName, _ := cmd.Flags().GetString("database-name")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		dbaasURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID
-		databaseURI := dbaasURI + "/databases/" + databaseName
-
-		bkp := aruba.NewDBaaSBackup().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			FromDBaaS(aruba.URI(dbaasURI)).
-			FromDatabase(aruba.URI(databaseURI)).
-			BilledBy(aruba.BillingPeriod(billingPeriod)).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromDatabase().Backups().Create(ctx, bkp)
-		if err != nil {
-			return fmt.Errorf("creating backup: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Backup", name))
-		}
-		return nil
-	},
+	RunE: runDatabaseBackupCreate,
 }
 
 var backupGetCmd = &cobra.Command{
 	Use:   "get [backup-id]",
 	Short: "Get backup details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		backup, err := client.FromDatabase().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
-		if err != nil {
-			return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
-		}
-
-		if backup != nil && backup.Raw() != nil {
-			raw := backup.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(backup, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nBackup Details:")
-			fmt.Println("==============")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Backup not found")
-		}
-		return nil
-	},
+	RunE:  runDatabaseBackupGet,
 }
 
 var backupListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all database backups",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromDatabase().Backups().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 30},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, backup := range list.Items() {
-				raw := backup.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No backups found")
-		}
-		return nil
-	},
+	RunE:  runDatabaseBackupList,
 }
 
 var backupDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id]",
 	Short: "Delete a backup",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
+	RunE:  runDatabaseBackupDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("backup", backupID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runDatabaseBackupCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	dbaasID, _ := cmd.Flags().GetString("dbaas-id")
+	databaseName, _ := cmd.Flags().GetString("database-name")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbaasURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID
+	databaseURI := dbaasURI + "/databases/" + databaseName
+
+	bkp := aruba.NewDBaaSBackup().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		FromDBaaS(aruba.URI(dbaasURI)).
+		FromDatabase(aruba.URI(databaseURI)).
+		BilledBy(aruba.BillingPeriod(billingPeriod)).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromDatabase().Backups().Create(ctx, bkp)
+	if err != nil {
+		return fmt.Errorf("creating backup: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
 		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
 		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Backup", name))
+	}
+	return nil
+}
 
-		ctx, cancel := newCtx()
-		defer cancel()
+func runDatabaseBackupGet(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromDatabase().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
-			if err != nil {
-				return fmt.Errorf("dry-run: database backup not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("database backup", backupID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	backup, err := client.FromDatabase().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
+	if err != nil {
+		return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
+	}
+
+	if backup != nil && backup.Raw() != nil {
+		raw := backup.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(backup, nil, nil)
 			return nil
 		}
 
-		err = client.FromDatabase().Backups().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
-		if err != nil {
-			return fmt.Errorf("deleting backup: %w", apiErrFromV2(err))
+		fmt.Println("\nBackup Details:")
+		fmt.Println("==============")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Backup not found")
+	}
+	return nil
+}
+
+func runDatabaseBackupList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromDatabase().Backups().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 30},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
 		}
 
-		fmt.Println(msgDeleted("Backup", backupID))
+		var rows [][]string
+		for _, backup := range list.Items() {
+			raw := backup.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No backups found")
+	}
+	return nil
+}
+
+func runDatabaseBackupDelete(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("backup", backupID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromDatabase().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
+		if err != nil {
+			return fmt.Errorf("dry-run: database backup not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("database backup", backupID))
 		return nil
-	},
+	}
+
+	err = client.FromDatabase().Backups().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
+	if err != nil {
+		return fmt.Errorf("deleting backup: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Backup", backupID))
+	return nil
 }

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -93,256 +93,266 @@ The DBaaS instance must already exist and be in a ready state.
 Use 'acloud database dbaas get <dbaas-id>' to check its status.`,
 	Example: `  acloud database dbaas database create <dbaas-id> --name myapp_db`,
 	Args:    cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
-		db := aruba.NewDatabase().InDBaaS(dbaasRef).Named(name)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromDatabase().Databases().Create(ctx, db)
-		if err != nil {
-			return fmt.Errorf("creating database: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			fmt.Printf("\n%s\n", msgCreated("Database", name))
-			fmt.Printf("Name:            %s\n", raw.Name)
-			if raw.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
-			}
-		} else {
-			fmt.Println(msgCreatedAsync("Database", name))
-		}
-		return nil
-	},
+	RunE:    runDBaaSDatabaseCreate,
 }
 
 var dbaasDatabaseGetCmd = &cobra.Command{
 	Use:   "get [dbaas-id] [database-name]",
 	Short: "Get database details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-		databaseName := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		dbURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + databaseName
-		db, err := client.FromDatabase().Databases().Get(ctx, aruba.URI(dbURI))
-		if err != nil {
-			return fmt.Errorf("getting database: %w", apiErrFromV2(err))
-		}
-
-		if db != nil && db.Raw() != nil {
-			raw := db.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(db, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nDatabase Details:")
-			fmt.Println("================")
-			fmt.Printf("Name:            %s\n", raw.Name)
-			if raw.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
-			}
-			if raw.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Database not found")
-		}
-		return nil
-	},
+	RunE:  runDBaaSDatabaseGet,
 }
 
 var dbaasDatabaseListCmd = &cobra.Command{
 	Use:   "list [dbaas-id]",
 	Short: "List all databases in DBaaS",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromDatabase().Databases().List(ctx, dbaasRef)
-		if err != nil {
-			return fmt.Errorf("listing databases: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "CREATION DATE", Width: 25},
-				{Header: "CREATED BY", Width: 30},
-			}
-
-			var rows [][]string
-			for _, db := range list.Items() {
-				raw := db.Raw()
-				if raw == nil {
-					continue
-				}
-				creationDate := ""
-				if raw.CreationDate != nil {
-					creationDate = raw.CreationDate.Format(DateLayout)
-				}
-				createdBy := ""
-				if raw.CreatedBy != nil {
-					createdBy = *raw.CreatedBy
-				}
-				rows = append(rows, []string{raw.Name, creationDate, createdBy})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No databases found")
-		}
-		return nil
-	},
+	RunE:  runDBaaSDatabaseList,
 }
 
 var dbaasDatabaseUpdateCmd = &cobra.Command{
 	Use:   "update [dbaas-id] [database-name]",
 	Short: "Update a database",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-		databaseName := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		if name == "" {
-			return fmt.Errorf("--name is required")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		dbURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + databaseName
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		db, err := client.FromDatabase().Databases().Get(ctx, aruba.URI(dbURI))
-		if err != nil {
-			return fmt.Errorf("getting database: %w", apiErrFromV2(err))
-		}
-		if db == nil || db.Raw() == nil {
-			return fmt.Errorf("database not found")
-		}
-
-		db.Named(name)
-
-		updated, err := client.FromDatabase().Databases().Update(ctx, db)
-		if err != nil {
-			return fmt.Errorf("updating database: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			fmt.Printf("\n%s\n", msgUpdated("Database", databaseName))
-			fmt.Printf("Name:            %s\n", updated.Raw().Name)
-		} else {
-			fmt.Println(msgUpdatedAsync("Database", databaseName))
-		}
-		return nil
-	},
+	RunE:  runDBaaSDatabaseUpdate,
 }
 
 var dbaasDatabaseDeleteCmd = &cobra.Command{
 	Use:   "delete [dbaas-id] [database-name]",
 	Short: "Delete a database",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-		databaseName := args[1]
+	RunE:  runDBaaSDatabaseDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete(fmt.Sprintf("database '%s' in DBaaS instance", databaseName), dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runDBaaSDatabaseCreate(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
+	db := aruba.NewDatabase().InDBaaS(dbaasRef).Named(name)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromDatabase().Databases().Create(ctx, db)
+	if err != nil {
+		return fmt.Errorf("creating database: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		fmt.Printf("\n%s\n", msgCreated("Database", name))
+		fmt.Printf("Name:            %s\n", raw.Name)
+		if raw.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
 		}
+	} else {
+		fmt.Println(msgCreatedAsync("Database", name))
+	}
+	return nil
+}
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
+func runDBaaSDatabaseGet(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+	databaseName := args[1]
 
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
 
-		dbURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + databaseName
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
 
-		ctx, cancel := newCtx()
-		defer cancel()
+	ctx, cancel := newCtx()
+	defer cancel()
+	dbURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + databaseName
+	db, err := client.FromDatabase().Databases().Get(ctx, aruba.URI(dbURI))
+	if err != nil {
+		return fmt.Errorf("getting database: %w", apiErrFromV2(err))
+	}
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromDatabase().Databases().Get(ctx, aruba.URI(dbURI))
-			if err != nil {
-				return fmt.Errorf("dry-run: database not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("database", databaseName))
+	if db != nil && db.Raw() != nil {
+		raw := db.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(db, nil, nil)
 			return nil
 		}
 
-		err = client.FromDatabase().Databases().Delete(ctx, aruba.URI(dbURI))
-		if err != nil {
-			return fmt.Errorf("deleting database: %w", apiErrFromV2(err))
+		fmt.Println("\nDatabase Details:")
+		fmt.Println("================")
+		fmt.Printf("Name:            %s\n", raw.Name)
+		if raw.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
+		}
+		if raw.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Database not found")
+	}
+	return nil
+}
+
+func runDBaaSDatabaseList(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromDatabase().Databases().List(ctx, dbaasRef)
+	if err != nil {
+		return fmt.Errorf("listing databases: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "CREATION DATE", Width: 25},
+			{Header: "CREATED BY", Width: 30},
 		}
 
-		fmt.Println(msgDeleted("Database", databaseName))
+		var rows [][]string
+		for _, db := range list.Items() {
+			raw := db.Raw()
+			if raw == nil {
+				continue
+			}
+			creationDate := ""
+			if raw.CreationDate != nil {
+				creationDate = raw.CreationDate.Format(DateLayout)
+			}
+			createdBy := ""
+			if raw.CreatedBy != nil {
+				createdBy = *raw.CreatedBy
+			}
+			rows = append(rows, []string{raw.Name, creationDate, createdBy})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No databases found")
+	}
+	return nil
+}
+
+func runDBaaSDatabaseUpdate(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+	databaseName := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	if name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + databaseName
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	db, err := client.FromDatabase().Databases().Get(ctx, aruba.URI(dbURI))
+	if err != nil {
+		return fmt.Errorf("getting database: %w", apiErrFromV2(err))
+	}
+	if db == nil || db.Raw() == nil {
+		return fmt.Errorf("database not found")
+	}
+
+	db.Named(name)
+
+	updated, err := client.FromDatabase().Databases().Update(ctx, db)
+	if err != nil {
+		return fmt.Errorf("updating database: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		fmt.Printf("\n%s\n", msgUpdated("Database", databaseName))
+		fmt.Printf("Name:            %s\n", updated.Raw().Name)
+	} else {
+		fmt.Println(msgUpdatedAsync("Database", databaseName))
+	}
+	return nil
+}
+
+func runDBaaSDatabaseDelete(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+	databaseName := args[1]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete(fmt.Sprintf("database '%s' in DBaaS instance", databaseName), dbaasID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/databases/" + databaseName
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromDatabase().Databases().Get(ctx, aruba.URI(dbURI))
+		if err != nil {
+			return fmt.Errorf("dry-run: database not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("database", databaseName))
 		return nil
-	},
+	}
+
+	err = client.FromDatabase().Databases().Delete(ctx, aruba.URI(dbURI))
+	if err != nil {
+		return fmt.Errorf("deleting database: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Database", databaseName))
+	return nil
 }

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -106,76 +106,251 @@ and users with 'acloud database dbaas user create'.`,
     --engine-id <engine-id> \
     --flavor <flavor-id>`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
+	RunE: runDBaaSCreate,
+}
+
+var dbaasGetCmd = &cobra.Command{
+	Use:   "get [dbaas-id]",
+	Short: "Get DBaaS instance details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDBaaSGet,
+}
+
+var dbaasListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all DBaaS instances",
+	Args:  cobra.NoArgs,
+	RunE:  runDBaaSList,
+}
+
+var dbaasUpdateCmd = &cobra.Command{
+	Use:   "update [dbaas-id]",
+	Short: "Update a DBaaS instance",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDBaaSUpdate,
+}
+
+var dbaasDeleteCmd = &cobra.Command{
+	Use:   "delete [dbaas-id]",
+	Short: "Delete a DBaaS instance",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDBaaSDelete,
+}
+
+func runDBaaSCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	zone, _ := cmd.Flags().GetString("zone")
+	engineID, _ := cmd.Flags().GetString("engine-id")
+	flavor, _ := cmd.Flags().GetString("flavor")
+	storageSize, _ := cmd.Flags().GetInt("storage-size")
+	vpcID, _ := cmd.Flags().GetString("vpc-id")
+	subnetID, _ := cmd.Flags().GetString("subnet-id")
+	sgID, _ := cmd.Flags().GetString("security-group-id")
+	elasticIPID, _ := cmd.Flags().GetString("elastic-ip-id")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbaas := aruba.NewDBaaS().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		InZone(aruba.Zone(zone)).
+		OfEngine(aruba.DatabaseEngine(engineID)).
+		OfFlavor(aruba.DBaaSFlavor(flavor)).
+		SizedGB(storageSize).
+		RetaggedAs(tags...)
+
+	if vpcID != "" {
+		dbaas.WithVPC(aruba.VPCRef(projectID, vpcID))
+	}
+	if subnetID != "" {
+		dbaas.WithSubnet(aruba.SubnetRef(projectID, vpcID, subnetID))
+	}
+	if sgID != "" {
+		dbaas.WithSecurityGroup(aruba.SecurityGroupRef(projectID, vpcID, sgID))
+	}
+	if elasticIPID != "" {
+		dbaas.WithElasticIP(aruba.ElasticIPRef(projectID, elasticIPID))
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromDatabase().DBaaS().Create(ctx, dbaas)
+	if err != nil {
+		return fmt.Errorf("creating DBaaS instance: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "ENGINE", Width: 20},
+			{Header: "VERSION", Width: 15},
+			{Header: "FLAVOR", Width: 20},
+			{Header: "REGION", Width: 20},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		engine := ""
+		if raw.Properties.Engine != nil && raw.Properties.Engine.Type != nil {
+			engine = *raw.Properties.Engine.Type
+		}
+		version := ""
+		if raw.Properties.Engine != nil && raw.Properties.Engine.Version != nil {
+			version = *raw.Properties.Engine.Version
+		}
+		flavorVal := ""
+		if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
+			flavorVal = *raw.Properties.Flavor.Name
+		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, engine, version, flavorVal, regionVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("DBaaS instance", name))
+	}
+	return nil
+}
+
+func runDBaaSGet(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	dbaas, err := client.FromDatabase().DBaaS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
+	if err != nil {
+		return fmt.Errorf("getting DBaaS instance: %w", apiErrFromV2(err))
+	}
+
+	if dbaas != nil && dbaas.Raw() != nil {
+		raw := dbaas.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(dbaas, nil, nil)
+			return nil
 		}
 
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		zone, _ := cmd.Flags().GetString("zone")
-		engineID, _ := cmd.Flags().GetString("engine-id")
-		flavor, _ := cmd.Flags().GetString("flavor")
-		storageSize, _ := cmd.Flags().GetInt("storage-size")
-		vpcID, _ := cmd.Flags().GetString("vpc-id")
-		subnetID, _ := cmd.Flags().GetString("subnet-id")
-		sgID, _ := cmd.Flags().GetString("security-group-id")
-		elasticIPID, _ := cmd.Flags().GetString("elastic-ip-id")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
+		fmt.Println("\nDBaaS Instance Details:")
+		fmt.Println("=======================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Properties.Engine != nil {
+			if raw.Properties.Engine.Type != nil {
+				fmt.Printf("Engine Type:     %s\n", *raw.Properties.Engine.Type)
+			}
+			if raw.Properties.Engine.Version != nil {
+				fmt.Printf("Engine Version:  %s\n", *raw.Properties.Engine.Version)
+			}
+			if raw.Properties.Engine.Name != nil {
+				fmt.Printf("Engine Name:     %s\n", *raw.Properties.Engine.Name)
+			}
+		}
+		if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
+			fmt.Printf("Flavor:          %s\n", *raw.Properties.Flavor.Name)
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("DBaaS instance not found")
+	}
+	return nil
+}
 
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+func runDBaaSList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromDatabase().DBaaS().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing DBaaS instances: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 30},
+			{Header: "ENGINE", Width: 20},
+			{Header: "VERSION", Width: 15},
+			{Header: "FLAVOR", Width: 20},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
 		}
 
-		dbaas := aruba.NewDBaaS().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			InZone(aruba.Zone(zone)).
-			OfEngine(aruba.DatabaseEngine(engineID)).
-			OfFlavor(aruba.DBaaSFlavor(flavor)).
-			SizedGB(storageSize).
-			RetaggedAs(tags...)
-
-		if vpcID != "" {
-			dbaas.WithVPC(aruba.VPCRef(projectID, vpcID))
-		}
-		if subnetID != "" {
-			dbaas.WithSubnet(aruba.SubnetRef(projectID, vpcID, subnetID))
-		}
-		if sgID != "" {
-			dbaas.WithSecurityGroup(aruba.SecurityGroupRef(projectID, vpcID, sgID))
-		}
-		if elasticIPID != "" {
-			dbaas.WithElasticIP(aruba.ElasticIPRef(projectID, elasticIPID))
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromDatabase().DBaaS().Create(ctx, dbaas)
-		if err != nil {
-			return fmt.Errorf("creating DBaaS instance: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "ENGINE", Width: 20},
-				{Header: "VERSION", Width: 15},
-				{Header: "FLAVOR", Width: 20},
-				{Header: "REGION", Width: 20},
+		var rows [][]string
+		for _, d := range list.Items() {
+			raw := d.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
 			}
 			id := ""
 			if raw.Metadata.ID != nil {
 				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
 			}
 			engine := ""
 			if raw.Properties.Engine != nil && raw.Properties.Engine.Type != nil {
@@ -185,294 +360,129 @@ and users with 'acloud database dbaas user create'.`,
 			if raw.Properties.Engine != nil && raw.Properties.Engine.Version != nil {
 				version = *raw.Properties.Engine.Version
 			}
-			flavorVal := ""
+			flavor := ""
 			if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
-				flavorVal = *raw.Properties.Flavor.Name
+				flavor = *raw.Properties.Flavor.Name
 			}
-			regionVal := ""
+			region := ""
 			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
+				region = string(raw.Metadata.LocationResponse.Value)
 			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, engine, version, flavorVal, regionVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("DBaaS instance", name))
-		}
-		return nil
-	},
-}
-
-var dbaasGetCmd = &cobra.Command{
-	Use:   "get [dbaas-id]",
-	Short: "Get DBaaS instance details",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		dbaas, err := client.FromDatabase().DBaaS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
-		if err != nil {
-			return fmt.Errorf("getting DBaaS instance: %w", apiErrFromV2(err))
-		}
-
-		if dbaas != nil && dbaas.Raw() != nil {
-			raw := dbaas.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(dbaas, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nDBaaS Instance Details:")
-			fmt.Println("=======================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Properties.Engine != nil {
-				if raw.Properties.Engine.Type != nil {
-					fmt.Printf("Engine Type:     %s\n", *raw.Properties.Engine.Type)
-				}
-				if raw.Properties.Engine.Version != nil {
-					fmt.Printf("Engine Version:  %s\n", *raw.Properties.Engine.Version)
-				}
-				if raw.Properties.Engine.Name != nil {
-					fmt.Printf("Engine Name:     %s\n", *raw.Properties.Engine.Name)
-				}
-			}
-			if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
-				fmt.Printf("Flavor:          %s\n", *raw.Properties.Flavor.Name)
-			}
+			status := ""
 			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+				status = string(*raw.Status.State)
 			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("DBaaS instance not found")
+			rows = append(rows, []string{name, id, engine, version, flavor, region, status})
 		}
-		return nil
-	},
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No DBaaS instances found")
+	}
+	return nil
 }
 
-var dbaasListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all DBaaS instances",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
+func runDBaaSUpdate(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	dbaas, err := client.FromDatabase().DBaaS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
+	if err != nil {
+		return fmt.Errorf("getting DBaaS instance: %w", apiErrFromV2(err))
+	}
+	if dbaas == nil || dbaas.Raw() == nil {
+		return fmt.Errorf("DBaaS instance not found")
+	}
+
+	if name != "" {
+		dbaas.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		dbaas.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromDatabase().DBaaS().Update(ctx, dbaas)
+	if err != nil {
+		return fmt.Errorf("updating DBaaS instance: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("DBaaS instance", dbaasID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("DBaaS instance", dbaasID))
+	}
+	return nil
+}
+
+func runDBaaSDelete(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("DBaaS instance", dbaasID)
 		if err != nil {
 			return err
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromDatabase().DBaaS().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing DBaaS instances: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 30},
-				{Header: "ENGINE", Width: 20},
-				{Header: "VERSION", Width: 15},
-				{Header: "FLAVOR", Width: 20},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, d := range list.Items() {
-				raw := d.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				engine := ""
-				if raw.Properties.Engine != nil && raw.Properties.Engine.Type != nil {
-					engine = *raw.Properties.Engine.Type
-				}
-				version := ""
-				if raw.Properties.Engine != nil && raw.Properties.Engine.Version != nil {
-					version = *raw.Properties.Engine.Version
-				}
-				flavor := ""
-				if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
-					flavor = *raw.Properties.Flavor.Name
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, engine, version, flavor, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No DBaaS instances found")
-		}
-		return nil
-	},
-}
-
-var dbaasUpdateCmd = &cobra.Command{
-	Use:   "update [dbaas-id]",
-	Short: "Update a DBaaS instance",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		dbaas, err := client.FromDatabase().DBaaS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
-		if err != nil {
-			return fmt.Errorf("getting DBaaS instance: %w", apiErrFromV2(err))
-		}
-		if dbaas == nil || dbaas.Raw() == nil {
-			return fmt.Errorf("DBaaS instance not found")
-		}
-
-		if name != "" {
-			dbaas.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			dbaas.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromDatabase().DBaaS().Update(ctx, dbaas)
-		if err != nil {
-			return fmt.Errorf("updating DBaaS instance: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("DBaaS instance", dbaasID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("DBaaS instance", dbaasID))
-		}
-		return nil
-	},
-}
-
-var dbaasDeleteCmd = &cobra.Command{
-	Use:   "delete [dbaas-id]",
-	Short: "Delete a DBaaS instance",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("DBaaS instance", dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromDatabase().DBaaS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
-			if err != nil {
-				return fmt.Errorf("dry-run: DBaaS instance not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("DBaaS instance", dbaasID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromDatabase().DBaaS().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromDatabase().DBaaS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
 		if err != nil {
-			return fmt.Errorf("deleting DBaaS instance: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: DBaaS instance not found or inaccessible: %w", err)
 		}
-
-		fmt.Println(msgDeleted("DBaaS instance", dbaasID))
+		fmt.Println(msgDryRun("DBaaS instance", dbaasID))
 		return nil
-	},
+	}
+
+	err = client.FromDatabase().DBaaS().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
+	if err != nil {
+		return fmt.Errorf("deleting DBaaS instance: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("DBaaS instance", dbaasID))
+	return nil
 }

--- a/cmd/database.dbaas.grant.go
+++ b/cmd/database.dbaas.grant.go
@@ -88,190 +88,198 @@ var dbaasGrantCreateCmd = &cobra.Command{
 Common roles: liteadmin, readonly, readwrite.`,
 	Example: `  acloud database dbaas grant create <dbaas-id> mydb --username myuser --role liteadmin`,
 	Args:    cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID, dbName := args[0], args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		username, _ := cmd.Flags().GetString("username")
-		role, _ := cmd.Flags().GetString("role")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		g := aruba.NewGrant().
-			InDatabase(databaseRef(projectID, dbaasID, dbName)).
-			ForUser(username).
-			OfRole(role)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromDatabase().Grants().Create(ctx, g)
-		if err != nil {
-			return fmt.Errorf("creating grant: %w", apiErrFromV2(err))
-		}
-
-		if created != nil {
-			fmt.Printf("\n%s\n", msgCreated("Grant", username))
-			fmt.Printf("Username:        %s\n", created.Username())
-			fmt.Printf("Role:            %s\n", created.RoleName())
-			fmt.Printf("Database:        %s\n", created.DatabaseName())
-		} else {
-			fmt.Printf("\n%s\n", msgCreatedAsync("Grant", username))
-		}
-		return nil
-	},
+	RunE:    runDBaaSGrantCreate,
 }
 
 var dbaasGrantListCmd = &cobra.Command{
 	Use:   "list [dbaas-id] [database-name]",
 	Short: "List all grants on a database",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID, dbName := args[0], args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromDatabase().Grants().List(ctx, databaseRef(projectID, dbaasID, dbName), listOpts(cmd)...)
-		if err != nil {
-			return fmt.Errorf("listing grants: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "GRANT ID", Width: 30},
-				{Header: "USERNAME", Width: 30},
-				{Header: "ROLE", Width: 20},
-				{Header: "DATABASE", Width: 25},
-			}
-			var rows [][]string
-			for _, g := range list.Items() {
-				row := []string{
-					g.ID(),
-					g.Username(),
-					g.RoleName(),
-					g.DatabaseName(),
-				}
-				rows = append(rows, row)
-			}
-			PrintOutput(nil, headers, rows)
-		} else {
-			fmt.Println("No grants found")
-		}
-		return nil
-	},
+	RunE:  runDBaaSGrantList,
 }
 
 var dbaasGrantGetCmd = &cobra.Command{
 	Use:   "get [dbaas-id] [database-name] [grant-id]",
 	Short: "Get grant details",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID, dbName, grantID := args[0], args[1], args[2]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		got, err := client.FromDatabase().Grants().Get(ctx, grantRef(projectID, dbaasID, dbName, grantID))
-		if err != nil {
-			return fmt.Errorf("getting grant: %w", apiErrFromV2(err))
-		}
-
-		if got != nil {
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(got, nil, nil)
-				return nil
-			}
-			fmt.Println("\nGrant Details:")
-			fmt.Println("==============")
-			fmt.Printf("Username:        %s\n", got.Username())
-			fmt.Printf("Role:            %s\n", got.RoleName())
-			fmt.Printf("Database:        %s\n", got.DatabaseName())
-			if t := got.CreatedAt(); !t.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", t.Format(DateLayout))
-			}
-			if s := got.CreatedBy(); s != "" {
-				fmt.Printf("Created By:      %s\n", s)
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Grant not found")
-		}
-		return nil
-	},
+	RunE:  runDBaaSGrantGet,
 }
 
 var dbaasGrantDeleteCmd = &cobra.Command{
 	Use:   "delete [dbaas-id] [database-name] [grant-id]",
 	Short: "Delete a grant",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID, dbName, grantID := args[0], args[1], args[2]
+	RunE:  runDBaaSGrantDelete,
+}
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
+func runDBaaSGrantCreate(cmd *cobra.Command, args []string) error {
+	dbaasID, dbName := args[0], args[1]
 
-		projectID, err := GetProjectID(cmd)
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	username, _ := cmd.Flags().GetString("username")
+	role, _ := cmd.Flags().GetString("role")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	g := aruba.NewGrant().
+		InDatabase(databaseRef(projectID, dbaasID, dbName)).
+		ForUser(username).
+		OfRole(role)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromDatabase().Grants().Create(ctx, g)
+	if err != nil {
+		return fmt.Errorf("creating grant: %w", apiErrFromV2(err))
+	}
+
+	if created != nil {
+		fmt.Printf("\n%s\n", msgCreated("Grant", username))
+		fmt.Printf("Username:        %s\n", created.Username())
+		fmt.Printf("Role:            %s\n", created.RoleName())
+		fmt.Printf("Database:        %s\n", created.DatabaseName())
+	} else {
+		fmt.Printf("\n%s\n", msgCreatedAsync("Grant", username))
+	}
+	return nil
+}
+
+func runDBaaSGrantList(cmd *cobra.Command, args []string) error {
+	dbaasID, dbName := args[0], args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromDatabase().Grants().List(ctx, databaseRef(projectID, dbaasID, dbName), listOpts(cmd)...)
+	if err != nil {
+		return fmt.Errorf("listing grants: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "GRANT ID", Width: 30},
+			{Header: "USERNAME", Width: 30},
+			{Header: "ROLE", Width: 20},
+			{Header: "DATABASE", Width: 25},
+		}
+		var rows [][]string
+		for _, g := range list.Items() {
+			row := []string{
+				g.ID(),
+				g.Username(),
+				g.RoleName(),
+				g.DatabaseName(),
+			}
+			rows = append(rows, row)
+		}
+		PrintOutput(nil, headers, rows)
+	} else {
+		fmt.Println("No grants found")
+	}
+	return nil
+}
+
+func runDBaaSGrantGet(cmd *cobra.Command, args []string) error {
+	dbaasID, dbName, grantID := args[0], args[1], args[2]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	got, err := client.FromDatabase().Grants().Get(ctx, grantRef(projectID, dbaasID, dbName, grantID))
+	if err != nil {
+		return fmt.Errorf("getting grant: %w", apiErrFromV2(err))
+	}
+
+	if got != nil {
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(got, nil, nil)
+			return nil
+		}
+		fmt.Println("\nGrant Details:")
+		fmt.Println("==============")
+		fmt.Printf("Username:        %s\n", got.Username())
+		fmt.Printf("Role:            %s\n", got.RoleName())
+		fmt.Printf("Database:        %s\n", got.DatabaseName())
+		if t := got.CreatedAt(); !t.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", t.Format(DateLayout))
+		}
+		if s := got.CreatedBy(); s != "" {
+			fmt.Printf("Created By:      %s\n", s)
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Grant not found")
+	}
+	return nil
+}
+
+func runDBaaSGrantDelete(cmd *cobra.Command, args []string) error {
+	dbaasID, dbName, grantID := args[0], args[1], args[2]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		if _, err := client.FromDatabase().Grants().Get(ctx, grantRef(projectID, dbaasID, dbName, grantID)); err != nil {
+			return fmt.Errorf("dry-run: grant not found or inaccessible: %w", apiErrFromV2(err))
+		}
+		fmt.Println(msgDryRun("grant", grantID))
+		return nil
+	}
+
+	if !skipConfirm {
+		ok, err := confirmDelete(fmt.Sprintf("grant '%s' on database '%s'", grantID, dbName), dbaasID)
 		if err != nil {
 			return err
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			if _, err := client.FromDatabase().Grants().Get(ctx, grantRef(projectID, dbaasID, dbName, grantID)); err != nil {
-				return fmt.Errorf("dry-run: grant not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("grant", grantID))
+		if !ok {
 			return nil
 		}
+	}
 
-		if !skipConfirm {
-			ok, err := confirmDelete(fmt.Sprintf("grant '%s' on database '%s'", grantID, dbName), dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
+	if err := client.FromDatabase().Grants().Delete(ctx, grantRef(projectID, dbaasID, dbName, grantID)); err != nil {
+		return fmt.Errorf("deleting grant: %w", apiErrFromV2(err))
+	}
 
-		if err := client.FromDatabase().Grants().Delete(ctx, grantRef(projectID, dbaasID, dbName, grantID)); err != nil {
-			return fmt.Errorf("deleting grant: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("Grant", grantID))
-		return nil
-	},
+	fmt.Println(msgDeleted("Grant", grantID))
+	return nil
 }

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -95,257 +95,267 @@ The user is granted access to the instance. Assign database-level privileges
 separately through your database client after the user is created.`,
 	Example: `  acloud database dbaas user create <dbaas-id> --username myuser --password mypassword`,
 	Args:    cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		username, _ := cmd.Flags().GetString("username")
-		password, _ := cmd.Flags().GetString("password")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
-		user := aruba.NewUser().InDBaaS(dbaasRef).WithUsername(username).WithPassword(password)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromDatabase().Users().Create(ctx, user)
-		if err != nil {
-			return fmt.Errorf("creating user: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			fmt.Printf("\n%s\n", msgCreated("User", username))
-			fmt.Printf("Username:        %s\n", raw.Username)
-			if raw.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
-			}
-		} else {
-			fmt.Println(msgCreatedAsync("User", username))
-		}
-		return nil
-	},
+	RunE:    runDBaaSUserCreate,
 }
 
 var dbaasUserGetCmd = &cobra.Command{
 	Use:   "get [dbaas-id] [username]",
 	Short: "Get user details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-		username := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		userURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username
-		u, err := client.FromDatabase().Users().Get(ctx, aruba.URI(userURI))
-		if err != nil {
-			return fmt.Errorf("getting user: %w", apiErrFromV2(err))
-		}
-
-		if u != nil && u.Raw() != nil {
-			raw := u.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(u, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nUser Details:")
-			fmt.Println("=============")
-			fmt.Printf("Username:        %s\n", raw.Username)
-			if raw.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
-			}
-			if raw.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("User not found")
-		}
-		return nil
-	},
+	RunE:  runDBaaSUserGet,
 }
 
 var dbaasUserListCmd = &cobra.Command{
 	Use:   "list [dbaas-id]",
 	Short: "List all users in DBaaS",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromDatabase().Users().List(ctx, dbaasRef)
-		if err != nil {
-			return fmt.Errorf("listing users: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "USERNAME", Width: 40},
-				{Header: "CREATION DATE", Width: 25},
-				{Header: "CREATED BY", Width: 30},
-			}
-
-			var rows [][]string
-			for _, user := range list.Items() {
-				raw := user.Raw()
-				if raw == nil {
-					continue
-				}
-				creationDate := ""
-				if raw.CreationDate != nil {
-					creationDate = raw.CreationDate.Format(DateLayout)
-				}
-				createdBy := ""
-				if raw.CreatedBy != nil {
-					createdBy = *raw.CreatedBy
-				}
-				rows = append(rows, []string{raw.Username, creationDate, createdBy})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No users found")
-		}
-		return nil
-	},
+	RunE:  runDBaaSUserList,
 }
 
 var dbaasUserUpdateCmd = &cobra.Command{
 	Use:   "update [dbaas-id] [username]",
 	Short: "Update a user (change password)",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-		username := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		password, _ := cmd.Flags().GetString("password")
-		if password == "" {
-			return fmt.Errorf("--password is required")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		userURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		u, err := client.FromDatabase().Users().Get(ctx, aruba.URI(userURI))
-		if err != nil {
-			return fmt.Errorf("getting user: %w", apiErrFromV2(err))
-		}
-		if u == nil || u.Raw() == nil {
-			return fmt.Errorf("user not found")
-		}
-
-		u.WithPassword(password)
-
-		updated, err := client.FromDatabase().Users().Update(ctx, u)
-		if err != nil {
-			return fmt.Errorf("updating user: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			fmt.Printf("\n%s\n", msgUpdated("User", username))
-			fmt.Printf("Username:        %s\n", updated.Raw().Username)
-		} else {
-			fmt.Println(msgUpdatedAsync("User", username))
-		}
-		return nil
-	},
+	RunE:  runDBaaSUserUpdate,
 }
 
 var dbaasUserDeleteCmd = &cobra.Command{
 	Use:   "delete [dbaas-id] [username]",
 	Short: "Delete a user",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dbaasID := args[0]
-		username := args[1]
+	RunE:  runDBaaSUserDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete(fmt.Sprintf("user '%s' in DBaaS instance", username), dbaasID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runDBaaSUserCreate(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	username, _ := cmd.Flags().GetString("username")
+	password, _ := cmd.Flags().GetString("password")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
+	user := aruba.NewUser().InDBaaS(dbaasRef).WithUsername(username).WithPassword(password)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromDatabase().Users().Create(ctx, user)
+	if err != nil {
+		return fmt.Errorf("creating user: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		fmt.Printf("\n%s\n", msgCreated("User", username))
+		fmt.Printf("Username:        %s\n", raw.Username)
+		if raw.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
 		}
+	} else {
+		fmt.Println(msgCreatedAsync("User", username))
+	}
+	return nil
+}
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
+func runDBaaSUserGet(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+	username := args[1]
 
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
 
-		userURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
 
-		ctx, cancel := newCtx()
-		defer cancel()
+	ctx, cancel := newCtx()
+	defer cancel()
+	userURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username
+	u, err := client.FromDatabase().Users().Get(ctx, aruba.URI(userURI))
+	if err != nil {
+		return fmt.Errorf("getting user: %w", apiErrFromV2(err))
+	}
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromDatabase().Users().Get(ctx, aruba.URI(userURI))
-			if err != nil {
-				return fmt.Errorf("dry-run: database user not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("database user", username))
+	if u != nil && u.Raw() != nil {
+		raw := u.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(u, nil, nil)
 			return nil
 		}
 
-		err = client.FromDatabase().Users().Delete(ctx, aruba.URI(userURI))
-		if err != nil {
-			return fmt.Errorf("deleting user: %w", apiErrFromV2(err))
+		fmt.Println("\nUser Details:")
+		fmt.Println("=============")
+		fmt.Printf("Username:        %s\n", raw.Username)
+		if raw.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
+		}
+		if raw.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("User not found")
+	}
+	return nil
+}
+
+func runDBaaSUserList(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	dbaasRef := aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromDatabase().Users().List(ctx, dbaasRef)
+	if err != nil {
+		return fmt.Errorf("listing users: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "USERNAME", Width: 40},
+			{Header: "CREATION DATE", Width: 25},
+			{Header: "CREATED BY", Width: 30},
 		}
 
-		fmt.Println(msgDeleted("User", username))
+		var rows [][]string
+		for _, user := range list.Items() {
+			raw := user.Raw()
+			if raw == nil {
+				continue
+			}
+			creationDate := ""
+			if raw.CreationDate != nil {
+				creationDate = raw.CreationDate.Format(DateLayout)
+			}
+			createdBy := ""
+			if raw.CreatedBy != nil {
+				createdBy = *raw.CreatedBy
+			}
+			rows = append(rows, []string{raw.Username, creationDate, createdBy})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No users found")
+	}
+	return nil
+}
+
+func runDBaaSUserUpdate(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+	username := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	password, _ := cmd.Flags().GetString("password")
+	if password == "" {
+		return fmt.Errorf("--password is required")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	userURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	u, err := client.FromDatabase().Users().Get(ctx, aruba.URI(userURI))
+	if err != nil {
+		return fmt.Errorf("getting user: %w", apiErrFromV2(err))
+	}
+	if u == nil || u.Raw() == nil {
+		return fmt.Errorf("user not found")
+	}
+
+	u.WithPassword(password)
+
+	updated, err := client.FromDatabase().Users().Update(ctx, u)
+	if err != nil {
+		return fmt.Errorf("updating user: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		fmt.Printf("\n%s\n", msgUpdated("User", username))
+		fmt.Printf("Username:        %s\n", updated.Raw().Username)
+	} else {
+		fmt.Println(msgUpdatedAsync("User", username))
+	}
+	return nil
+}
+
+func runDBaaSUserDelete(cmd *cobra.Command, args []string) error {
+	dbaasID := args[0]
+	username := args[1]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete(fmt.Sprintf("user '%s' in DBaaS instance", username), dbaasID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	userURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID + "/users/" + username
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromDatabase().Users().Get(ctx, aruba.URI(userURI))
+		if err != nil {
+			return fmt.Errorf("dry-run: database user not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("database user", username))
 		return nil
-	},
+	}
+
+	err = client.FromDatabase().Users().Delete(ctx, aruba.URI(userURI))
+	if err != nil {
+		return fmt.Errorf("deleting user: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("User", username))
+	return nil
 }

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -92,320 +92,330 @@ Use 'acloud context set-project' to switch the active project at any time.`,
 	Example: `  acloud management project create --name my-project --description "Production workloads"
   acloud management project create --name dev-project --default`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get flags
-		name, _ := cmd.Flags().GetString("name")
-		description, _ := cmd.Flags().GetString("description")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		setDefault, _ := cmd.Flags().GetBool("default")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		// Get SDK client
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		// Build the create request
-		proj := aruba.NewProject().Named(name).RetaggedAs(tags...)
-		if description != "" {
-			proj.DescribedAs(description)
-		}
-		if setDefault {
-			proj.AsDefault()
-		}
-
-		// Debug output if verbose
-		if verbose {
-			fmt.Println("Creating project with the following parameters:")
-			fmt.Printf("  Name:        %s\n", name)
-			if description != "" {
-				fmt.Printf("  Description: %s\n", description)
-			}
-			fmt.Printf("  Default:     %t\n", setDefault)
-			if len(tags) > 0 {
-				fmt.Printf("  Tags:        %v\n", tags)
-			}
-			fmt.Println()
-		}
-
-		// Create the project using the SDK
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromProject().Create(ctx, proj)
-		if err != nil {
-			return fmt.Errorf("creating project: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.ID() != "" {
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "DEFAULT", Width: 10},
-			}
-			defaultVal := "No"
-			if created.IsDefault() {
-				defaultVal = "Yes"
-			}
-			row := []string{created.ID(), created.Name(), defaultVal}
-			PrintOutput(created, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("Project", name))
-		}
-		return nil
-	},
+	RunE: runProjectCreate,
 }
 
 var projectGetCmd = &cobra.Command{
 	Use:   "get [project-id]",
 	Short: "Get project details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID := args[0]
-
-		// Get SDK client
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		// Get project details using the SDK
-		ctx, cancel := newCtx()
-		defer cancel()
-		p, err := client.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("getting project: %w", apiErrFromV2(err))
-		}
-
-		if p != nil && p.ID() != "" {
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(p, nil, nil)
-				return nil
-			}
-
-			// Display project details
-			fmt.Println("\nProject Details:")
-			fmt.Println("================")
-
-			fmt.Printf("ID:              %s\n", p.ID())
-			fmt.Printf("Name:            %s\n", p.Name())
-
-			if p.Description() != "" {
-				fmt.Printf("Description:     %s\n", p.Description())
-			}
-
-			fmt.Printf("Default:         %t\n", p.IsDefault())
-
-			if !p.CreatedAt().IsZero() {
-				fmt.Printf("Creation Date:   %s\n", p.CreatedAt().Format(DateLayout))
-			}
-			if !p.UpdatedAt().IsZero() {
-				fmt.Printf("Update Date:     %s\n", p.UpdatedAt().Format(DateLayout))
-			}
-			// CreatedBy / UpdatedBy have no wrapper accessors in sdk-go v1.0.0. TECH_DEBT: TD-033 (#131)
-			// See https://github.com/Arubacloud/acloud-cli/issues/131
-			if raw := p.Raw(); raw != nil {
-				if raw.Metadata.CreatedBy != nil {
-					fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-				}
-				if raw.Metadata.UpdatedBy != nil {
-					fmt.Printf("Updated By:      %s\n", *raw.Metadata.UpdatedBy)
-				}
-			}
-
-			tags := p.Tags()
-			if len(tags) > 0 {
-				fmt.Printf("Tags:            %v\n", tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-
-			fmt.Println()
-		} else {
-			fmt.Println("Project not found")
-		}
-		return nil
-	},
+	RunE:  runProjectGet,
 }
 
 var projectUpdateCmd = &cobra.Command{
 	Use:   "update [project-id]",
 	Short: "Update a project (description and/or tags only)",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID := args[0]
-
-		// Get flags
-		description, _ := cmd.Flags().GetString("description")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		// At least one field must be provided
-		if description == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --description or --tags must be provided")
-		}
-
-		// Get SDK client
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		// First, get the current project details to preserve existing values.
-		// projectWrapper calls Get and normalises any API error via apiErrFromV2.
-		ctx, cancel := newCtx()
-		defer cancel()
-		p, err := client.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("fetching current project: %w", apiErrFromV2(err))
-		}
-
-		if p == nil || p.ID() == "" {
-			return fmt.Errorf("project not found or no data returned")
-		}
-
-		// Apply updates
-		if description != "" {
-			p.DescribedAs(description)
-		}
-		if cmd.Flags().Changed("tags") {
-			p.RetaggedAs(tags...)
-		}
-
-		// Update the project using the SDK
-		updated, err := client.FromProject().Update(ctx, p)
-		if err != nil {
-			return fmt.Errorf("updating project: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.ID() != "" {
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "DEFAULT", Width: 10},
-			}
-			defaultVal := "No"
-			if updated.IsDefault() {
-				defaultVal = "Yes"
-			}
-			row := []string{updated.ID(), updated.Name(), defaultVal}
-			PrintOutput(updated, headers, [][]string{row})
-		} else {
-			fmt.Println(msgUpdatedAsync("Project", projectID))
-		}
-		return nil
-	},
+	RunE:  runProjectUpdate,
 }
 
 var projectDeleteCmd = &cobra.Command{
 	Use:   "delete [project-id]",
 	Short: "Delete a project",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID := args[0]
-
-		// Get confirmation flag
-		confirm, _ := cmd.Flags().GetBool("yes")
-
-		// If not confirmed, ask for confirmation
-		if !confirm {
-			ok, err := confirmDelete("project", projectID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		// Get SDK client
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		projectRef := aruba.URI("/projects/" + projectID)
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromProject().Get(ctx, projectRef)
-			if err != nil {
-				return fmt.Errorf("dry-run: project not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("project", projectID))
-			return nil
-		}
-
-		// Delete the project using the SDK
-		err = client.FromProject().Delete(ctx, projectRef)
-		if err != nil {
-			return fmt.Errorf("deleting project: %w", apiErrFromV2(err))
-		}
-
-		headers := []TableColumn{
-			{Header: "ID", Width: 30},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{projectID, status}
-		PrintOutput(result, headers, [][]string{{projectID, status}})
-		return nil
-	},
+	RunE:  runProjectDelete,
 }
 
 var projectListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all projects",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get SDK client
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+	RunE:  runProjectList,
+}
+
+func runProjectCreate(cmd *cobra.Command, args []string) error {
+	// Get flags
+	name, _ := cmd.Flags().GetString("name")
+	description, _ := cmd.Flags().GetString("description")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	setDefault, _ := cmd.Flags().GetBool("default")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	// Get SDK client
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// Build the create request
+	proj := aruba.NewProject().Named(name).RetaggedAs(tags...)
+	if description != "" {
+		proj.DescribedAs(description)
+	}
+	if setDefault {
+		proj.AsDefault()
+	}
+
+	// Debug output if verbose
+	if verbose {
+		fmt.Println("Creating project with the following parameters:")
+		fmt.Printf("  Name:        %s\n", name)
+		if description != "" {
+			fmt.Printf("  Description: %s\n", description)
+		}
+		fmt.Printf("  Default:     %t\n", setDefault)
+		if len(tags) > 0 {
+			fmt.Printf("  Tags:        %v\n", tags)
+		}
+		fmt.Println()
+	}
+
+	// Create the project using the SDK
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromProject().Create(ctx, proj)
+	if err != nil {
+		return fmt.Errorf("creating project: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.ID() != "" {
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "DEFAULT", Width: 10},
+		}
+		defaultVal := "No"
+		if created.IsDefault() {
+			defaultVal = "Yes"
+		}
+		row := []string{created.ID(), created.Name(), defaultVal}
+		PrintOutput(created, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("Project", name))
+	}
+	return nil
+}
+
+func runProjectGet(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+
+	// Get SDK client
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// Get project details using the SDK
+	ctx, cancel := newCtx()
+	defer cancel()
+	p, err := client.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("getting project: %w", apiErrFromV2(err))
+	}
+
+	if p != nil && p.ID() != "" {
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(p, nil, nil)
+			return nil
 		}
 
-		// List projects using the SDK
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromProject().List(ctx)
-		if err != nil {
-			return fmt.Errorf("listing projects: %w", apiErrFromV2(err))
+		// Display project details
+		fmt.Println("\nProject Details:")
+		fmt.Println("================")
+
+		fmt.Printf("ID:              %s\n", p.ID())
+		fmt.Printf("Name:            %s\n", p.Name())
+
+		if p.Description() != "" {
+			fmt.Printf("Description:     %s\n", p.Description())
 		}
 
-		if list != nil && len(list.Items()) > 0 {
-			// Define table columns
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "ID", Width: 30},
-				{Header: "CREATION DATE", Width: 15},
+		fmt.Printf("Default:         %t\n", p.IsDefault())
+
+		if !p.CreatedAt().IsZero() {
+			fmt.Printf("Creation Date:   %s\n", p.CreatedAt().Format(DateLayout))
+		}
+		if !p.UpdatedAt().IsZero() {
+			fmt.Printf("Update Date:     %s\n", p.UpdatedAt().Format(DateLayout))
+		}
+		// CreatedBy / UpdatedBy have no wrapper accessors in sdk-go v1.0.0. TECH_DEBT: TD-033 (#131)
+		// See https://github.com/Arubacloud/acloud-cli/issues/131
+		if raw := p.Raw(); raw != nil {
+			if raw.Metadata.CreatedBy != nil {
+				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
 			}
-
-			// Build rows
-			var rows [][]string
-			for _, p := range list.Items() {
-				name := p.Name()
-				id := p.ID()
-
-				// Format creation date as dd-mm-yyyy
-				creationDate := "N/A"
-				if !p.CreatedAt().IsZero() {
-					creationDate = p.CreatedAt().Format("02-01-2006")
-				}
-
-				rows = append(rows, []string{name, id, creationDate})
+			if raw.Metadata.UpdatedBy != nil {
+				fmt.Printf("Updated By:      %s\n", *raw.Metadata.UpdatedBy)
 			}
+		}
 
-			// Print the table
-			PrintOutput(list, headers, rows)
+		tags := p.Tags()
+		if len(tags) > 0 {
+			fmt.Printf("Tags:            %v\n", tags)
 		} else {
-			fmt.Println("No projects found")
+			fmt.Printf("Tags:            []\n")
 		}
+
+		fmt.Println()
+	} else {
+		fmt.Println("Project not found")
+	}
+	return nil
+}
+
+func runProjectUpdate(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+
+	// Get flags
+	description, _ := cmd.Flags().GetString("description")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	// At least one field must be provided
+	if description == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --description or --tags must be provided")
+	}
+
+	// Get SDK client
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// First, get the current project details to preserve existing values.
+	// projectWrapper calls Get and normalises any API error via apiErrFromV2.
+	ctx, cancel := newCtx()
+	defer cancel()
+	p, err := client.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("fetching current project: %w", apiErrFromV2(err))
+	}
+
+	if p == nil || p.ID() == "" {
+		return fmt.Errorf("project not found or no data returned")
+	}
+
+	// Apply updates
+	if description != "" {
+		p.DescribedAs(description)
+	}
+	if cmd.Flags().Changed("tags") {
+		p.RetaggedAs(tags...)
+	}
+
+	// Update the project using the SDK
+	updated, err := client.FromProject().Update(ctx, p)
+	if err != nil {
+		return fmt.Errorf("updating project: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.ID() != "" {
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "DEFAULT", Width: 10},
+		}
+		defaultVal := "No"
+		if updated.IsDefault() {
+			defaultVal = "Yes"
+		}
+		row := []string{updated.ID(), updated.Name(), defaultVal}
+		PrintOutput(updated, headers, [][]string{row})
+	} else {
+		fmt.Println(msgUpdatedAsync("Project", projectID))
+	}
+	return nil
+}
+
+func runProjectDelete(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+
+	// Get confirmation flag
+	confirm, _ := cmd.Flags().GetBool("yes")
+
+	// If not confirmed, ask for confirmation
+	if !confirm {
+		ok, err := confirmDelete("project", projectID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	// Get SDK client
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	projectRef := aruba.URI("/projects/" + projectID)
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromProject().Get(ctx, projectRef)
+		if err != nil {
+			return fmt.Errorf("dry-run: project not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("project", projectID))
 		return nil
-	},
+	}
+
+	// Delete the project using the SDK
+	err = client.FromProject().Delete(ctx, projectRef)
+	if err != nil {
+		return fmt.Errorf("deleting project: %w", apiErrFromV2(err))
+	}
+
+	headers := []TableColumn{
+		{Header: "ID", Width: 30},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{projectID, status}
+	PrintOutput(result, headers, [][]string{{projectID, status}})
+	return nil
+}
+
+func runProjectList(cmd *cobra.Command, args []string) error {
+	// Get SDK client
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// List projects using the SDK
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromProject().List(ctx)
+	if err != nil {
+		return fmt.Errorf("listing projects: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		// Define table columns
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "ID", Width: 30},
+			{Header: "CREATION DATE", Width: 15},
+		}
+
+		// Build rows
+		var rows [][]string
+		for _, p := range list.Items() {
+			name := p.Name()
+			id := p.ID()
+
+			// Format creation date as dd-mm-yyyy
+			creationDate := "N/A"
+			if !p.CreatedAt().IsZero() {
+				creationDate = p.CreatedAt().Format("02-01-2006")
+			}
+
+			rows = append(rows, []string{name, id, creationDate})
+		}
+
+		// Print the table
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No projects found")
+	}
+	return nil
 }

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -92,312 +92,322 @@ Billing period: Hour (default), Month, or Year.`,
 	Example: `  acloud network elasticip create --name my-eip --region IT-BG
   acloud network elasticip create --name prod-eip --region IT-BG --billing-period Month`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		eip := aruba.NewElasticIP().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			BilledBy(aruba.BillingPeriod(billingPeriod)).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromNetwork().ElasticIPs().Create(ctx, eip)
-		if err != nil {
-			return fmt.Errorf("creating Elastic IP: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			fmt.Printf("\n%s\n", msgCreated("Elastic IP", name))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			if raw.Properties.Address != nil {
-				fmt.Printf("Address: %s\n", *raw.Properties.Address)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgCreatedAsync("Elastic IP", name))
-		}
-		return nil
-	},
+	RunE: runElasticIPCreate,
 }
 
 var elasticipListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all Elastic IPs",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().ElasticIPs().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing Elastic IPs: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "ADDRESS", Width: 16},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, eip := range list.Items() {
-				raw := eip.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				address := ""
-				if raw.Properties.Address != nil {
-					address = *raw.Properties.Address
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, address, status})
-			}
-
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No Elastic IPs found")
-		}
-		return nil
-	},
+	RunE:  runElasticIPList,
 }
 
 var elasticipGetCmd = &cobra.Command{
 	Use:   "get <elastic-ip-id>",
 	Short: "Get Elastic IP details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		eipID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, eipID))
-		if err != nil {
-			return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
-		}
-
-		if eip != nil && eip.Raw() != nil {
-			raw := eip.Raw()
-
-			fmt.Println("\nElastic IP Details:")
-			fmt.Println("===================")
-
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-			if raw.Properties.Address != nil {
-				fmt.Printf("Address:         %s\n", *raw.Properties.Address)
-			}
-			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
-			}
-			fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		}
-		return nil
-	},
+	RunE:  runElasticIPGet,
 }
 
 var elasticipUpdateCmd = &cobra.Command{
 	Use:   "update <elastic-ip-id>",
 	Short: "Update an Elastic IP",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		eipID := args[0]
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, eipID))
-		if err != nil {
-			return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
-		}
-
-		if eip == nil || eip.Raw() == nil {
-			return fmt.Errorf("Elastic IP not found")
-		}
-
-		if eip.Raw().Status.State != nil && *eip.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update Elastic IP while it is in 'InCreation' state. Please wait until the Elastic IP is fully created")
-		}
-
-		if name != "" {
-			eip.Named(name)
-		}
-		if len(tags) > 0 {
-			eip.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromNetwork().ElasticIPs().Update(ctx, eip)
-		if err != nil {
-			return fmt.Errorf("updating Elastic IP: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Elastic IP", eipID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Elastic IP", eipID))
-		}
-		return nil
-	},
+	RunE:  runElasticIPUpdate,
 }
 
 var elasticipDeleteCmd = &cobra.Command{
 	Use:   "delete <elastic-ip-id>",
 	Short: "Delete an Elastic IP",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		eipID := args[0]
+	RunE:  runElasticIPDelete,
+}
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
+func runElasticIPCreate(cmd *cobra.Command, args []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
 
-		if !skipConfirm {
-			ok, err := confirmDelete("Elastic IP", eipID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	eip := aruba.NewElasticIP().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		BilledBy(aruba.BillingPeriod(billingPeriod)).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromNetwork().ElasticIPs().Create(ctx, eip)
+	if err != nil {
+		return fmt.Errorf("creating Elastic IP: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		fmt.Printf("\n%s\n", msgCreated("Elastic IP", name))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
+		}
+		if raw.Properties.Address != nil {
+			fmt.Printf("Address: %s\n", *raw.Properties.Address)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgCreatedAsync("Elastic IP", name))
+	}
+	return nil
+}
+
+func runElasticIPList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().ElasticIPs().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing Elastic IPs: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "ADDRESS", Width: 16},
+			{Header: "STATUS", Width: 15},
 		}
 
-		projectID, err := GetProjectID(cmd)
+		var rows [][]string
+		for _, eip := range list.Items() {
+			raw := eip.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			address := ""
+			if raw.Properties.Address != nil {
+				address = *raw.Properties.Address
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, address, status})
+		}
+
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No Elastic IPs found")
+	}
+	return nil
+}
+
+func runElasticIPGet(cmd *cobra.Command, args []string) error {
+	eipID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, eipID))
+	if err != nil {
+		return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
+	}
+
+	if eip != nil && eip.Raw() != nil {
+		raw := eip.Raw()
+
+		fmt.Println("\nElastic IP Details:")
+		fmt.Println("===================")
+
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+		if raw.Properties.Address != nil {
+			fmt.Printf("Address:         %s\n", *raw.Properties.Address)
+		}
+		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+			fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
+		}
+		fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	}
+	return nil
+}
+
+func runElasticIPUpdate(cmd *cobra.Command, args []string) error {
+	eipID := args[0]
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	eip, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, eipID))
+	if err != nil {
+		return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
+	}
+
+	if eip == nil || eip.Raw() == nil {
+		return fmt.Errorf("Elastic IP not found")
+	}
+
+	if eip.Raw().Status.State != nil && *eip.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update Elastic IP while it is in 'InCreation' state. Please wait until the Elastic IP is fully created")
+	}
+
+	if name != "" {
+		eip.Named(name)
+	}
+	if len(tags) > 0 {
+		eip.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromNetwork().ElasticIPs().Update(ctx, eip)
+	if err != nil {
+		return fmt.Errorf("updating Elastic IP: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Elastic IP", eipID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Elastic IP", eipID))
+	}
+	return nil
+}
+
+func runElasticIPDelete(cmd *cobra.Command, args []string) error {
+	eipID := args[0]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+
+	if !skipConfirm {
+		ok, err := confirmDelete("Elastic IP", eipID)
 		if err != nil {
 			return err
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, eipID))
-			if err != nil {
-				return fmt.Errorf("dry-run: elastic IP not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("elastic IP", eipID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().ElasticIPs().Delete(ctx, aruba.ElasticIPRef(projectID, eipID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(projectID, eipID))
 		if err != nil {
-			return fmt.Errorf("deleting Elastic IP: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: elastic IP not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		fmt.Println(msgDeleted("Elastic IP", eipID))
+		fmt.Println(msgDryRun("elastic IP", eipID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().ElasticIPs().Delete(ctx, aruba.ElasticIPRef(projectID, eipID))
+	if err != nil {
+		return fmt.Errorf("deleting Elastic IP: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Elastic IP", eipID))
+	return nil
 }

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -73,135 +73,139 @@ var loadbalancerListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all Load Balancers",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().LoadBalancers().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing Load Balancers: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "ADDRESS", Width: 16},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, lb := range list.Items() {
-				raw := lb.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				address := ""
-				if raw.Properties.Address != nil {
-					address = *raw.Properties.Address
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, address, status})
-			}
-
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No Load Balancers found")
-		}
-		return nil
-	},
+	RunE:  runLoadBalancerList,
 }
 
 var loadbalancerGetCmd = &cobra.Command{
 	Use:   "get <loadbalancer-id>",
 	Short: "Get Load Balancer details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		lbID := args[0]
+	RunE:  runLoadBalancerGet,
+}
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
+func runLoadBalancerList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().LoadBalancers().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing Load Balancers: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "ADDRESS", Width: 16},
+			{Header: "STATUS", Width: 15},
 		}
 
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		lb, err := client.FromNetwork().LoadBalancers().Get(ctx, aruba.LoadBalancerRef(projectID, lbID))
-		if err != nil {
-			return fmt.Errorf("getting Load Balancer details: %w", apiErrFromV2(err))
-		}
-
-		if lb != nil && lb.Raw() != nil {
+		var rows [][]string
+		for _, lb := range list.Items() {
 			raw := lb.Raw()
-
-			fmt.Println("\nLoad Balancer Details:")
-			fmt.Println("======================")
-
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+			if raw == nil {
+				continue
 			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
+			name := ""
 			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+				name = *raw.Metadata.Name
 			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			address := ""
 			if raw.Properties.Address != nil {
-				fmt.Printf("Address:         %s\n", *raw.Properties.Address)
+				address = *raw.Properties.Address
 			}
-			if raw.Properties.VPC != nil && raw.Properties.VPC.URI != "" {
-				fmt.Printf("VPC:             %s\n", raw.Properties.VPC.URI)
-			}
-
-			fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
-
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-
+			status := ""
 			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
+				status = string(*raw.Status.State)
 			}
+			rows = append(rows, []string{name, id, region, address, status})
 		}
-		return nil
-	},
+
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No Load Balancers found")
+	}
+	return nil
+}
+
+func runLoadBalancerGet(cmd *cobra.Command, args []string) error {
+	lbID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	lb, err := client.FromNetwork().LoadBalancers().Get(ctx, aruba.LoadBalancerRef(projectID, lbID))
+	if err != nil {
+		return fmt.Errorf("getting Load Balancer details: %w", apiErrFromV2(err))
+	}
+
+	if lb != nil && lb.Raw() != nil {
+		raw := lb.Raw()
+
+		fmt.Println("\nLoad Balancer Details:")
+		fmt.Println("======================")
+
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Properties.Address != nil {
+			fmt.Printf("Address:         %s\n", *raw.Properties.Address)
+		}
+		if raw.Properties.VPC != nil && raw.Properties.VPC.URI != "" {
+			fmt.Printf("VPC:             %s\n", raw.Properties.VPC.URI)
+		}
+
+		fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
+
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	}
+	return nil
 }

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -57,306 +57,316 @@ after the group is created.`,
 	Example: `  acloud network securitygroup create <vpc-id> --name web-sg --region IT-BG
   acloud network securitygroup create <vpc-id> --name db-sg --region IT-BG --tags tier=db`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		sg := aruba.NewSecurityGroup().
-			InVPC(aruba.VPCRef(projectID, vpcID)).
-			Named(name).
-			RetaggedAs(tags...)
-
-		resp, err := client.FromNetwork().SecurityGroups().Create(ctx, sg)
-		if err != nil {
-			return fmt.Errorf("creating security group: %w", apiErrFromV2(err))
-		}
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{name, id, region, status}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("Security group", name))
-		}
-		return nil
-	},
+	RunE: runSecurityGroupCreate,
 }
 
 var securitygroupGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [securitygroup-id]",
 	Short: "Get security group details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		sgID := args[1]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		sg, err := client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
-		if err != nil {
-			return fmt.Errorf("getting security group: %w", apiErrFromV2(err))
-		}
-		if sg != nil && sg.Raw() != nil {
-			raw := sg.Raw()
-			fmt.Println("\nSecurity Group Details:")
-			fmt.Println("======================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("Security group not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runSecurityGroupGet,
 }
 
 var securitygroupListCmd = &cobra.Command{
 	Use:   "list [vpc-id]",
 	Short: "List security groups for a VPC",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().SecurityGroups().List(ctx, aruba.VPCRef(projectID, vpcID))
-		if err != nil {
-			return fmt.Errorf("listing security groups: %w", apiErrFromV2(err))
-		}
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, sg := range list.Items() {
-				raw := sg.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No security groups found.")
-		}
-		return nil
-	},
+	RunE:  runSecurityGroupList,
 }
 
 var securitygroupUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [securitygroup-id]",
 	Short: "Update a security group",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		sgID := args[1]
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		sg, err := client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
-		if err != nil || sg == nil || sg.Raw() == nil {
-			return fmt.Errorf("fetching current security group: %w", apiErrFromV2(err))
-		}
-
-		if sg.Raw().Status.State != nil && *sg.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update security group while it is in 'InCreation' state. Please wait until the security group is fully created")
-		}
-
-		if name != "" {
-			sg.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			sg.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromNetwork().SecurityGroups().Update(ctx, sg)
-		if err != nil {
-			return fmt.Errorf("updating security group: %w", apiErrFromV2(err))
-		}
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			updateRegion := ""
-			if raw.Metadata.LocationResponse != nil {
-				updateRegion = string(raw.Metadata.LocationResponse.Value)
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{nameVal, id, updateRegion, status}
-			PrintOutput(updated, headers, [][]string{row})
-		} else {
-			fmt.Println(msgUpdatedAsync("Security group", sgID))
-		}
-		return nil
-	},
+	RunE:  runSecurityGroupUpdate,
 }
 
 var securitygroupDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [securitygroup-id]",
 	Short: "Delete a security group",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		sgID := args[1]
+	RunE:  runSecurityGroupDelete,
+}
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("security group", sgID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runSecurityGroupCreate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	sg := aruba.NewSecurityGroup().
+		InVPC(aruba.VPCRef(projectID, vpcID)).
+		Named(name).
+		RetaggedAs(tags...)
+
+	resp, err := client.FromNetwork().SecurityGroups().Create(ctx, sg)
+	if err != nil {
+		return fmt.Errorf("creating security group: %w", apiErrFromV2(err))
+	}
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "STATUS", Width: 15},
 		}
+		region := ""
+		if raw.Metadata.LocationResponse != nil {
+			region = string(raw.Metadata.LocationResponse.Value)
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{name, id, region, status}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("Security group", name))
+	}
+	return nil
+}
 
-		projectID, err := GetProjectID(cmd)
+func runSecurityGroupGet(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	sgID := args[1]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	sg, err := client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
+	if err != nil {
+		return fmt.Errorf("getting security group: %w", apiErrFromV2(err))
+	}
+	if sg != nil && sg.Raw() != nil {
+		raw := sg.Raw()
+		fmt.Println("\nSecurity Group Details:")
+		fmt.Println("======================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("Security group not found or no data returned.")
+	}
+	return nil
+}
+
+func runSecurityGroupList(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().SecurityGroups().List(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return fmt.Errorf("listing security groups: %w", apiErrFromV2(err))
+	}
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, sg := range list.Items() {
+			raw := sg.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No security groups found.")
+	}
+	return nil
+}
+
+func runSecurityGroupUpdate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	sgID := args[1]
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	sg, err := client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
+	if err != nil || sg == nil || sg.Raw() == nil {
+		return fmt.Errorf("fetching current security group: %w", apiErrFromV2(err))
+	}
+
+	if sg.Raw().Status.State != nil && *sg.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update security group while it is in 'InCreation' state. Please wait until the security group is fully created")
+	}
+
+	if name != "" {
+		sg.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		sg.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromNetwork().SecurityGroups().Update(ctx, sg)
+	if err != nil {
+		return fmt.Errorf("updating security group: %w", apiErrFromV2(err))
+	}
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		updateRegion := ""
+		if raw.Metadata.LocationResponse != nil {
+			updateRegion = string(raw.Metadata.LocationResponse.Value)
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{nameVal, id, updateRegion, status}
+		PrintOutput(updated, headers, [][]string{row})
+	} else {
+		fmt.Println(msgUpdatedAsync("Security group", sgID))
+	}
+	return nil
+}
+
+func runSecurityGroupDelete(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	sgID := args[1]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("security group", sgID)
 		if err != nil {
 			return err
 		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
-			if err != nil {
-				return fmt.Errorf("dry-run: security group not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("security group", sgID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().SecurityGroups().Delete(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
 		if err != nil {
-			return fmt.Errorf("deleting security group: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: security group not found or inaccessible: %w", apiErrFromV2(err))
 		}
-		headers := []TableColumn{
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{sgID, status}
-		PrintOutput(result, headers, [][]string{{sgID, status}})
+		fmt.Println(msgDryRun("security group", sgID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().SecurityGroups().Delete(ctx, aruba.SecurityGroupRef(projectID, vpcID, sgID))
+	if err != nil {
+		return fmt.Errorf("deleting security group: %w", apiErrFromV2(err))
+	}
+	headers := []TableColumn{
+		{Header: "ID", Width: 26},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{sgID, status}
+	PrintOutput(result, headers, [][]string{{sgID, status}})
+	return nil
 }

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -129,394 +129,404 @@ Example target values:
     --direction Egress --protocol ANY \
     --target-kind Ip --target-value 0.0.0.0/0`,
 	Args: cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		securityGroupID := args[1]
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		direction, _ := cmd.Flags().GetString("direction")
-		protocol, _ := cmd.Flags().GetString("protocol")
-		port, _ := cmd.Flags().GetString("port")
-		targetKind, _ := cmd.Flags().GetString("target-kind")
-		targetValue, _ := cmd.Flags().GetString("target-value")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		if verbose {
-			fmt.Println("Creating security rule with the following parameters:")
-			fmt.Printf("  Name:         %s\n", name)
-			fmt.Printf("  Region:       %s\n", region)
-			fmt.Printf("  Direction:    %s\n", direction)
-			fmt.Printf("  Protocol:     %s\n", protocol)
-			fmt.Printf("  Port:         %s\n", port)
-			fmt.Printf("  Target Kind:  %s\n", targetKind)
-			fmt.Printf("  Target Value: %s\n", targetValue)
-			if len(tags) > 0 {
-				fmt.Printf("  Tags:         %v\n", tags)
-			}
-			fmt.Println()
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		rule := aruba.NewSecurityRule().
-			InSecurityGroup(aruba.SecurityGroupRef(projectID, vpcID, securityGroupID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			WithDirection(aruba.RuleDirection(direction)).
-			WithProtocol(aruba.RuleProtocol(protocol)).
-			RetaggedAs(tags...)
-
-		if port != "" {
-			rule = rule.WithPort(port)
-		}
-
-		if aruba.EndpointTypeDto(targetKind) == aruba.EndpointTypeSecurityGroup {
-			rule = rule.TargetingSecurityGroup(aruba.URI(targetValue))
-		} else {
-			rule = rule.TargetingCIDR(targetValue)
-		}
-
-		resp, err := client.FromNetwork().SecurityGroupRules().Create(ctx, rule)
-		if err != nil {
-			return fmt.Errorf("creating security rule: %w", apiErrFromV2(err))
-		}
-
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "DIRECTION", Width: 12},
-				{Header: "PROTOCOL", Width: 12},
-				{Header: "PORT", Width: 12},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{name, id, direction, protocol, port, status}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("Security rule", name))
-		}
-		return nil
-	},
+	RunE: runSecurityRuleCreate,
 }
 
 var securityruleGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [securitygroup-id] [securityrule-id]",
 	Short: "Get security rule details",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		securityGroupID := args[1]
-		securityRuleID := args[2]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		rule, err := client.FromNetwork().SecurityGroupRules().Get(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
-		if err != nil {
-			return fmt.Errorf("getting security rule: %w", apiErrFromV2(err))
-		}
-
-		if rule != nil && rule.Raw() != nil {
-			raw := rule.Raw()
-			fmt.Println("\nSecurity Rule Details:")
-			fmt.Println("=====================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-			fmt.Printf("Direction:       %s\n", raw.Properties.Direction)
-			fmt.Printf("Protocol:        %s\n", raw.Properties.Protocol)
-			fmt.Printf("Port:            %s\n", raw.Properties.Port)
-			if raw.Properties.Target != nil {
-				fmt.Printf("Target Kind:     %s\n", raw.Properties.Target.Kind)
-				fmt.Printf("Target Value:    %s\n", raw.Properties.Target.Value)
-			}
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("Security rule not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runSecurityRuleGet,
 }
 
 var securityruleListCmd = &cobra.Command{
 	Use:   "list [vpc-id] [securitygroup-id]",
 	Short: "List security rules for a security group",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		securityGroupID := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().SecurityGroupRules().List(ctx, aruba.SecurityGroupRef(projectID, vpcID, securityGroupID))
-		if err != nil {
-			return fmt.Errorf("listing security rules: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "DIRECTION", Width: 12},
-				{Header: "PROTOCOL", Width: 12},
-				{Header: "PORT", Width: 12},
-				{Header: "TARGET", Width: 30},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, rule := range list.Items() {
-				raw := rule.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				direction := string(raw.Properties.Direction)
-				protocol := string(raw.Properties.Protocol)
-				port := raw.Properties.Port
-				target := ""
-				if raw.Properties.Target != nil {
-					target = fmt.Sprintf("%s:%s", raw.Properties.Target.Kind, raw.Properties.Target.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, direction, protocol, port, target, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No security rules found.")
-		}
-		return nil
-	},
+	RunE:  runSecurityRuleList,
 }
 
 var securityruleUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [securitygroup-id] [securityrule-id]",
 	Short: "Update a security rule",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		securityGroupID := args[1]
-		securityRuleID := args[2]
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one field (--name or --tags) must be provided for update")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		rule, err := client.FromNetwork().SecurityGroupRules().Get(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
-		if err != nil {
-			return fmt.Errorf("fetching current security rule: %w", apiErrFromV2(err))
-		}
-
-		if rule == nil || rule.Raw() == nil {
-			return fmt.Errorf("security rule not found or no data returned")
-		}
-
-		if rule.Raw().Status.State != nil && *rule.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update security rule while it is in 'InCreation' state. Please wait until the security rule is fully created")
-		}
-
-		if name != "" {
-			rule.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			rule.RetaggedAs(tags...)
-		}
-
-		debugEnabled, _ := rootCmd.PersistentFlags().GetBool("debug")
-		if debugEnabled {
-			fmt.Fprintf(os.Stderr, "\n=== DEBUG: Security Rule Update ===\n")
-			fmt.Fprintf(os.Stderr, "VPC ID: %s\n", vpcID)
-			fmt.Fprintf(os.Stderr, "Security Group ID: %s\n", securityGroupID)
-			fmt.Fprintf(os.Stderr, "Security Rule ID: %s\n", securityRuleID)
-			if reqJSON, err := json.Marshal(rule.RawRequest()); err == nil {
-				fmt.Fprintf(os.Stderr, "Request: %s\n", reqJSON)
-			}
-			fmt.Fprintf(os.Stderr, "===================================\n\n")
-		}
-
-		updated, err := client.FromNetwork().SecurityGroupRules().Update(ctx, rule)
-		if err != nil {
-			return fmt.Errorf("updating security rule: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "DIRECTION", Width: 12},
-				{Header: "PROTOCOL", Width: 12},
-				{Header: "PORT", Width: 12},
-				{Header: "STATUS", Width: 15},
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{nameVal, id, string(raw.Properties.Direction), string(raw.Properties.Protocol), raw.Properties.Port, status}
-			PrintOutput(updated, headers, [][]string{row})
-		} else {
-			fmt.Println(msgUpdatedAsync("Security rule", securityRuleID))
-		}
-		return nil
-	},
+	RunE:  runSecurityRuleUpdate,
 }
 
 var securityruleDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [securitygroup-id] [securityrule-id]",
 	Short: "Delete a security rule",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		securityGroupID := args[1]
-		securityRuleID := args[2]
+	RunE:  runSecurityRuleDelete,
+}
 
-		projectID, err := GetProjectID(cmd)
+func runSecurityRuleCreate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	securityGroupID := args[1]
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	direction, _ := cmd.Flags().GetString("direction")
+	protocol, _ := cmd.Flags().GetString("protocol")
+	port, _ := cmd.Flags().GetString("port")
+	targetKind, _ := cmd.Flags().GetString("target-kind")
+	targetValue, _ := cmd.Flags().GetString("target-value")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	if verbose {
+		fmt.Println("Creating security rule with the following parameters:")
+		fmt.Printf("  Name:         %s\n", name)
+		fmt.Printf("  Region:       %s\n", region)
+		fmt.Printf("  Direction:    %s\n", direction)
+		fmt.Printf("  Protocol:     %s\n", protocol)
+		fmt.Printf("  Port:         %s\n", port)
+		fmt.Printf("  Target Kind:  %s\n", targetKind)
+		fmt.Printf("  Target Value: %s\n", targetValue)
+		if len(tags) > 0 {
+			fmt.Printf("  Tags:         %v\n", tags)
+		}
+		fmt.Println()
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	rule := aruba.NewSecurityRule().
+		InSecurityGroup(aruba.SecurityGroupRef(projectID, vpcID, securityGroupID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		WithDirection(aruba.RuleDirection(direction)).
+		WithProtocol(aruba.RuleProtocol(protocol)).
+		RetaggedAs(tags...)
+
+	if port != "" {
+		rule = rule.WithPort(port)
+	}
+
+	if aruba.EndpointTypeDto(targetKind) == aruba.EndpointTypeSecurityGroup {
+		rule = rule.TargetingSecurityGroup(aruba.URI(targetValue))
+	} else {
+		rule = rule.TargetingCIDR(targetValue)
+	}
+
+	resp, err := client.FromNetwork().SecurityGroupRules().Create(ctx, rule)
+	if err != nil {
+		return fmt.Errorf("creating security rule: %w", apiErrFromV2(err))
+	}
+
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "DIRECTION", Width: 12},
+			{Header: "PROTOCOL", Width: 12},
+			{Header: "PORT", Width: 12},
+			{Header: "STATUS", Width: 15},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{name, id, direction, protocol, port, status}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("Security rule", name))
+	}
+	return nil
+}
+
+func runSecurityRuleGet(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	securityGroupID := args[1]
+	securityRuleID := args[2]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	rule, err := client.FromNetwork().SecurityGroupRules().Get(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
+	if err != nil {
+		return fmt.Errorf("getting security rule: %w", apiErrFromV2(err))
+	}
+
+	if rule != nil && rule.Raw() != nil {
+		raw := rule.Raw()
+		fmt.Println("\nSecurity Rule Details:")
+		fmt.Println("=====================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+		fmt.Printf("Direction:       %s\n", raw.Properties.Direction)
+		fmt.Printf("Protocol:        %s\n", raw.Properties.Protocol)
+		fmt.Printf("Port:            %s\n", raw.Properties.Port)
+		if raw.Properties.Target != nil {
+			fmt.Printf("Target Kind:     %s\n", raw.Properties.Target.Kind)
+			fmt.Printf("Target Value:    %s\n", raw.Properties.Target.Value)
+		}
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("Security rule not found or no data returned.")
+	}
+	return nil
+}
+
+func runSecurityRuleList(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	securityGroupID := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().SecurityGroupRules().List(ctx, aruba.SecurityGroupRef(projectID, vpcID, securityGroupID))
+	if err != nil {
+		return fmt.Errorf("listing security rules: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "DIRECTION", Width: 12},
+			{Header: "PROTOCOL", Width: 12},
+			{Header: "PORT", Width: 12},
+			{Header: "TARGET", Width: 30},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, rule := range list.Items() {
+			raw := rule.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			direction := string(raw.Properties.Direction)
+			protocol := string(raw.Properties.Protocol)
+			port := raw.Properties.Port
+			target := ""
+			if raw.Properties.Target != nil {
+				target = fmt.Sprintf("%s:%s", raw.Properties.Target.Kind, raw.Properties.Target.Value)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, direction, protocol, port, target, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No security rules found.")
+	}
+	return nil
+}
+
+func runSecurityRuleUpdate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	securityGroupID := args[1]
+	securityRuleID := args[2]
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one field (--name or --tags) must be provided for update")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	rule, err := client.FromNetwork().SecurityGroupRules().Get(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
+	if err != nil {
+		return fmt.Errorf("fetching current security rule: %w", apiErrFromV2(err))
+	}
+
+	if rule == nil || rule.Raw() == nil {
+		return fmt.Errorf("security rule not found or no data returned")
+	}
+
+	if rule.Raw().Status.State != nil && *rule.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update security rule while it is in 'InCreation' state. Please wait until the security rule is fully created")
+	}
+
+	if name != "" {
+		rule.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		rule.RetaggedAs(tags...)
+	}
+
+	debugEnabled, _ := rootCmd.PersistentFlags().GetBool("debug")
+	if debugEnabled {
+		fmt.Fprintf(os.Stderr, "\n=== DEBUG: Security Rule Update ===\n")
+		fmt.Fprintf(os.Stderr, "VPC ID: %s\n", vpcID)
+		fmt.Fprintf(os.Stderr, "Security Group ID: %s\n", securityGroupID)
+		fmt.Fprintf(os.Stderr, "Security Rule ID: %s\n", securityRuleID)
+		if reqJSON, err := json.Marshal(rule.RawRequest()); err == nil {
+			fmt.Fprintf(os.Stderr, "Request: %s\n", reqJSON)
+		}
+		fmt.Fprintf(os.Stderr, "===================================\n\n")
+	}
+
+	updated, err := client.FromNetwork().SecurityGroupRules().Update(ctx, rule)
+	if err != nil {
+		return fmt.Errorf("updating security rule: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "DIRECTION", Width: 12},
+			{Header: "PROTOCOL", Width: 12},
+			{Header: "PORT", Width: 12},
+			{Header: "STATUS", Width: 15},
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{nameVal, id, string(raw.Properties.Direction), string(raw.Properties.Protocol), raw.Properties.Port, status}
+		PrintOutput(updated, headers, [][]string{row})
+	} else {
+		fmt.Println(msgUpdatedAsync("Security rule", securityRuleID))
+	}
+	return nil
+}
+
+func runSecurityRuleDelete(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	securityGroupID := args[1]
+	securityRuleID := args[2]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+
+	if !skipConfirm {
+		ok, err := confirmDelete("security rule", securityRuleID)
 		if err != nil {
 			return err
 		}
-
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		if !skipConfirm {
-			ok, err := confirmDelete("security rule", securityRuleID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().SecurityGroupRules().Get(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
-			if err != nil {
-				return fmt.Errorf("dry-run: security rule not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("security rule", securityRuleID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().SecurityGroupRules().Delete(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().SecurityGroupRules().Get(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
 		if err != nil {
-			return fmt.Errorf("deleting security rule: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: security rule not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		headers := []TableColumn{
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{securityRuleID, status}
-		PrintOutput(result, headers, [][]string{{securityRuleID, status}})
+		fmt.Println(msgDryRun("security rule", securityRuleID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().SecurityGroupRules().Delete(ctx, aruba.SecurityRuleRef(projectID, vpcID, securityGroupID, securityRuleID))
+	if err != nil {
+		return fmt.Errorf("deleting security rule: %w", apiErrFromV2(err))
+	}
+
+	headers := []TableColumn{
+		{Header: "ID", Width: 26},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{securityRuleID, status}
+	PrintOutput(result, headers, [][]string{{securityRuleID, status}})
+	return nil
 }

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -73,414 +73,424 @@ DHCP routes format: "destination:gateway" (e.g., "10.1.0.0/24:10.0.0.1").`,
   acloud network subnet create <vpc-id> --name my-subnet --region IT-BG \
     --cidr 10.0.1.0/24 --dhcp-enabled \
     --dhcp-dns 8.8.8.8,8.8.4.4`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		name, _ := cmd.Flags().GetString("name")
-		cidr, _ := cmd.Flags().GetString("cidr")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		dhcpEnabled, _ := cmd.Flags().GetBool("dhcp-enabled")
-		dhcpRoutes, _ := cmd.Flags().GetStringSlice("dhcp-routes")
-		dhcpDNS, _ := cmd.Flags().GetStringSlice("dhcp-dns")
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		// Determine SubnetType
-		subnetType := aruba.SubnetTypeBasic
-		if cidr != "" {
-			subnetType = aruba.SubnetTypeAdvanced
-			if !dhcpEnabled {
-				return fmt.Errorf("--dhcp-enabled is required when creating an Advanced subnet (CIDR provided)")
-			}
-		}
-
-		subnet := aruba.NewSubnet().
-			InVPC(aruba.VPCRef(projectID, vpcID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			OfType(subnetType).
-			RetaggedAs(tags...)
-
-		if cidr != "" {
-			subnet = subnet.WithCIDR(cidr)
-		}
-
-		if dhcpEnabled {
-			dhcp := aruba.NewSubnetDHCP().Enabled()
-			for _, routeStr := range dhcpRoutes {
-				parts := splitRouteString(routeStr)
-				if len(parts) == 2 {
-					dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: parts[0], Gateway: parts[1]})
-				} else {
-					fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
-				}
-			}
-			if len(dhcpDNS) > 0 {
-				dhcp = dhcp.WithDNSServers(dhcpDNS...)
-			}
-			subnet = subnet.WithDHCP(dhcp)
-		}
-
-		resp, err := client.FromNetwork().Subnets().Create(ctx, subnet)
-		if err != nil {
-			return fmt.Errorf("creating subnet: %w", apiErrFromV2(err))
-		}
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "CIDR", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			displayCIDR := cidr
-			if raw.Properties.Network != nil && raw.Properties.Network.Address != "" {
-				displayCIDR = raw.Properties.Network.Address
-			}
-			if displayCIDR == "" {
-				displayCIDR = "N/A (Basic)"
-			}
-			createRegion := ""
-			if raw.Metadata.LocationResponse != nil {
-				createRegion = string(raw.Metadata.LocationResponse.Value)
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{name, id, createRegion, displayCIDR, status}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("Subnet", name))
-		}
-		return nil
-	},
+	RunE: runSubnetCreate,
 }
 
 var subnetGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [subnet-id]",
 	Short: "Get subnet details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		subnetID := args[1]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		subnet, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
-		if err != nil {
-			return fmt.Errorf("getting subnet: %w", apiErrFromV2(err))
-		}
-		if subnet != nil && subnet.Raw() != nil {
-			raw := subnet.Raw()
-			fmt.Println("\nSubnet Details:")
-			fmt.Println("===============")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil && string(raw.Metadata.LocationResponse.Value) != "" {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Properties.Type != "" {
-				fmt.Printf("Type:            %s\n", raw.Properties.Type)
-			}
-			if raw.Properties.Network != nil {
-				fmt.Printf("CIDR:            %s\n", raw.Properties.Network.Address)
-			}
-			if raw.Properties.DHCP != nil {
-				fmt.Printf("DHCP Enabled:    %v\n", raw.Properties.DHCP.Enabled)
-				if len(raw.Properties.DHCP.Routes) > 0 {
-					fmt.Printf("DHCP Routes:\n")
-					for _, route := range raw.Properties.DHCP.Routes {
-						fmt.Printf("  - %s -> %s\n", route.Address, route.Gateway)
-					}
-				}
-				if len(raw.Properties.DHCP.DNS) > 0 {
-					fmt.Printf("DHCP DNS:        %v\n", raw.Properties.DHCP.DNS)
-				}
-			}
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("Subnet not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runSubnetGet,
 }
 
 var subnetListCmd = &cobra.Command{
 	Use:   "list [vpc-id]",
 	Short: "List subnets for a VPC",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().Subnets().List(ctx, aruba.VPCRef(projectID, vpcID))
-		if err != nil {
-			return fmt.Errorf("listing subnets: %w", apiErrFromV2(err))
-		}
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "CIDR", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, subnet := range list.Items() {
-				raw := subnet.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				cidr := ""
-				if raw.Properties.Network != nil {
-					cidr = raw.Properties.Network.Address
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, cidr, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No subnets found.")
-		}
-		return nil
-	},
+	RunE:  runSubnetList,
 }
 
 var subnetUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [subnet-id]",
 	Short: "Update a subnet",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		subnetID := args[1]
-		name, _ := cmd.Flags().GetString("name")
-		cidr, _ := cmd.Flags().GetString("cidr")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		dhcpEnabled, _ := cmd.Flags().GetBool("dhcp-enabled")
-		dhcpRoutes, _ := cmd.Flags().GetStringSlice("dhcp-routes")
-		dhcpDNS, _ := cmd.Flags().GetStringSlice("dhcp-dns")
-		if name == "" && cidr == "" && !cmd.Flags().Changed("tags") && !cmd.Flags().Changed("dhcp-enabled") && !cmd.Flags().Changed("dhcp-routes") && !cmd.Flags().Changed("dhcp-dns") {
-			return fmt.Errorf("at least one of --name, --cidr, --tags, --dhcp-enabled, --dhcp-routes, or --dhcp-dns must be provided")
-		}
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		subnet, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
-		if err != nil || subnet == nil || subnet.ID() == "" {
-			return fmt.Errorf("fetching current subnet: %w", apiErrFromV2(err))
-		}
-
-		if subnet.State() == StateInCreation {
-			return fmt.Errorf("cannot update subnet while it is in 'InCreation' state. Please wait until the subnet is fully created")
-		}
-
-		if name != "" {
-			subnet.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			subnet.RetaggedAs(tags...)
-		}
-		if cidr != "" {
-			subnet.WithCIDR(cidr)
-		}
-
-		// Update DHCP config for Advanced subnets.
-		// sdk-go v1.0.0 exposes Type() and DHCP() accessors (closes #133 / TD-035).
-		if subnet.Type() == aruba.SubnetTypeAdvanced {
-			currentDHCP := subnet.DHCP()
-			if cmd.Flags().Changed("dhcp-enabled") || len(dhcpRoutes) > 0 || len(dhcpDNS) > 0 {
-				dhcp := aruba.NewSubnetDHCP()
-				// Preserve existing enabled state
-				if (currentDHCP != nil && currentDHCP.IsEnabled()) || dhcpEnabled {
-					dhcp = dhcp.Enabled()
-				}
-				// Preserve existing routes unless new ones provided
-				if len(dhcpRoutes) > 0 {
-					for _, routeStr := range dhcpRoutes {
-						parts := splitRouteString(routeStr)
-						if len(parts) == 2 {
-							dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: parts[0], Gateway: parts[1]})
-						} else {
-							fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
-						}
-					}
-				} else if currentDHCP != nil {
-					for _, r := range currentDHCP.Routes() {
-						dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: r.Address, Gateway: r.Gateway})
-					}
-				}
-				// Preserve existing DNS unless new ones provided
-				if len(dhcpDNS) > 0 {
-					dhcp = dhcp.WithDNSServers(dhcpDNS...)
-				} else if currentDHCP != nil && len(currentDHCP.DNS()) > 0 {
-					dhcp = dhcp.WithDNSServers(currentDHCP.DNS()...)
-				}
-				subnet.WithDHCP(dhcp)
-			}
-		}
-
-		updated, err := client.FromNetwork().Subnets().Update(ctx, subnet)
-		if err != nil {
-			return fmt.Errorf("updating subnet: %w", apiErrFromV2(err))
-		}
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "CIDR", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			cidrVal := ""
-			if raw.Properties.Network != nil {
-				cidrVal = raw.Properties.Network.Address
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			PrintOutput(updated, headers, [][]string{{nameVal, id, cidrVal, status}})
-		} else {
-			fmt.Println(msgUpdatedAsync("Subnet", subnetID))
-		}
-		return nil
-	},
+	RunE:  runSubnetUpdate,
 }
 
 var subnetDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [subnet-id]",
 	Short: "Delete a subnet",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		subnetID := args[1]
+	RunE:  runSubnetDelete,
+}
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("subnet", subnetID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
+func runSubnetCreate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	name, _ := cmd.Flags().GetString("name")
+	cidr, _ := cmd.Flags().GetString("cidr")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	dhcpEnabled, _ := cmd.Flags().GetBool("dhcp-enabled")
+	dhcpRoutes, _ := cmd.Flags().GetStringSlice("dhcp-routes")
+	dhcpDNS, _ := cmd.Flags().GetStringSlice("dhcp-dns")
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	// Determine SubnetType
+	subnetType := aruba.SubnetTypeBasic
+	if cidr != "" {
+		subnetType = aruba.SubnetTypeAdvanced
+		if !dhcpEnabled {
+			return fmt.Errorf("--dhcp-enabled is required when creating an Advanced subnet (CIDR provided)")
+		}
+	}
+
+	subnet := aruba.NewSubnet().
+		InVPC(aruba.VPCRef(projectID, vpcID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		OfType(subnetType).
+		RetaggedAs(tags...)
+
+	if cidr != "" {
+		subnet = subnet.WithCIDR(cidr)
+	}
+
+	if dhcpEnabled {
+		dhcp := aruba.NewSubnetDHCP().Enabled()
+		for _, routeStr := range dhcpRoutes {
+			parts := splitRouteString(routeStr)
+			if len(parts) == 2 {
+				dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: parts[0], Gateway: parts[1]})
+			} else {
+				fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
 			}
 		}
+		if len(dhcpDNS) > 0 {
+			dhcp = dhcp.WithDNSServers(dhcpDNS...)
+		}
+		subnet = subnet.WithDHCP(dhcp)
+	}
 
-		projectID, err := GetProjectID(cmd)
+	resp, err := client.FromNetwork().Subnets().Create(ctx, subnet)
+	if err != nil {
+		return fmt.Errorf("creating subnet: %w", apiErrFromV2(err))
+	}
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "CIDR", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		displayCIDR := cidr
+		if raw.Properties.Network != nil && raw.Properties.Network.Address != "" {
+			displayCIDR = raw.Properties.Network.Address
+		}
+		if displayCIDR == "" {
+			displayCIDR = "N/A (Basic)"
+		}
+		createRegion := ""
+		if raw.Metadata.LocationResponse != nil {
+			createRegion = string(raw.Metadata.LocationResponse.Value)
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{name, id, createRegion, displayCIDR, status}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("Subnet", name))
+	}
+	return nil
+}
+
+func runSubnetGet(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	subnetID := args[1]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	subnet, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
+	if err != nil {
+		return fmt.Errorf("getting subnet: %w", apiErrFromV2(err))
+	}
+	if subnet != nil && subnet.Raw() != nil {
+		raw := subnet.Raw()
+		fmt.Println("\nSubnet Details:")
+		fmt.Println("===============")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil && string(raw.Metadata.LocationResponse.Value) != "" {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Properties.Type != "" {
+			fmt.Printf("Type:            %s\n", raw.Properties.Type)
+		}
+		if raw.Properties.Network != nil {
+			fmt.Printf("CIDR:            %s\n", raw.Properties.Network.Address)
+		}
+		if raw.Properties.DHCP != nil {
+			fmt.Printf("DHCP Enabled:    %v\n", raw.Properties.DHCP.Enabled)
+			if len(raw.Properties.DHCP.Routes) > 0 {
+				fmt.Printf("DHCP Routes:\n")
+				for _, route := range raw.Properties.DHCP.Routes {
+					fmt.Printf("  - %s -> %s\n", route.Address, route.Gateway)
+				}
+			}
+			if len(raw.Properties.DHCP.DNS) > 0 {
+				fmt.Printf("DHCP DNS:        %v\n", raw.Properties.DHCP.DNS)
+			}
+		}
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("Subnet not found or no data returned.")
+	}
+	return nil
+}
+
+func runSubnetList(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().Subnets().List(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return fmt.Errorf("listing subnets: %w", apiErrFromV2(err))
+	}
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "CIDR", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, subnet := range list.Items() {
+			raw := subnet.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			cidr := ""
+			if raw.Properties.Network != nil {
+				cidr = raw.Properties.Network.Address
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, cidr, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No subnets found.")
+	}
+	return nil
+}
+
+func runSubnetUpdate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	subnetID := args[1]
+	name, _ := cmd.Flags().GetString("name")
+	cidr, _ := cmd.Flags().GetString("cidr")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	dhcpEnabled, _ := cmd.Flags().GetBool("dhcp-enabled")
+	dhcpRoutes, _ := cmd.Flags().GetStringSlice("dhcp-routes")
+	dhcpDNS, _ := cmd.Flags().GetStringSlice("dhcp-dns")
+	if name == "" && cidr == "" && !cmd.Flags().Changed("tags") && !cmd.Flags().Changed("dhcp-enabled") && !cmd.Flags().Changed("dhcp-routes") && !cmd.Flags().Changed("dhcp-dns") {
+		return fmt.Errorf("at least one of --name, --cidr, --tags, --dhcp-enabled, --dhcp-routes, or --dhcp-dns must be provided")
+	}
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	subnet, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
+	if err != nil || subnet == nil || subnet.ID() == "" {
+		return fmt.Errorf("fetching current subnet: %w", apiErrFromV2(err))
+	}
+
+	if subnet.State() == StateInCreation {
+		return fmt.Errorf("cannot update subnet while it is in 'InCreation' state. Please wait until the subnet is fully created")
+	}
+
+	if name != "" {
+		subnet.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		subnet.RetaggedAs(tags...)
+	}
+	if cidr != "" {
+		subnet.WithCIDR(cidr)
+	}
+
+	// Update DHCP config for Advanced subnets.
+	// sdk-go v1.0.0 exposes Type() and DHCP() accessors (closes #133 / TD-035).
+	if subnet.Type() == aruba.SubnetTypeAdvanced {
+		currentDHCP := subnet.DHCP()
+		if cmd.Flags().Changed("dhcp-enabled") || len(dhcpRoutes) > 0 || len(dhcpDNS) > 0 {
+			dhcp := aruba.NewSubnetDHCP()
+			// Preserve existing enabled state
+			if (currentDHCP != nil && currentDHCP.IsEnabled()) || dhcpEnabled {
+				dhcp = dhcp.Enabled()
+			}
+			// Preserve existing routes unless new ones provided
+			if len(dhcpRoutes) > 0 {
+				for _, routeStr := range dhcpRoutes {
+					parts := splitRouteString(routeStr)
+					if len(parts) == 2 {
+						dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: parts[0], Gateway: parts[1]})
+					} else {
+						fmt.Printf("Warning: Invalid route format '%s', expected 'destination:gateway'. Skipping.\n", routeStr)
+					}
+				}
+			} else if currentDHCP != nil {
+				for _, r := range currentDHCP.Routes() {
+					dhcp = dhcp.WithRoutes(aruba.SubnetDHCPRouteCommon{Address: r.Address, Gateway: r.Gateway})
+				}
+			}
+			// Preserve existing DNS unless new ones provided
+			if len(dhcpDNS) > 0 {
+				dhcp = dhcp.WithDNSServers(dhcpDNS...)
+			} else if currentDHCP != nil && len(currentDHCP.DNS()) > 0 {
+				dhcp = dhcp.WithDNSServers(currentDHCP.DNS()...)
+			}
+			subnet.WithDHCP(dhcp)
+		}
+	}
+
+	updated, err := client.FromNetwork().Subnets().Update(ctx, subnet)
+	if err != nil {
+		return fmt.Errorf("updating subnet: %w", apiErrFromV2(err))
+	}
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "CIDR", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		cidrVal := ""
+		if raw.Properties.Network != nil {
+			cidrVal = raw.Properties.Network.Address
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		PrintOutput(updated, headers, [][]string{{nameVal, id, cidrVal, status}})
+	} else {
+		fmt.Println(msgUpdatedAsync("Subnet", subnetID))
+	}
+	return nil
+}
+
+func runSubnetDelete(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	subnetID := args[1]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("subnet", subnetID)
 		if err != nil {
 			return err
 		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
-			if err != nil {
-				return fmt.Errorf("dry-run: subnet not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("subnet", subnetID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().Subnets().Delete(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
 		if err != nil {
-			return fmt.Errorf("deleting subnet: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: subnet not found or inaccessible: %w", apiErrFromV2(err))
 		}
-		headers := []TableColumn{
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{subnetID, status}
-		PrintOutput(result, headers, [][]string{{subnetID, status}})
+		fmt.Println(msgDryRun("subnet", subnetID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().Subnets().Delete(ctx, aruba.SubnetRef(projectID, vpcID, subnetID))
+	if err != nil {
+		return fmt.Errorf("deleting subnet: %w", apiErrFromV2(err))
+	}
+	headers := []TableColumn{
+		{Header: "ID", Width: 26},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{subnetID, status}
+	PrintOutput(result, headers, [][]string{{subnetID, status}})
+	return nil
 }

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -92,305 +92,315 @@ network resources are created within a VPC.`,
 	Example: `  acloud network vpc create --name my-vpc --region IT-BG
   acloud network vpc create --name prod-vpc --region IT-BG --tags env=prod,team=infra`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		vpc := aruba.NewVPC().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromNetwork().VPCs().Create(ctx, vpc)
-		if err != nil {
-			return fmt.Errorf("creating VPC: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			fmt.Printf("\n%s\n", msgCreated("VPC", name))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			fmt.Printf("Default: %t\n", raw.Properties.Default)
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgCreatedAsync("VPC", name))
-		}
-		return nil
-	},
+	RunE: runVPCCreate,
 }
 
 var vpcGetCmd = &cobra.Command{
 	Use:   "get <vpc-id>",
 	Short: "Get VPC details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		vpc, err := client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(projectID, vpcID))
-		if err != nil {
-			return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
-		}
-
-		if vpc != nil && vpc.Raw() != nil {
-			raw := vpc.Raw()
-
-			fmt.Println("\nVPC Details:")
-			fmt.Println("============")
-
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-			fmt.Printf("Default:         %t\n", raw.Properties.Default)
-			fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
-
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("VPC not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runVPCGet,
 }
 
 var vpcUpdateCmd = &cobra.Command{
 	Use:   "update <vpc-id>",
 	Short: "Update a VPC",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		vpc, err := client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(projectID, vpcID))
-		if err != nil {
-			return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
-		}
-
-		if vpc == nil || vpc.Raw() == nil {
-			return fmt.Errorf("VPC not found")
-		}
-
-		if vpc.Raw().Status.State != nil && *vpc.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update VPC while it is in 'InCreation' state. Please wait until the VPC is fully created")
-		}
-
-		if name != "" {
-			vpc.Named(name)
-		}
-		if len(tags) > 0 {
-			vpc.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromNetwork().VPCs().Update(ctx, vpc)
-		if err != nil {
-			return fmt.Errorf("updating VPC: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("VPC", vpcID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("VPC", vpcID))
-		}
-		return nil
-	},
+	RunE:  runVPCUpdate,
 }
 
 var vpcDeleteCmd = &cobra.Command{
 	Use:   "delete <vpc-id>",
 	Short: "Delete a VPC",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-
-		if !skipConfirm {
-			ok, err := confirmDelete("VPC", vpcID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(projectID, vpcID))
-			if err != nil {
-				return fmt.Errorf("dry-run: VPC not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("VPC", vpcID))
-			return nil
-		}
-
-		err = client.FromNetwork().VPCs().Delete(ctx, aruba.VPCRef(projectID, vpcID))
-		if err != nil {
-			return fmt.Errorf("deleting VPC: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("VPC", vpcID))
-		return nil
-	},
+	RunE:  runVPCDelete,
 }
 
 var vpcListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all VPCs",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+	RunE:  runVPCList,
+}
+
+func runVPCCreate(cmd *cobra.Command, args []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	vpc := aruba.NewVPC().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromNetwork().VPCs().Create(ctx, vpc)
+	if err != nil {
+		return fmt.Errorf("creating VPC: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		fmt.Printf("\n%s\n", msgCreated("VPC", name))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
+		}
+		fmt.Printf("Default: %t\n", raw.Properties.Default)
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgCreatedAsync("VPC", name))
+	}
+	return nil
+}
+
+func runVPCGet(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	vpc, err := client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
+	}
+
+	if vpc != nil && vpc.Raw() != nil {
+		raw := vpc.Raw()
+
+		fmt.Println("\nVPC Details:")
+		fmt.Println("============")
+
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+		fmt.Printf("Default:         %t\n", raw.Properties.Default)
+		fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
+
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
 		}
 
-		projectID, err := GetProjectID(cmd)
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("VPC not found or no data returned.")
+	}
+	return nil
+}
+
+func runVPCUpdate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	vpc, err := client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
+	}
+
+	if vpc == nil || vpc.Raw() == nil {
+		return fmt.Errorf("VPC not found")
+	}
+
+	if vpc.Raw().Status.State != nil && *vpc.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update VPC while it is in 'InCreation' state. Please wait until the VPC is fully created")
+	}
+
+	if name != "" {
+		vpc.Named(name)
+	}
+	if len(tags) > 0 {
+		vpc.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromNetwork().VPCs().Update(ctx, vpc)
+	if err != nil {
+		return fmt.Errorf("updating VPC: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("VPC", vpcID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("VPC", vpcID))
+	}
+	return nil
+}
+
+func runVPCDelete(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+
+	if !skipConfirm {
+		ok, err := confirmDelete("VPC", vpcID)
 		if err != nil {
 			return err
 		}
+		if !ok {
+			return nil
+		}
+	}
 
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().VPCs().List(ctx, aruba.URI("/projects/"+projectID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(projectID, vpcID))
 		if err != nil {
-			return fmt.Errorf("listing VPCs: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: VPC not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "ID", Width: 25},
-				{Header: "REGION", Width: 18},
-				{Header: "SUBNETS", Width: 10},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, vpc := range list.Items() {
-				raw := vpc.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				subnets := fmt.Sprintf("%d", len(raw.Properties.LinkedResources))
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, subnets, status})
-			}
-
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No VPCs found")
-		}
+		fmt.Println(msgDryRun("VPC", vpcID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().VPCs().Delete(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return fmt.Errorf("deleting VPC: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("VPC", vpcID))
+	return nil
+}
+
+func runVPCList(cmd *cobra.Command, args []string) error {
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().VPCs().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing VPCs: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "ID", Width: 25},
+			{Header: "REGION", Width: 18},
+			{Header: "SUBNETS", Width: 10},
+			{Header: "STATUS", Width: 15},
+		}
+
+		var rows [][]string
+		for _, vpc := range list.Items() {
+			raw := vpc.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			subnets := fmt.Sprintf("%d", len(raw.Properties.LinkedResources))
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, subnets, status})
+		}
+
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No VPCs found")
+	}
+	return nil
 }

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -60,245 +60,184 @@ peering is established.`,
 	Example: `  acloud network vpcpeering create <vpc-id> \
     --name my-peering --region IT-BG --peer-vpc-id <peer-vpc-id>`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		name, _ := cmd.Flags().GetString("name")
-		peerVPCID, _ := cmd.Flags().GetString("peer-vpc-id")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		peering := aruba.NewVPCPeering().
-			InVPC(aruba.VPCRef(projectID, vpcID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			PeeredWith(aruba.URI(peerVPCID)).
-			RetaggedAs(tags...)
-
-		resp, err := client.FromNetwork().VPCPeerings().Create(ctx, peering)
-		if err != nil {
-			return fmt.Errorf("creating VPC peering: %w", apiErrFromV2(err))
-		}
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "PEER VPC", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			peerVPC := ""
-			if raw.Properties.RemoteVPC != nil {
-				peerVPC = raw.Properties.RemoteVPC.URI
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{name, id, peerVPC, regionVal, status}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("VPC peering", name))
-		}
-		return nil
-	},
+	RunE: runVPCPeeringCreate,
 }
 
 var vpcpeeringGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [peering-id]",
 	Short: "Get VPC peering details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		peering, err := client.FromNetwork().VPCPeerings().Get(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
-		if err != nil {
-			return fmt.Errorf("getting VPC peering: %w", apiErrFromV2(err))
-		}
-		if peering != nil && peering.Raw() != nil {
-			raw := peering.Raw()
-			fmt.Println("\nVPC Peering Details:")
-			fmt.Println("====================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Properties.RemoteVPC != nil {
-				fmt.Printf("Peer VPC:        %s\n", raw.Properties.RemoteVPC.URI)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("VPC peering not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runVPCPeeringGet,
 }
 
 var vpcpeeringListCmd = &cobra.Command{
 	Use:   "list [vpc-id]",
 	Short: "List VPC peerings for a VPC",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().VPCPeerings().List(ctx, aruba.VPCRef(projectID, vpcID))
-		if err != nil {
-			return fmt.Errorf("listing VPC peerings: %w", apiErrFromV2(err))
-		}
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "PEER VPC", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, peering := range list.Items() {
-				raw := peering.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				peerVPC := ""
-				if raw.Properties.RemoteVPC != nil {
-					peerVPC = raw.Properties.RemoteVPC.URI
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, peerVPC, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No VPC peerings found.")
-		}
-		return nil
-	},
+	RunE:  runVPCPeeringList,
 }
 
 var vpcpeeringUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [peering-id]",
 	Short: "Update a VPC peering",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
+	RunE:  runVPCPeeringUpdate,
+}
 
-		peering, err := client.FromNetwork().VPCPeerings().Get(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
-		if err != nil || peering == nil || peering.Raw() == nil {
-			return fmt.Errorf("fetching current VPC peering: %w", apiErrFromV2(err))
-		}
+var vpcpeeringDeleteCmd = &cobra.Command{
+	Use:   "delete [vpc-id] [peering-id]",
+	Short: "Delete a VPC peering",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runVPCPeeringDelete,
+}
 
-		if peering.Raw().Status.State != nil && *peering.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update VPC peering while it is in 'InCreation' state. Please wait until the VPC peering is fully created")
-		}
+func runVPCPeeringCreate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	name, _ := cmd.Flags().GetString("name")
+	peerVPCID, _ := cmd.Flags().GetString("peer-vpc-id")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
 
-		if name != "" {
-			peering.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			peering.RetaggedAs(tags...)
-		}
+	peering := aruba.NewVPCPeering().
+		InVPC(aruba.VPCRef(projectID, vpcID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		PeeredWith(aruba.URI(peerVPCID)).
+		RetaggedAs(tags...)
 
-		updated, err := client.FromNetwork().VPCPeerings().Update(ctx, peering)
-		if err != nil {
-			return fmt.Errorf("updating VPC peering: %w", apiErrFromV2(err))
+	resp, err := client.FromNetwork().VPCPeerings().Create(ctx, peering)
+	if err != nil {
+		return fmt.Errorf("creating VPC peering: %w", apiErrFromV2(err))
+	}
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "PEER VPC", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "STATUS", Width: 15},
 		}
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "PEER VPC", Width: 26},
-				{Header: "REGION", Width: 18},
-				{Header: "STATUS", Width: 15},
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		peerVPC := ""
+		if raw.Properties.RemoteVPC != nil {
+			peerVPC = raw.Properties.RemoteVPC.URI
+		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{name, id, peerVPC, regionVal, status}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("VPC peering", name))
+	}
+	return nil
+}
+
+func runVPCPeeringGet(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	peering, err := client.FromNetwork().VPCPeerings().Get(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
+	if err != nil {
+		return fmt.Errorf("getting VPC peering: %w", apiErrFromV2(err))
+	}
+	if peering != nil && peering.Raw() != nil {
+		raw := peering.Raw()
+		fmt.Println("\nVPC Peering Details:")
+		fmt.Println("====================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Properties.RemoteVPC != nil {
+			fmt.Printf("Peer VPC:        %s\n", raw.Properties.RemoteVPC.URI)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("VPC peering not found or no data returned.")
+	}
+	return nil
+}
+
+func runVPCPeeringList(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().VPCPeerings().List(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return fmt.Errorf("listing VPC peerings: %w", apiErrFromV2(err))
+	}
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "PEER VPC", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, peering := range list.Items() {
+			raw := peering.Raw()
+			if raw == nil {
+				continue
 			}
-			nameVal := ""
+			name := ""
 			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
+				name = *raw.Metadata.Name
 			}
 			id := ""
 			if raw.Metadata.ID != nil {
@@ -308,77 +247,148 @@ var vpcpeeringUpdateCmd = &cobra.Command{
 			if raw.Properties.RemoteVPC != nil {
 				peerVPC = raw.Properties.RemoteVPC.URI
 			}
-			regionVal := ""
+			region := ""
 			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
+				region = string(raw.Metadata.LocationResponse.Value)
 			}
 			status := ""
 			if raw.Status.State != nil {
 				status = string(*raw.Status.State)
 			}
-			row := []string{nameVal, id, peerVPC, regionVal, status}
-			PrintOutput(updated, headers, [][]string{row})
-		} else {
-			fmt.Println(msgUpdatedAsync("VPC peering", peeringID))
+			rows = append(rows, []string{name, id, peerVPC, region, status})
 		}
-		return nil
-	},
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No VPC peerings found.")
+	}
+	return nil
 }
 
-var vpcpeeringDeleteCmd = &cobra.Command{
-	Use:   "delete [vpc-id] [peering-id]",
-	Short: "Delete a VPC peering",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
+func runVPCPeeringUpdate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("VPC peering", peeringID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+	peering, err := client.FromNetwork().VPCPeerings().Get(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
+	if err != nil || peering == nil || peering.Raw() == nil {
+		return fmt.Errorf("fetching current VPC peering: %w", apiErrFromV2(err))
+	}
+
+	if peering.Raw().Status.State != nil && *peering.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update VPC peering while it is in 'InCreation' state. Please wait until the VPC peering is fully created")
+	}
+
+	if name != "" {
+		peering.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		peering.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromNetwork().VPCPeerings().Update(ctx, peering)
+	if err != nil {
+		return fmt.Errorf("updating VPC peering: %w", apiErrFromV2(err))
+	}
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "PEER VPC", Width: 26},
+			{Header: "REGION", Width: 18},
+			{Header: "STATUS", Width: 15},
 		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		peerVPC := ""
+		if raw.Properties.RemoteVPC != nil {
+			peerVPC = raw.Properties.RemoteVPC.URI
+		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{nameVal, id, peerVPC, regionVal, status}
+		PrintOutput(updated, headers, [][]string{row})
+	} else {
+		fmt.Println(msgUpdatedAsync("VPC peering", peeringID))
+	}
+	return nil
+}
 
-		projectID, err := GetProjectID(cmd)
+func runVPCPeeringDelete(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("VPC peering", peeringID)
 		if err != nil {
 			return err
 		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().VPCPeerings().Get(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
-			if err != nil {
-				return fmt.Errorf("dry-run: VPC peering not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("VPC peering", peeringID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().VPCPeerings().Delete(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().VPCPeerings().Get(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
 		if err != nil {
-			return fmt.Errorf("deleting VPC peering: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: VPC peering not found or inaccessible: %w", apiErrFromV2(err))
 		}
-		headers := []TableColumn{
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{peeringID, status}
-		PrintOutput(result, headers, [][]string{{peeringID, status}})
+		fmt.Println(msgDryRun("VPC peering", peeringID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().VPCPeerings().Delete(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
+	if err != nil {
+		return fmt.Errorf("deleting VPC peering: %w", apiErrFromV2(err))
+	}
+	headers := []TableColumn{
+		{Header: "ID", Width: 26},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{peeringID, status}
+	PrintOutput(result, headers, [][]string{{peeringID, status}})
+	return nil
 }

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -114,370 +114,380 @@ Billing period: Hour (default), Month, or Year.`,
     --local-network 10.0.0.0/24 \
     --remote-network 10.1.0.0/24`,
 	Args: cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		localNetwork, _ := cmd.Flags().GetString("local-network")
-		remoteNetwork, _ := cmd.Flags().GetString("remote-network")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		// Debug output if verbose
-		if verbose {
-			fmt.Println("Creating VPC peering route with the following parameters:")
-			fmt.Printf("  Name:            %s\n", name)
-			fmt.Printf("  Local Network:   %s\n", localNetwork)
-			fmt.Printf("  Remote Network:  %s\n", remoteNetwork)
-			fmt.Printf("  Billing Period:  %s\n", billingPeriod)
-			if len(tags) > 0 {
-				fmt.Printf("  Tags:            %v\n", tags)
-			}
-			fmt.Println()
-		}
-
-		route := aruba.NewVPCPeeringRoute().
-			InVPCPeering(aruba.VPCPeeringRef(projectID, vpcID, peeringID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			WithLocalCIDR(localNetwork).
-			WithRemoteCIDR(remoteNetwork).
-			BilledBy(aruba.BillingPeriod(billingPeriod)).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		resp, err := client.FromNetwork().VPCPeeringRoutes().Create(ctx, route)
-		if err != nil {
-			return fmt.Errorf("creating VPC peering route: %w", apiErrFromV2(err))
-		}
-
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "LOCAL NETWORK", Width: 18},
-				{Header: "REMOTE NETWORK", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			nameVal := name
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			localNet := ""
-			if raw.Properties.LocalNetworkAddress != "" {
-				localNet = raw.Properties.LocalNetworkAddress
-			}
-			remoteNet := ""
-			if raw.Properties.RemoteNetworkAddress != "" {
-				remoteNet = raw.Properties.RemoteNetworkAddress
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{nameVal, id, localNet, remoteNet, status}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("VPC peering route", name))
-		}
-		return nil
-	},
+	RunE: runVPCPeeringRouteCreate,
 }
 
 var vpcpeeringrouteGetCmd = &cobra.Command{
 	Use:   "get [vpc-id] [peering-id] [route-id]",
 	Short: "Get VPC peering route details",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-		routeID := args[2]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		route, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
-		if err != nil {
-			return fmt.Errorf("getting VPC peering route: %w", apiErrFromV2(err))
-		}
-
-		if route != nil && route.Raw() != nil {
-			raw := route.Raw()
-			fmt.Println("\nVPC Peering Route Details:")
-			fmt.Println("==========================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			} else {
-				fmt.Printf("ID:              %s\n", routeID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			fmt.Printf("Local Network:    %s\n", raw.Properties.LocalNetworkAddress)
-			fmt.Printf("Remote Network:   %s\n", raw.Properties.RemoteNetworkAddress)
-			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("VPC peering route not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runVPCPeeringRouteGet,
 }
 
 var vpcpeeringrouteListCmd = &cobra.Command{
 	Use:   "list [vpc-id] [peering-id]",
 	Short: "List VPC peering routes",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
-		if err != nil {
-			return fmt.Errorf("listing VPC peering routes: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "LOCAL NETWORK", Width: 18},
-				{Header: "REMOTE NETWORK", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, route := range list.Items() {
-				raw := route.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				localNetwork := raw.Properties.LocalNetworkAddress
-				remoteNetwork := raw.Properties.RemoteNetworkAddress
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, localNetwork, remoteNetwork, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No VPC peering routes found.")
-		}
-		return nil
-	},
+	RunE:  runVPCPeeringRouteList,
 }
 
 var vpcpeeringrouteUpdateCmd = &cobra.Command{
 	Use:   "update [vpc-id] [peering-id] [route-id]",
 	Short: "Update a VPC peering route",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-		routeID := args[2]
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		localNetwork, _ := cmd.Flags().GetString("local-network")
-		remoteNetwork, _ := cmd.Flags().GetString("remote-network")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-
-		if name == "" && !cmd.Flags().Changed("tags") && localNetwork == "" && remoteNetwork == "" && billingPeriod == "" {
-			return fmt.Errorf("at least one field must be provided for update")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		// Fetch current VPC peering route details
-		route, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
-		if err != nil || route == nil || route.Raw() == nil {
-			return fmt.Errorf("fetching current VPC peering route: %w", apiErrFromV2(err))
-		}
-
-		// Block update if VPC peering route is in 'InCreation' state
-		if route.Raw().Status.State != nil && *route.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update VPC peering route while it is in 'InCreation' state. Please wait until the VPC peering route is fully created")
-		}
-
-		if name != "" {
-			route.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			route.RetaggedAs(tags...)
-		}
-		if localNetwork != "" {
-			route.WithLocalCIDR(localNetwork)
-		}
-		if remoteNetwork != "" {
-			route.WithRemoteCIDR(remoteNetwork)
-		}
-		if billingPeriod != "" {
-			route.BilledBy(aruba.BillingPeriod(billingPeriod))
-		}
-
-		updated, err := client.FromNetwork().VPCPeeringRoutes().Update(ctx, route)
-		if err != nil {
-			return fmt.Errorf("updating VPC peering route: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "LOCAL NETWORK", Width: 18},
-				{Header: "REMOTE NETWORK", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			id := routeID
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			localNet := raw.Properties.LocalNetworkAddress
-			remoteNet := raw.Properties.RemoteNetworkAddress
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{nameVal, id, localNet, remoteNet, status}
-			PrintOutput(updated, headers, [][]string{row})
-		} else {
-			fmt.Println(msgUpdatedAsync("VPC peering route", routeID))
-		}
-		return nil
-	},
+	RunE:  runVPCPeeringRouteUpdate,
 }
 
 var vpcpeeringrouteDeleteCmd = &cobra.Command{
 	Use:   "delete [vpc-id] [peering-id] [route-id]",
 	Short: "Delete a VPC peering route",
 	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpcID := args[0]
-		peeringID := args[1]
-		routeID := args[2]
+	RunE:  runVPCPeeringRouteDelete,
+}
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("VPC peering route", routeID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runVPCPeeringRouteCreate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	localNetwork, _ := cmd.Flags().GetString("local-network")
+	remoteNetwork, _ := cmd.Flags().GetString("remote-network")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// Debug output if verbose
+	if verbose {
+		fmt.Println("Creating VPC peering route with the following parameters:")
+		fmt.Printf("  Name:            %s\n", name)
+		fmt.Printf("  Local Network:   %s\n", localNetwork)
+		fmt.Printf("  Remote Network:  %s\n", remoteNetwork)
+		fmt.Printf("  Billing Period:  %s\n", billingPeriod)
+		if len(tags) > 0 {
+			fmt.Printf("  Tags:            %v\n", tags)
 		}
+		fmt.Println()
+	}
 
-		projectID, err := GetProjectID(cmd)
+	route := aruba.NewVPCPeeringRoute().
+		InVPCPeering(aruba.VPCPeeringRef(projectID, vpcID, peeringID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		WithLocalCIDR(localNetwork).
+		WithRemoteCIDR(remoteNetwork).
+		BilledBy(aruba.BillingPeriod(billingPeriod)).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	resp, err := client.FromNetwork().VPCPeeringRoutes().Create(ctx, route)
+	if err != nil {
+		return fmt.Errorf("creating VPC peering route: %w", apiErrFromV2(err))
+	}
+
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "LOCAL NETWORK", Width: 18},
+			{Header: "REMOTE NETWORK", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		nameVal := name
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		localNet := ""
+		if raw.Properties.LocalNetworkAddress != "" {
+			localNet = raw.Properties.LocalNetworkAddress
+		}
+		remoteNet := ""
+		if raw.Properties.RemoteNetworkAddress != "" {
+			remoteNet = raw.Properties.RemoteNetworkAddress
+		}
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{nameVal, id, localNet, remoteNet, status}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("VPC peering route", name))
+	}
+	return nil
+}
+
+func runVPCPeeringRouteGet(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+	routeID := args[2]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	route, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
+	if err != nil {
+		return fmt.Errorf("getting VPC peering route: %w", apiErrFromV2(err))
+	}
+
+	if route != nil && route.Raw() != nil {
+		raw := route.Raw()
+		fmt.Println("\nVPC Peering Route Details:")
+		fmt.Println("==========================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		} else {
+			fmt.Printf("ID:              %s\n", routeID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		fmt.Printf("Local Network:    %s\n", raw.Properties.LocalNetworkAddress)
+		fmt.Printf("Remote Network:   %s\n", raw.Properties.RemoteNetworkAddress)
+		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+			fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("VPC peering route not found or no data returned.")
+	}
+	return nil
+}
+
+func runVPCPeeringRouteList(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, aruba.VPCPeeringRef(projectID, vpcID, peeringID))
+	if err != nil {
+		return fmt.Errorf("listing VPC peering routes: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "LOCAL NETWORK", Width: 18},
+			{Header: "REMOTE NETWORK", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, route := range list.Items() {
+			raw := route.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			localNetwork := raw.Properties.LocalNetworkAddress
+			remoteNetwork := raw.Properties.RemoteNetworkAddress
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, localNetwork, remoteNetwork, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No VPC peering routes found.")
+	}
+	return nil
+}
+
+func runVPCPeeringRouteUpdate(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+	routeID := args[2]
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	localNetwork, _ := cmd.Flags().GetString("local-network")
+	remoteNetwork, _ := cmd.Flags().GetString("remote-network")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+
+	if name == "" && !cmd.Flags().Changed("tags") && localNetwork == "" && remoteNetwork == "" && billingPeriod == "" {
+		return fmt.Errorf("at least one field must be provided for update")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	// Fetch current VPC peering route details
+	route, err := client.FromNetwork().VPCPeeringRoutes().Get(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
+	if err != nil || route == nil || route.Raw() == nil {
+		return fmt.Errorf("fetching current VPC peering route: %w", apiErrFromV2(err))
+	}
+
+	// Block update if VPC peering route is in 'InCreation' state
+	if route.Raw().Status.State != nil && *route.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update VPC peering route while it is in 'InCreation' state. Please wait until the VPC peering route is fully created")
+	}
+
+	if name != "" {
+		route.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		route.RetaggedAs(tags...)
+	}
+	if localNetwork != "" {
+		route.WithLocalCIDR(localNetwork)
+	}
+	if remoteNetwork != "" {
+		route.WithRemoteCIDR(remoteNetwork)
+	}
+	if billingPeriod != "" {
+		route.BilledBy(aruba.BillingPeriod(billingPeriod))
+	}
+
+	updated, err := client.FromNetwork().VPCPeeringRoutes().Update(ctx, route)
+	if err != nil {
+		return fmt.Errorf("updating VPC peering route: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "LOCAL NETWORK", Width: 18},
+			{Header: "REMOTE NETWORK", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := routeID
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		localNet := raw.Properties.LocalNetworkAddress
+		remoteNet := raw.Properties.RemoteNetworkAddress
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{nameVal, id, localNet, remoteNet, status}
+		PrintOutput(updated, headers, [][]string{row})
+	} else {
+		fmt.Println(msgUpdatedAsync("VPC peering route", routeID))
+	}
+	return nil
+}
+
+func runVPCPeeringRouteDelete(cmd *cobra.Command, args []string) error {
+	vpcID := args[0]
+	peeringID := args[1]
+	routeID := args[2]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("VPC peering route", routeID)
 		if err != nil {
 			return err
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().VPCPeeringRoutes().Get(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
-			if err != nil {
-				return fmt.Errorf("dry-run: VPC peering route not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("VPC peering route", routeID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().VPCPeeringRoutes().Delete(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().VPCPeeringRoutes().Get(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
 		if err != nil {
-			return fmt.Errorf("deleting VPC peering route: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: VPC peering route not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		headers := []TableColumn{
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{routeID, status}
-		PrintOutput(result, headers, [][]string{{routeID, status}})
+		fmt.Println(msgDryRun("VPC peering route", routeID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().VPCPeeringRoutes().Delete(ctx, aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
+	if err != nil {
+		return fmt.Errorf("deleting VPC peering route: %w", apiErrFromV2(err))
+	}
+
+	headers := []TableColumn{
+		{Header: "ID", Width: 26},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{routeID, status}
+	PrintOutput(result, headers, [][]string{{routeID, status}})
+	return nil
 }

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -101,344 +101,354 @@ with --onprem-subnet. Both values should be valid CIDR blocks.`,
     --cloud-subnet 10.0.0.0/24 \
     --onprem-subnet 192.168.1.0/24`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		cloudSubnet, _ := cmd.Flags().GetString("cloud-subnet")
-		onPremSubnet, _ := cmd.Flags().GetString("onprem-subnet")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		// Debug output if verbose
-		if verbose {
-			fmt.Println("Creating VPN route with the following parameters:")
-			fmt.Printf("  Name:          %s\n", name)
-			fmt.Printf("  Region:        %s\n", region)
-			fmt.Printf("  Cloud Subnet:  %s\n", cloudSubnet)
-			fmt.Printf("  OnPrem Subnet: %s\n", onPremSubnet)
-			if len(tags) > 0 {
-				fmt.Printf("  Tags:          %v\n", tags)
-			}
-			fmt.Println()
-		}
-
-		route := aruba.NewVPNRoute().
-			InVPNTunnel(aruba.VPNTunnelRef(projectID, vpnTunnelID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			WithCloudSubnet(cloudSubnet).
-			WithOnPremSubnet(onPremSubnet).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		resp, err := client.FromNetwork().VPNRoutes().Create(ctx, route)
-		if err != nil {
-			return fmt.Errorf("creating VPN route: %w", apiErrFromV2(err))
-		}
-
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "CLOUD SUBNET", Width: 18},
-				{Header: "ONPREM SUBNET", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			cloudSubnetVal := raw.Properties.CloudSubnet.CIDR
-			onPremSubnetVal := raw.Properties.OnPremSubnet
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{name, id, cloudSubnetVal, onPremSubnetVal, status}
-			PrintOutput(resp, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("VPN route", name))
-		}
-		return nil
-	},
+	RunE: runVPNRouteCreate,
 }
 
 var vpnrouteGetCmd = &cobra.Command{
 	Use:   "get [vpn-tunnel-id] [route-id]",
 	Short: "Get VPN tunnel route details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
-		routeID := args[1]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		route, err := client.FromNetwork().VPNRoutes().Get(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
-		if err != nil {
-			return fmt.Errorf("getting VPN route: %w", apiErrFromV2(err))
-		}
-
-		if route != nil && route.Raw() != nil {
-			raw := route.Raw()
-			fmt.Println("\nVPN Route Details:")
-			fmt.Println("==================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-			fmt.Printf("Cloud Subnet:    %s\n", raw.Properties.CloudSubnet.CIDR)
-			fmt.Printf("OnPrem Subnet:   %s\n", raw.Properties.OnPremSubnet)
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		} else {
-			fmt.Println("VPN route not found or no data returned.")
-		}
-		return nil
-	},
+	RunE:  runVPNRouteGet,
 }
 
 var vpnrouteListCmd = &cobra.Command{
 	Use:   "list [vpn-tunnel-id]",
 	Short: "List VPN tunnel routes",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().VPNRoutes().List(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
-		if err != nil {
-			return fmt.Errorf("listing VPN routes: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "CLOUD SUBNET", Width: 18},
-				{Header: "ONPREM SUBNET", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, route := range list.Items() {
-				raw := route.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				cloudSubnet := raw.Properties.CloudSubnet.CIDR
-				onPremSubnet := raw.Properties.OnPremSubnet
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, cloudSubnet, onPremSubnet, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No VPN routes found.")
-		}
-		return nil
-	},
+	RunE:  runVPNRouteList,
 }
 
 var vpnrouteUpdateCmd = &cobra.Command{
 	Use:   "update [vpn-tunnel-id] [route-id]",
 	Short: "Update a VPN tunnel route",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
-		routeID := args[1]
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		cloudSubnet, _ := cmd.Flags().GetString("cloud-subnet")
-		onPremSubnet, _ := cmd.Flags().GetString("onprem-subnet")
-
-		if name == "" && !cmd.Flags().Changed("tags") && cloudSubnet == "" && onPremSubnet == "" {
-			return fmt.Errorf("at least one field must be provided for update")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		// Fetch current VPN route details
-		route, err := client.FromNetwork().VPNRoutes().Get(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
-		if err != nil || route == nil || route.Raw() == nil {
-			return fmt.Errorf("fetching current VPN route: %w", apiErrFromV2(err))
-		}
-
-		// Block update if VPN route is in 'InCreation' state
-		if route.Raw().Status.State != nil && *route.Raw().Status.State == StateInCreation {
-			return fmt.Errorf("cannot update VPN route while it is in 'InCreation' state. Please wait until the VPN route is fully created")
-		}
-
-		if name != "" {
-			route.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			route.RetaggedAs(tags...)
-		}
-		if cloudSubnet != "" {
-			route.WithCloudSubnet(cloudSubnet)
-		}
-		if onPremSubnet != "" {
-			route.WithOnPremSubnet(onPremSubnet)
-		}
-
-		updated, err := client.FromNetwork().VPNRoutes().Update(ctx, route)
-		if err != nil {
-			return fmt.Errorf("updating VPN route: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "CLOUD SUBNET", Width: 18},
-				{Header: "ONPREM SUBNET", Width: 18},
-				{Header: "STATUS", Width: 15},
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			cloudSubnetVal := raw.Properties.CloudSubnet.CIDR
-			onPremSubnetVal := raw.Properties.OnPremSubnet
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			row := []string{nameVal, id, cloudSubnetVal, onPremSubnetVal, status}
-			PrintOutput(updated, headers, [][]string{row})
-		} else {
-			fmt.Println(msgUpdatedAsync("VPN route", routeID))
-		}
-		return nil
-	},
+	RunE:  runVPNRouteUpdate,
 }
 
 var vpnrouteDeleteCmd = &cobra.Command{
 	Use:   "delete [vpn-tunnel-id] [route-id]",
 	Short: "Delete a VPN tunnel route",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
-		routeID := args[1]
+	RunE:  runVPNRouteDelete,
+}
 
-		projectID, err := GetProjectID(cmd)
+func runVPNRouteCreate(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	cloudSubnet, _ := cmd.Flags().GetString("cloud-subnet")
+	onPremSubnet, _ := cmd.Flags().GetString("onprem-subnet")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// Debug output if verbose
+	if verbose {
+		fmt.Println("Creating VPN route with the following parameters:")
+		fmt.Printf("  Name:          %s\n", name)
+		fmt.Printf("  Region:        %s\n", region)
+		fmt.Printf("  Cloud Subnet:  %s\n", cloudSubnet)
+		fmt.Printf("  OnPrem Subnet: %s\n", onPremSubnet)
+		if len(tags) > 0 {
+			fmt.Printf("  Tags:          %v\n", tags)
+		}
+		fmt.Println()
+	}
+
+	route := aruba.NewVPNRoute().
+		InVPNTunnel(aruba.VPNTunnelRef(projectID, vpnTunnelID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		WithCloudSubnet(cloudSubnet).
+		WithOnPremSubnet(onPremSubnet).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	resp, err := client.FromNetwork().VPNRoutes().Create(ctx, route)
+	if err != nil {
+		return fmt.Errorf("creating VPN route: %w", apiErrFromV2(err))
+	}
+
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "CLOUD SUBNET", Width: 18},
+			{Header: "ONPREM SUBNET", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		cloudSubnetVal := raw.Properties.CloudSubnet.CIDR
+		onPremSubnetVal := raw.Properties.OnPremSubnet
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{name, id, cloudSubnetVal, onPremSubnetVal, status}
+		PrintOutput(resp, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("VPN route", name))
+	}
+	return nil
+}
+
+func runVPNRouteGet(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+	routeID := args[1]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	route, err := client.FromNetwork().VPNRoutes().Get(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
+	if err != nil {
+		return fmt.Errorf("getting VPN route: %w", apiErrFromV2(err))
+	}
+
+	if route != nil && route.Raw() != nil {
+		raw := route.Raw()
+		fmt.Println("\nVPN Route Details:")
+		fmt.Println("==================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+		fmt.Printf("Cloud Subnet:    %s\n", raw.Properties.CloudSubnet.CIDR)
+		fmt.Printf("OnPrem Subnet:   %s\n", raw.Properties.OnPremSubnet)
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	} else {
+		fmt.Println("VPN route not found or no data returned.")
+	}
+	return nil
+}
+
+func runVPNRouteList(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().VPNRoutes().List(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
+	if err != nil {
+		return fmt.Errorf("listing VPN routes: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "CLOUD SUBNET", Width: 18},
+			{Header: "ONPREM SUBNET", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, route := range list.Items() {
+			raw := route.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			cloudSubnet := raw.Properties.CloudSubnet.CIDR
+			onPremSubnet := raw.Properties.OnPremSubnet
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, cloudSubnet, onPremSubnet, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No VPN routes found.")
+	}
+	return nil
+}
+
+func runVPNRouteUpdate(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+	routeID := args[1]
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	cloudSubnet, _ := cmd.Flags().GetString("cloud-subnet")
+	onPremSubnet, _ := cmd.Flags().GetString("onprem-subnet")
+
+	if name == "" && !cmd.Flags().Changed("tags") && cloudSubnet == "" && onPremSubnet == "" {
+		return fmt.Errorf("at least one field must be provided for update")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	// Fetch current VPN route details
+	route, err := client.FromNetwork().VPNRoutes().Get(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
+	if err != nil || route == nil || route.Raw() == nil {
+		return fmt.Errorf("fetching current VPN route: %w", apiErrFromV2(err))
+	}
+
+	// Block update if VPN route is in 'InCreation' state
+	if route.Raw().Status.State != nil && *route.Raw().Status.State == StateInCreation {
+		return fmt.Errorf("cannot update VPN route while it is in 'InCreation' state. Please wait until the VPN route is fully created")
+	}
+
+	if name != "" {
+		route.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		route.RetaggedAs(tags...)
+	}
+	if cloudSubnet != "" {
+		route.WithCloudSubnet(cloudSubnet)
+	}
+	if onPremSubnet != "" {
+		route.WithOnPremSubnet(onPremSubnet)
+	}
+
+	updated, err := client.FromNetwork().VPNRoutes().Update(ctx, route)
+	if err != nil {
+		return fmt.Errorf("updating VPN route: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "CLOUD SUBNET", Width: 18},
+			{Header: "ONPREM SUBNET", Width: 18},
+			{Header: "STATUS", Width: 15},
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		cloudSubnetVal := raw.Properties.CloudSubnet.CIDR
+		onPremSubnetVal := raw.Properties.OnPremSubnet
+		status := ""
+		if raw.Status.State != nil {
+			status = string(*raw.Status.State)
+		}
+		row := []string{nameVal, id, cloudSubnetVal, onPremSubnetVal, status}
+		PrintOutput(updated, headers, [][]string{row})
+	} else {
+		fmt.Println(msgUpdatedAsync("VPN route", routeID))
+	}
+	return nil
+}
+
+func runVPNRouteDelete(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+	routeID := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("VPN route", routeID)
 		if err != nil {
 			return err
 		}
-
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("VPN route", routeID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().VPNRoutes().Get(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
-			if err != nil {
-				return fmt.Errorf("dry-run: VPN route not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("VPN route", routeID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().VPNRoutes().Delete(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().VPNRoutes().Get(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
 		if err != nil {
-			return fmt.Errorf("deleting VPN route: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: VPN route not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		headers := []TableColumn{
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-		status := "deleted"
-		result := struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-		}{routeID, status}
-		PrintOutput(result, headers, [][]string{{routeID, status}})
+		fmt.Println(msgDryRun("VPN route", routeID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().VPNRoutes().Delete(ctx, aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
+	if err != nil {
+		return fmt.Errorf("deleting VPN route: %w", apiErrFromV2(err))
+	}
+
+	headers := []TableColumn{
+		{Header: "ID", Width: 26},
+		{Header: "STATUS", Width: 15},
+	}
+	status := "deleted"
+	result := struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}{routeID, status}
+	PrintOutput(result, headers, [][]string{{routeID, status}})
+	return nil
 }

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -194,154 +194,14 @@ var vpntunnelListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all VPN tunnels",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromNetwork().VPNTunnels().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing VPN tunnels: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 40},
-				{Header: "ID", Width: 25},
-				{Header: "REGION", Width: 18},
-				{Header: "TYPE", Width: 15},
-				{Header: "STATUS", Width: 15},
-			}
-			var rows [][]string
-			for _, vpn := range list.Items() {
-				raw := vpn.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				vpnType := ""
-				if raw.Properties.VPNType != nil {
-					vpnType = string(*raw.Properties.VPNType)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, vpnType, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No VPN tunnels found")
-		}
-		return nil
-	},
+	RunE:  runVPNTunnelList,
 }
 
 var vpntunnelGetCmd = &cobra.Command{
 	Use:   "get <vpn-tunnel-id>",
 	Short: "Get VPN tunnel details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		vpn, err := client.FromNetwork().VPNTunnels().Get(ctx, aruba.VPNTunnelRef(projectID, vpnID))
-		if err != nil {
-			return fmt.Errorf("getting VPN tunnel details: %w", apiErrFromV2(err))
-		}
-
-		if vpn != nil && vpn.Raw() != nil {
-			raw := vpn.Raw()
-
-			fmt.Println("\nVPN Tunnel Details:")
-			fmt.Println("===================")
-
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-			if raw.Properties.VPNType != nil {
-				fmt.Printf("VPN Type:        %s\n", *raw.Properties.VPNType)
-			}
-			if raw.Properties.VPNClientProtocol != nil {
-				fmt.Printf("Protocol:        %s\n", *raw.Properties.VPNClientProtocol)
-			}
-			if raw.Properties.VPNClientSettingsCommon != nil && raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP != nil {
-				fmt.Printf("Peer IP:         %s\n", *raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP)
-			}
-			if raw.Properties.IPConfigurationsCommon != nil {
-				fmt.Println("\nIP Configuration:")
-				if raw.Properties.IPConfigurationsCommon.VPC != nil {
-					fmt.Printf("  VPC:           %s\n", raw.Properties.IPConfigurationsCommon.VPC.URI)
-				}
-				if raw.Properties.IPConfigurationsCommon.Subnet != nil {
-					fmt.Printf("  Subnet CIDR:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.CIDR)
-					if raw.Properties.IPConfigurationsCommon.Subnet.Name != "" {
-						fmt.Printf("  Subnet Name:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.Name)
-					}
-				}
-				if raw.Properties.IPConfigurationsCommon.PublicIP != nil {
-					fmt.Printf("  Public IP:     %s\n", raw.Properties.IPConfigurationsCommon.PublicIP.URI)
-				}
-			}
-			if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-				fmt.Printf("\nBilling Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
-			}
-			if raw.Metadata.CreationDate != nil {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-		}
-		return nil
-	},
+	RunE:  runVPNTunnelGet,
 }
 
 var vpntunnelCreateCmd = &cobra.Command{
@@ -364,291 +224,441 @@ IKE and ESP settings are optional; the platform uses secure defaults when omitte
     --elastic-ip-id <eip-id> \
     --psk my-pre-shared-key`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		vpnType, _ := cmd.Flags().GetString("vpn-type")
-		protocol, _ := cmd.Flags().GetString("protocol")
-		peerIP, _ := cmd.Flags().GetString("peer-ip")
-		vpcID, _ := cmd.Flags().GetString("vpc-id")
-		subnetCIDR, _ := cmd.Flags().GetString("subnet-cidr")
-		subnetName, _ := cmd.Flags().GetString("subnet-name")
-		publicIPID, _ := cmd.Flags().GetString("elastic-ip-id")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		psk, _ := cmd.Flags().GetString("psk")
-
-		// IKE settings
-		ikeLifetime, _ := cmd.Flags().GetInt32("ike-lifetime")
-		ikeEncryption, _ := cmd.Flags().GetString("ike-encryption")
-		ikeHash, _ := cmd.Flags().GetString("ike-hash")
-		ikeDHGroup, _ := cmd.Flags().GetString("ike-dh-group")
-		ikeDPDAction, _ := cmd.Flags().GetString("ike-dpd-action")
-		ikeDPDInterval, _ := cmd.Flags().GetInt32("ike-dpd-interval")
-		ikeDPDTimeout, _ := cmd.Flags().GetInt32("ike-dpd-timeout")
-		// ESP settings
-		espLifetime, _ := cmd.Flags().GetInt32("esp-lifetime")
-		espEncryption, _ := cmd.Flags().GetString("esp-encryption")
-		if espEncryption == "" {
-			espEncryption = "aes256"
-		}
-		espHash, _ := cmd.Flags().GetString("esp-hash")
-		espPFS, _ := cmd.Flags().GetString("esp-pfs")
-		// PSK settings
-		pskCloudSite, _ := cmd.Flags().GetString("psk-cloud-site")
-		pskOnpremSite, _ := cmd.Flags().GetString("psk-onprem-site")
-
-		if subnetCIDR == "" && subnetName == "" {
-			return fmt.Errorf("--subnet-cidr or --subnet-name is required")
-		}
-
-		for _, check := range []struct {
-			val   string
-			flag  string
-			valid []string
-		}{
-			{ikeEncryption, "ike-encryption", vpnEncryptionAlgorithms},
-			{ikeHash, "ike-hash", vpnHashAlgorithms},
-			{ikeDHGroup, "ike-dh-group", vpnDHGroups},
-			{ikeDPDAction, "ike-dpd-action", vpnDPDActions},
-			{espEncryption, "esp-encryption", vpnEncryptionAlgorithms},
-			{espHash, "esp-hash", vpnHashAlgorithms},
-			{espPFS, "esp-pfs", vpnPFSGroups},
-		} {
-			if err := vpnValidateEnum(check.val, check.flag, check.valid); err != nil {
-				return err
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		// Build IP config
-		ipConfig := aruba.NewVPNIPConfig().
-			WithVPC(aruba.VPCRef(projectID, vpcID)).
-			WithElasticIP(aruba.ElasticIPRef(projectID, publicIPID)).
-			WithSubnet(subnetName, subnetCIDR)
-
-		// Build IKE settings
-		ike := aruba.NewVPNIKE().WithLifetimeSeconds(int(ikeLifetime))
-		if ikeEncryption != "" {
-			ike.WithEncryption(aruba.IKEEncryption(ikeEncryption))
-		}
-		if ikeHash != "" {
-			ike.WithHash(aruba.IKEHash(ikeHash))
-		}
-		if ikeDHGroup != "" {
-			ike.WithDHGroup(aruba.IKEDHGroup(ikeDHGroup))
-		}
-		if ikeDPDAction != "" {
-			ike.WithDPDAction(aruba.IKEDPDAction(ikeDPDAction))
-		}
-		if ikeDPDInterval > 0 {
-			ike.WithDPDIntervalSeconds(int(ikeDPDInterval))
-		}
-		if ikeDPDTimeout > 0 {
-			ike.WithDPDTimeoutSeconds(int(ikeDPDTimeout))
-		}
-
-		// Build ESP settings
-		esp := aruba.NewVPNESP().
-			WithEncryption(aruba.ESPEncryption(espEncryption)).
-			WithLifetimeSeconds(int(espLifetime))
-		if espHash != "" {
-			esp.WithHash(aruba.ESPHash(espHash))
-		}
-		if espPFS != "" {
-			esp.WithPFS(aruba.ESPPFSGroup(espPFS))
-		}
-
-		// Build PSK settings
-		pskBuilder := aruba.NewVPNPSK()
-		if psk != "" {
-			pskBuilder.WithKey(psk)
-		}
-		if pskCloudSite != "" {
-			pskBuilder.WithCloudSite(pskCloudSite)
-		}
-		if pskOnpremSite != "" {
-			pskBuilder.WithOnPremSite(pskOnpremSite)
-		}
-
-		tunnel := aruba.NewVPNTunnel().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			OfType(aruba.VPNType(vpnType)).
-			WithVPNClientProtocol(aruba.VPNClientProtocol(protocol)).
-			BilledBy(aruba.BillingPeriod(billingPeriod)).
-			WithPeerClientPublicIP(peerIP).
-			WithIPConfig(ipConfig).
-			WithIKESettings(ike).
-			WithESPSettings(esp).
-			WithPSKSettings(pskBuilder).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		resp, err := client.FromNetwork().VPNTunnels().Create(ctx, tunnel)
-		if err != nil {
-			return fmt.Errorf("creating VPN tunnel: %w", apiErrFromV2(err))
-		}
-
-		if resp != nil && resp.Raw() != nil {
-			raw := resp.Raw()
-			fmt.Printf("\n%s\n", msgCreated("VPN Tunnel", name))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:       %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:     %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:      %s\n", *raw.Metadata.URI)
-			}
-			if raw.Properties.VPNType != nil {
-				fmt.Printf("Type:     %s\n", *raw.Properties.VPNType)
-			}
-			if raw.Properties.VPNClientProtocol != nil {
-				fmt.Printf("Protocol: %s\n", *raw.Properties.VPNClientProtocol)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:     %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgCreatedAsync("VPN Tunnel", name))
-		}
-		return nil
-	},
+	RunE: runVPNTunnelCreate,
 }
 
 var vpntunnelUpdateCmd = &cobra.Command{
 	Use:   "update <vpn-tunnel-id>",
 	Short: "Update a VPN tunnel",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		vpn, err := client.FromNetwork().VPNTunnels().Get(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
-		if err != nil {
-			return fmt.Errorf("getting VPN tunnel: %w", apiErrFromV2(err))
-		}
-
-		if vpn == nil || vpn.ID() == "" {
-			return fmt.Errorf("VPN tunnel not found")
-		}
-
-		if vpn.State() == StateInCreation {
-			return fmt.Errorf("cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created")
-		}
-
-		if name != "" {
-			vpn.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			vpn.RetaggedAs(tags...)
-		}
-		// sdk-go v1.0.0 fromResponse now rehydrates IKE/ESP/PSK into the wrapper
-		// via IKE()/ESP()/PSK() accessors, so Update carries them in the PUT body
-		// without manual re-attachment (closes #132 / TD-034).
-
-		updated, err := client.FromNetwork().VPNTunnels().Update(ctx, vpn)
-		if err != nil {
-			return fmt.Errorf("updating VPN tunnel: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("VPN Tunnel", vpnTunnelID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("VPN Tunnel", vpnTunnelID))
-		}
-		return nil
-	},
+	RunE:  runVPNTunnelUpdate,
 }
 
 var vpntunnelDeleteCmd = &cobra.Command{
 	Use:   "delete <vpn-tunnel-id>",
 	Short: "Delete a VPN tunnel",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vpnTunnelID := args[0]
+	RunE:  runVPNTunnelDelete,
+}
 
-		skipConfirm, _ := cmd.Flags().GetBool("yes")
-		if !skipConfirm {
-			ok, err := confirmDelete("VPN tunnel", vpnTunnelID)
-			if err != nil {
-				return err
+func runVPNTunnelList(cmd *cobra.Command, args []string) error {
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromNetwork().VPNTunnels().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing VPN tunnels: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 40},
+			{Header: "ID", Width: 25},
+			{Header: "REGION", Width: 18},
+			{Header: "TYPE", Width: 15},
+			{Header: "STATUS", Width: 15},
+		}
+		var rows [][]string
+		for _, vpn := range list.Items() {
+			raw := vpn.Raw()
+			if raw == nil {
+				continue
 			}
-			if !ok {
-				return nil
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			vpnType := ""
+			if raw.Properties.VPNType != nil {
+				vpnType = string(*raw.Properties.VPNType)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, vpnType, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No VPN tunnels found")
+	}
+	return nil
+}
+
+func runVPNTunnelGet(cmd *cobra.Command, args []string) error {
+	vpnID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	vpn, err := client.FromNetwork().VPNTunnels().Get(ctx, aruba.VPNTunnelRef(projectID, vpnID))
+	if err != nil {
+		return fmt.Errorf("getting VPN tunnel details: %w", apiErrFromV2(err))
+	}
+
+	if vpn != nil && vpn.Raw() != nil {
+		raw := vpn.Raw()
+
+		fmt.Println("\nVPN Tunnel Details:")
+		fmt.Println("===================")
+
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+		if raw.Properties.VPNType != nil {
+			fmt.Printf("VPN Type:        %s\n", *raw.Properties.VPNType)
+		}
+		if raw.Properties.VPNClientProtocol != nil {
+			fmt.Printf("Protocol:        %s\n", *raw.Properties.VPNClientProtocol)
+		}
+		if raw.Properties.VPNClientSettingsCommon != nil && raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP != nil {
+			fmt.Printf("Peer IP:         %s\n", *raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP)
+		}
+		if raw.Properties.IPConfigurationsCommon != nil {
+			fmt.Println("\nIP Configuration:")
+			if raw.Properties.IPConfigurationsCommon.VPC != nil {
+				fmt.Printf("  VPC:           %s\n", raw.Properties.IPConfigurationsCommon.VPC.URI)
+			}
+			if raw.Properties.IPConfigurationsCommon.Subnet != nil {
+				fmt.Printf("  Subnet CIDR:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.CIDR)
+				if raw.Properties.IPConfigurationsCommon.Subnet.Name != "" {
+					fmt.Printf("  Subnet Name:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.Name)
+				}
+			}
+			if raw.Properties.IPConfigurationsCommon.PublicIP != nil {
+				fmt.Printf("  Public IP:     %s\n", raw.Properties.IPConfigurationsCommon.PublicIP.URI)
 			}
 		}
+		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+			fmt.Printf("\nBilling Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
+		}
+		if raw.Metadata.CreationDate != nil {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+	}
+	return nil
+}
 
-		projectID, err := GetProjectID(cmd)
+func runVPNTunnelCreate(cmd *cobra.Command, args []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	vpnType, _ := cmd.Flags().GetString("vpn-type")
+	protocol, _ := cmd.Flags().GetString("protocol")
+	peerIP, _ := cmd.Flags().GetString("peer-ip")
+	vpcID, _ := cmd.Flags().GetString("vpc-id")
+	subnetCIDR, _ := cmd.Flags().GetString("subnet-cidr")
+	subnetName, _ := cmd.Flags().GetString("subnet-name")
+	publicIPID, _ := cmd.Flags().GetString("elastic-ip-id")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	psk, _ := cmd.Flags().GetString("psk")
+
+	// IKE settings
+	ikeLifetime, _ := cmd.Flags().GetInt32("ike-lifetime")
+	ikeEncryption, _ := cmd.Flags().GetString("ike-encryption")
+	ikeHash, _ := cmd.Flags().GetString("ike-hash")
+	ikeDHGroup, _ := cmd.Flags().GetString("ike-dh-group")
+	ikeDPDAction, _ := cmd.Flags().GetString("ike-dpd-action")
+	ikeDPDInterval, _ := cmd.Flags().GetInt32("ike-dpd-interval")
+	ikeDPDTimeout, _ := cmd.Flags().GetInt32("ike-dpd-timeout")
+	// ESP settings
+	espLifetime, _ := cmd.Flags().GetInt32("esp-lifetime")
+	espEncryption, _ := cmd.Flags().GetString("esp-encryption")
+	if espEncryption == "" {
+		espEncryption = "aes256"
+	}
+	espHash, _ := cmd.Flags().GetString("esp-hash")
+	espPFS, _ := cmd.Flags().GetString("esp-pfs")
+	// PSK settings
+	pskCloudSite, _ := cmd.Flags().GetString("psk-cloud-site")
+	pskOnpremSite, _ := cmd.Flags().GetString("psk-onprem-site")
+
+	if subnetCIDR == "" && subnetName == "" {
+		return fmt.Errorf("--subnet-cidr or --subnet-name is required")
+	}
+
+	for _, check := range []struct {
+		val   string
+		flag  string
+		valid []string
+	}{
+		{ikeEncryption, "ike-encryption", vpnEncryptionAlgorithms},
+		{ikeHash, "ike-hash", vpnHashAlgorithms},
+		{ikeDHGroup, "ike-dh-group", vpnDHGroups},
+		{ikeDPDAction, "ike-dpd-action", vpnDPDActions},
+		{espEncryption, "esp-encryption", vpnEncryptionAlgorithms},
+		{espHash, "esp-hash", vpnHashAlgorithms},
+		{espPFS, "esp-pfs", vpnPFSGroups},
+	} {
+		if err := vpnValidateEnum(check.val, check.flag, check.valid); err != nil {
+			return err
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	// Build IP config
+	ipConfig := aruba.NewVPNIPConfig().
+		WithVPC(aruba.VPCRef(projectID, vpcID)).
+		WithElasticIP(aruba.ElasticIPRef(projectID, publicIPID)).
+		WithSubnet(subnetName, subnetCIDR)
+
+	// Build IKE settings
+	ike := aruba.NewVPNIKE().WithLifetimeSeconds(int(ikeLifetime))
+	if ikeEncryption != "" {
+		ike.WithEncryption(aruba.IKEEncryption(ikeEncryption))
+	}
+	if ikeHash != "" {
+		ike.WithHash(aruba.IKEHash(ikeHash))
+	}
+	if ikeDHGroup != "" {
+		ike.WithDHGroup(aruba.IKEDHGroup(ikeDHGroup))
+	}
+	if ikeDPDAction != "" {
+		ike.WithDPDAction(aruba.IKEDPDAction(ikeDPDAction))
+	}
+	if ikeDPDInterval > 0 {
+		ike.WithDPDIntervalSeconds(int(ikeDPDInterval))
+	}
+	if ikeDPDTimeout > 0 {
+		ike.WithDPDTimeoutSeconds(int(ikeDPDTimeout))
+	}
+
+	// Build ESP settings
+	esp := aruba.NewVPNESP().
+		WithEncryption(aruba.ESPEncryption(espEncryption)).
+		WithLifetimeSeconds(int(espLifetime))
+	if espHash != "" {
+		esp.WithHash(aruba.ESPHash(espHash))
+	}
+	if espPFS != "" {
+		esp.WithPFS(aruba.ESPPFSGroup(espPFS))
+	}
+
+	// Build PSK settings
+	pskBuilder := aruba.NewVPNPSK()
+	if psk != "" {
+		pskBuilder.WithKey(psk)
+	}
+	if pskCloudSite != "" {
+		pskBuilder.WithCloudSite(pskCloudSite)
+	}
+	if pskOnpremSite != "" {
+		pskBuilder.WithOnPremSite(pskOnpremSite)
+	}
+
+	tunnel := aruba.NewVPNTunnel().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		OfType(aruba.VPNType(vpnType)).
+		WithVPNClientProtocol(aruba.VPNClientProtocol(protocol)).
+		BilledBy(aruba.BillingPeriod(billingPeriod)).
+		WithPeerClientPublicIP(peerIP).
+		WithIPConfig(ipConfig).
+		WithIKESettings(ike).
+		WithESPSettings(esp).
+		WithPSKSettings(pskBuilder).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	resp, err := client.FromNetwork().VPNTunnels().Create(ctx, tunnel)
+	if err != nil {
+		return fmt.Errorf("creating VPN tunnel: %w", apiErrFromV2(err))
+	}
+
+	if resp != nil && resp.Raw() != nil {
+		raw := resp.Raw()
+		fmt.Printf("\n%s\n", msgCreated("VPN Tunnel", name))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:       %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:     %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:      %s\n", *raw.Metadata.URI)
+		}
+		if raw.Properties.VPNType != nil {
+			fmt.Printf("Type:     %s\n", *raw.Properties.VPNType)
+		}
+		if raw.Properties.VPNClientProtocol != nil {
+			fmt.Printf("Protocol: %s\n", *raw.Properties.VPNClientProtocol)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:     %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgCreatedAsync("VPN Tunnel", name))
+	}
+	return nil
+}
+
+func runVPNTunnelUpdate(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	vpn, err := client.FromNetwork().VPNTunnels().Get(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
+	if err != nil {
+		return fmt.Errorf("getting VPN tunnel: %w", apiErrFromV2(err))
+	}
+
+	if vpn == nil || vpn.ID() == "" {
+		return fmt.Errorf("VPN tunnel not found")
+	}
+
+	if vpn.State() == StateInCreation {
+		return fmt.Errorf("cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created")
+	}
+
+	if name != "" {
+		vpn.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		vpn.RetaggedAs(tags...)
+	}
+	// sdk-go v1.0.0 fromResponse now rehydrates IKE/ESP/PSK into the wrapper
+	// via IKE()/ESP()/PSK() accessors, so Update carries them in the PUT body
+	// without manual re-attachment (closes #132 / TD-034).
+
+	updated, err := client.FromNetwork().VPNTunnels().Update(ctx, vpn)
+	if err != nil {
+		return fmt.Errorf("updating VPN tunnel: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("VPN Tunnel", vpnTunnelID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("VPN Tunnel", vpnTunnelID))
+	}
+	return nil
+}
+
+func runVPNTunnelDelete(cmd *cobra.Command, args []string) error {
+	vpnTunnelID := args[0]
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		ok, err := confirmDelete("VPN tunnel", vpnTunnelID)
 		if err != nil {
 			return err
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromNetwork().VPNTunnels().Get(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
-			if err != nil {
-				return fmt.Errorf("dry-run: VPN tunnel not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("VPN tunnel", vpnTunnelID))
+		if !ok {
 			return nil
 		}
+	}
 
-		err = client.FromNetwork().VPNTunnels().Delete(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromNetwork().VPNTunnels().Get(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
 		if err != nil {
-			return fmt.Errorf("deleting VPN tunnel: %w", apiErrFromV2(err))
+			return fmt.Errorf("dry-run: VPN tunnel not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		fmt.Println(msgDeleted("VPN tunnel", vpnTunnelID))
+		fmt.Println(msgDryRun("VPN tunnel", vpnTunnelID))
 		return nil
-	},
+	}
+
+	err = client.FromNetwork().VPNTunnels().Delete(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
+	if err != nil {
+		return fmt.Errorf("deleting VPN tunnel: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("VPN tunnel", vpnTunnelID))
+	return nil
 }

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -118,395 +118,405 @@ The job is enabled by default; pass --enabled=false to create it disabled.`,
     --step-resource-uri /projects/<pid>/providers/Aruba.Compute/cloudServers/<id> \
     --step-action-uri poweroff`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		jobType, _ := cmd.Flags().GetString("job-type")
-		scheduleAt, _ := cmd.Flags().GetString("schedule-at")
-		cron, _ := cmd.Flags().GetString("cron")
-		executeUntil, _ := cmd.Flags().GetString("execute-until")
-		enabled, _ := cmd.Flags().GetBool("enabled")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		stepResourceURI, _ := cmd.Flags().GetString("step-resource-uri")
-		stepActionURI, _ := cmd.Flags().GetString("step-action-uri")
-		stepHTTPVerb, _ := cmd.Flags().GetString("step-http-verb")
-		stepName, _ := cmd.Flags().GetString("step-name")
-
-		if jobType != "OneShot" && jobType != "Recurring" {
-			return fmt.Errorf("--job-type must be either 'OneShot' or 'Recurring'")
-		}
-		if jobType == "OneShot" && scheduleAt == "" {
-			return fmt.Errorf("--schedule-at is required for OneShot jobs")
-		}
-		if jobType == "Recurring" {
-			if cron == "" {
-				return fmt.Errorf("--cron is required for Recurring jobs")
-			}
-			if executeUntil == "" {
-				return fmt.Errorf("--execute-until is required for Recurring jobs")
-			}
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		job := aruba.NewJob().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			RetaggedAs(tags...)
-
-		if enabled {
-			job.Enabled()
-		} else {
-			job.Disabled()
-		}
-
-		if jobType == "OneShot" {
-			t, err := time.Parse(time.RFC3339, scheduleAt)
-			if err != nil {
-				return fmt.Errorf("invalid --schedule-at (use RFC3339, e.g. 2026-06-01T10:00:00Z): %w", err)
-			}
-			job.OneShotAt(t)
-		} else {
-			t, err := time.Parse(time.RFC3339, executeUntil)
-			if err != nil {
-				return fmt.Errorf("invalid --execute-until (use RFC3339, e.g. 2026-12-31T23:59:59Z): %w", err)
-			}
-			job.WithCron(cron)
-			job.RecurringUntil(t)
-		}
-
-		if stepResourceURI != "" {
-			step := aruba.NewJobStep().
-				Targeting(aruba.URI(stepResourceURI)).
-				WithVerb(aruba.HTTPVerb(stepHTTPVerb))
-			if stepActionURI != "" {
-				step.WithAction(stepActionURI)
-			}
-			if stepName != "" {
-				step.Named(stepName)
-			}
-			job.WithSteps(step)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromSchedule().Jobs().Create(ctx, job)
-		if err != nil {
-			return fmt.Errorf("creating job: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "TYPE", Width: 15},
-				{Header: "ENABLED", Width: 10},
-				{Header: "REGION", Width: 20},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			jobTypeVal := string(raw.Properties.JobType)
-			enabledVal := "No"
-			if raw.Properties.Enabled {
-				enabledVal = "Yes"
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, jobTypeVal, enabledVal, regionVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Job", name))
-		}
-		return nil
-	},
+	RunE: runJobCreate,
 }
 
 var jobGetCmd = &cobra.Command{
 	Use:   "get [job-id]",
 	Short: "Get job details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		jobID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		job, err := client.FromSchedule().Jobs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Schedule/jobs/"+jobID))
-		if err != nil {
-			return fmt.Errorf("getting job: %w", apiErrFromV2(err))
-		}
-
-		if job != nil && job.Raw() != nil {
-			raw := job.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(job, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nJob Details:")
-			fmt.Println("============")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			fmt.Printf("Job Type:        %s\n", string(raw.Properties.JobType))
-			fmt.Printf("Enabled:         %t\n", raw.Properties.Enabled)
-			if raw.Properties.ScheduleAt != nil {
-				fmt.Printf("Schedule At:     %s\n", *raw.Properties.ScheduleAt)
-			}
-			if raw.Properties.Cron != nil {
-				fmt.Printf("CRON:            %s\n", *raw.Properties.Cron)
-			}
-			if raw.Properties.ExecuteUntil != nil {
-				fmt.Printf("Execute Until:   %s\n", *raw.Properties.ExecuteUntil)
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Job not found")
-		}
-		return nil
-	},
+	RunE:  runJobGet,
 }
 
 var jobListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all scheduled jobs",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromSchedule().Jobs().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing jobs: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 30},
-				{Header: "TYPE", Width: 15},
-				{Header: "ENABLED", Width: 10},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, job := range list.Items() {
-				raw := job.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				jobType := string(raw.Properties.JobType)
-				enabledVal := "No"
-				if raw.Properties.Enabled {
-					enabledVal = "Yes"
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, jobType, enabledVal, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No jobs found")
-		}
-		return nil
-	},
+	RunE:  runJobList,
 }
 
 var jobUpdateCmd = &cobra.Command{
 	Use:   "update [job-id]",
 	Short: "Update a job",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		jobID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		enabledSet := cmd.Flags().Changed("enabled")
-		enabled, _ := cmd.Flags().GetBool("enabled")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !enabledSet && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name, --enabled, or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		job, err := client.FromSchedule().Jobs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Schedule/jobs/"+jobID))
-		if err != nil {
-			return fmt.Errorf("getting job: %w", apiErrFromV2(err))
-		}
-		if job == nil || job.ID() == "" {
-			return fmt.Errorf("job not found")
-		}
-
-		if name != "" {
-			job.Named(name)
-		}
-		if enabledSet {
-			if enabled {
-				job.Enabled()
-			} else {
-				job.Disabled()
-			}
-		}
-		if cmd.Flags().Changed("tags") {
-			job.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromSchedule().Jobs().Update(ctx, job)
-		if err != nil {
-			return fmt.Errorf("updating job: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Job", jobID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			fmt.Printf("Enabled:         %t\n", raw.Properties.Enabled)
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Job", jobID))
-		}
-		return nil
-	},
+	RunE:  runJobUpdate,
 }
 
 var jobDeleteCmd = &cobra.Command{
 	Use:   "delete [job-id]",
 	Short: "Delete a job",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		jobID := args[0]
+	RunE:  runJobDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("job", jobID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runJobCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	jobType, _ := cmd.Flags().GetString("job-type")
+	scheduleAt, _ := cmd.Flags().GetString("schedule-at")
+	cron, _ := cmd.Flags().GetString("cron")
+	executeUntil, _ := cmd.Flags().GetString("execute-until")
+	enabled, _ := cmd.Flags().GetBool("enabled")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	stepResourceURI, _ := cmd.Flags().GetString("step-resource-uri")
+	stepActionURI, _ := cmd.Flags().GetString("step-action-uri")
+	stepHTTPVerb, _ := cmd.Flags().GetString("step-http-verb")
+	stepName, _ := cmd.Flags().GetString("step-name")
+
+	if jobType != "OneShot" && jobType != "Recurring" {
+		return fmt.Errorf("--job-type must be either 'OneShot' or 'Recurring'")
+	}
+	if jobType == "OneShot" && scheduleAt == "" {
+		return fmt.Errorf("--schedule-at is required for OneShot jobs")
+	}
+	if jobType == "Recurring" {
+		if cron == "" {
+			return fmt.Errorf("--cron is required for Recurring jobs")
 		}
+		if executeUntil == "" {
+			return fmt.Errorf("--execute-until is required for Recurring jobs")
+		}
+	}
 
-		projectID, err := GetProjectID(cmd)
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	job := aruba.NewJob().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		RetaggedAs(tags...)
+
+	if enabled {
+		job.Enabled()
+	} else {
+		job.Disabled()
+	}
+
+	if jobType == "OneShot" {
+		t, err := time.Parse(time.RFC3339, scheduleAt)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid --schedule-at (use RFC3339, e.g. 2026-06-01T10:00:00Z): %w", err)
 		}
-
-		client, err := GetArubaClient()
+		job.OneShotAt(t)
+	} else {
+		t, err := time.Parse(time.RFC3339, executeUntil)
 		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+			return fmt.Errorf("invalid --execute-until (use RFC3339, e.g. 2026-12-31T23:59:59Z): %w", err)
 		}
+		job.WithCron(cron)
+		job.RecurringUntil(t)
+	}
 
-		ctx, cancel := newCtx()
-		defer cancel()
+	if stepResourceURI != "" {
+		step := aruba.NewJobStep().
+			Targeting(aruba.URI(stepResourceURI)).
+			WithVerb(aruba.HTTPVerb(stepHTTPVerb))
+		if stepActionURI != "" {
+			step.WithAction(stepActionURI)
+		}
+		if stepName != "" {
+			step.Named(stepName)
+		}
+		job.WithSteps(step)
+	}
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromSchedule().Jobs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Schedule/jobs/"+jobID))
-			if err != nil {
-				return fmt.Errorf("dry-run: schedule job not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("schedule job", jobID))
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromSchedule().Jobs().Create(ctx, job)
+	if err != nil {
+		return fmt.Errorf("creating job: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "TYPE", Width: 15},
+			{Header: "ENABLED", Width: 10},
+			{Header: "REGION", Width: 20},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		jobTypeVal := string(raw.Properties.JobType)
+		enabledVal := "No"
+		if raw.Properties.Enabled {
+			enabledVal = "Yes"
+		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, jobTypeVal, enabledVal, regionVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Job", name))
+	}
+	return nil
+}
+
+func runJobGet(cmd *cobra.Command, args []string) error {
+	jobID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	job, err := client.FromSchedule().Jobs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Schedule/jobs/"+jobID))
+	if err != nil {
+		return fmt.Errorf("getting job: %w", apiErrFromV2(err))
+	}
+
+	if job != nil && job.Raw() != nil {
+		raw := job.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(job, nil, nil)
 			return nil
 		}
 
-		if err = client.FromSchedule().Jobs().Delete(ctx, jobRef(projectID, jobID)); err != nil {
-			return fmt.Errorf("deleting job: %w", apiErrFromV2(err))
+		fmt.Println("\nJob Details:")
+		fmt.Println("============")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
 		}
-		fmt.Println(msgDeleted("Job", jobID))
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		fmt.Printf("Job Type:        %s\n", string(raw.Properties.JobType))
+		fmt.Printf("Enabled:         %t\n", raw.Properties.Enabled)
+		if raw.Properties.ScheduleAt != nil {
+			fmt.Printf("Schedule At:     %s\n", *raw.Properties.ScheduleAt)
+		}
+		if raw.Properties.Cron != nil {
+			fmt.Printf("CRON:            %s\n", *raw.Properties.Cron)
+		}
+		if raw.Properties.ExecuteUntil != nil {
+			fmt.Printf("Execute Until:   %s\n", *raw.Properties.ExecuteUntil)
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Job not found")
+	}
+	return nil
+}
+
+func runJobList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromSchedule().Jobs().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing jobs: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 30},
+			{Header: "TYPE", Width: 15},
+			{Header: "ENABLED", Width: 10},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
+		}
+
+		var rows [][]string
+		for _, job := range list.Items() {
+			raw := job.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			jobType := string(raw.Properties.JobType)
+			enabledVal := "No"
+			if raw.Properties.Enabled {
+				enabledVal = "Yes"
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, jobType, enabledVal, region, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No jobs found")
+	}
+	return nil
+}
+
+func runJobUpdate(cmd *cobra.Command, args []string) error {
+	jobID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	enabledSet := cmd.Flags().Changed("enabled")
+	enabled, _ := cmd.Flags().GetBool("enabled")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !enabledSet && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name, --enabled, or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	job, err := client.FromSchedule().Jobs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Schedule/jobs/"+jobID))
+	if err != nil {
+		return fmt.Errorf("getting job: %w", apiErrFromV2(err))
+	}
+	if job == nil || job.ID() == "" {
+		return fmt.Errorf("job not found")
+	}
+
+	if name != "" {
+		job.Named(name)
+	}
+	if enabledSet {
+		if enabled {
+			job.Enabled()
+		} else {
+			job.Disabled()
+		}
+	}
+	if cmd.Flags().Changed("tags") {
+		job.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromSchedule().Jobs().Update(ctx, job)
+	if err != nil {
+		return fmt.Errorf("updating job: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Job", jobID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		fmt.Printf("Enabled:         %t\n", raw.Properties.Enabled)
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Job", jobID))
+	}
+	return nil
+}
+
+func runJobDelete(cmd *cobra.Command, args []string) error {
+	jobID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("job", jobID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromSchedule().Jobs().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Schedule/jobs/"+jobID))
+		if err != nil {
+			return fmt.Errorf("dry-run: schedule job not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("schedule job", jobID))
 		return nil
-	},
+	}
+
+	if err = client.FromSchedule().Jobs().Delete(ctx, jobRef(projectID, jobID)); err != nil {
+		return fmt.Errorf("deleting job: %w", apiErrFromV2(err))
+	}
+	fmt.Println(msgDeleted("Job", jobID))
+	return nil
 }

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -98,301 +98,311 @@ Billing period: Hour (default), Month, or Year.`,
 	Example: `  acloud security kms create --name my-kms --region IT-BG
   acloud security kms create --name prod-kms --region IT-BG --billing-period Month`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		kms := aruba.NewKMS().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			BilledBy(aruba.BillingPeriod(billingPeriod)).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromSecurity().KMS().Create(ctx, kms)
-		if err != nil {
-			return fmt.Errorf("creating KMS: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			row := []string{id, nameVal, regionVal, statusVal}
-			PrintOutput(created, headers, [][]string{row})
-		} else {
-			fmt.Println(msgCreatedAsync("KMS", name))
-		}
-		return nil
-	},
+	RunE: runKMSCreate,
 }
 
 var kmsGetCmd = &cobra.Command{
 	Use:   "get [kms-id]",
 	Short: "Get KMS resource details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kmsID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kms, err := client.FromSecurity().KMS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Security/kms/"+kmsID))
-		if err != nil {
-			return fmt.Errorf("getting KMS: %w", apiErrFromV2(err))
-		}
-
-		if kms != nil && kms.Raw() != nil {
-			raw := kms.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(kms, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nKMS Details:")
-			fmt.Println("============")
-
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", *raw.Status.State)
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("KMS not found")
-		}
-		return nil
-	},
+	RunE:  runKMSGet,
 }
 
 var kmsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all KMS resources",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromSecurity().KMS().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing KMS: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 30},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, kms := range list.Items() {
-				raw := kms.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, region, status})
-			}
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No KMS resources found")
-		}
-		return nil
-	},
+	RunE:  runKMSList,
 }
 
 var kmsUpdateCmd = &cobra.Command{
 	Use:   "update [kms-id]",
 	Short: "Update a KMS resource",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kmsID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		kms, err := client.FromSecurity().KMS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Security/kms/"+kmsID))
-		if err != nil {
-			return fmt.Errorf("getting KMS: %w", apiErrFromV2(err))
-		}
-
-		if kms == nil || kms.Raw() == nil {
-			return fmt.Errorf("KMS not found")
-		}
-
-		if name != "" {
-			kms.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			kms.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromSecurity().KMS().Update(ctx, kms)
-		if err != nil {
-			return fmt.Errorf("updating KMS: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("KMS", kmsID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("KMS", kmsID))
-		}
-		return nil
-	},
+	RunE:  runKMSUpdate,
 }
 
 var kmsDeleteCmd = &cobra.Command{
 	Use:   "delete [kms-id]",
 	Short: "Delete a KMS resource",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		kmsID := args[0]
+	RunE:  runKMSDelete,
+}
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
+func runKMSCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	kms := aruba.NewKMS().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		BilledBy(aruba.BillingPeriod(billingPeriod)).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromSecurity().KMS().Create(ctx, kms)
+	if err != nil {
+		return fmt.Errorf("creating KMS: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
 		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
 		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		row := []string{id, nameVal, regionVal, statusVal}
+		PrintOutput(created, headers, [][]string{row})
+	} else {
+		fmt.Println(msgCreatedAsync("KMS", name))
+	}
+	return nil
+}
 
-		ctx, cancel := newCtx()
-		defer cancel()
+func runKMSGet(cmd *cobra.Command, args []string) error {
+	kmsID := args[0]
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromSecurity().KMS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Security/kms/"+kmsID))
-			if err != nil {
-				return fmt.Errorf("dry-run: KMS not found or inaccessible: %w", err)
-			}
-			fmt.Println(msgDryRun("KMS", kmsID))
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kms, err := client.FromSecurity().KMS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Security/kms/"+kmsID))
+	if err != nil {
+		return fmt.Errorf("getting KMS: %w", apiErrFromV2(err))
+	}
+
+	if kms != nil && kms.Raw() != nil {
+		raw := kms.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(kms, nil, nil)
 			return nil
 		}
 
-		if err := client.FromSecurity().KMS().Delete(ctx, kmsRef(projectID, kmsID)); err != nil {
-			return fmt.Errorf("deleting KMS: %w", apiErrFromV2(err))
+		fmt.Println("\nKMS Details:")
+		fmt.Println("============")
+
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
 		}
-		fmt.Println(msgDeleted("KMS", kmsID))
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", *raw.Status.State)
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("KMS not found")
+	}
+	return nil
+}
+
+func runKMSList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromSecurity().KMS().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing KMS: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 30},
+			{Header: "REGION", Width: 20},
+			{Header: "STATUS", Width: 15},
+		}
+
+		var rows [][]string
+		for _, kms := range list.Items() {
+			raw := kms.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, region, status})
+		}
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No KMS resources found")
+	}
+	return nil
+}
+
+func runKMSUpdate(cmd *cobra.Command, args []string) error {
+	kmsID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	kms, err := client.FromSecurity().KMS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Security/kms/"+kmsID))
+	if err != nil {
+		return fmt.Errorf("getting KMS: %w", apiErrFromV2(err))
+	}
+
+	if kms == nil || kms.Raw() == nil {
+		return fmt.Errorf("KMS not found")
+	}
+
+	if name != "" {
+		kms.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		kms.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromSecurity().KMS().Update(ctx, kms)
+	if err != nil {
+		return fmt.Errorf("updating KMS: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("KMS", kmsID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("KMS", kmsID))
+	}
+	return nil
+}
+
+func runKMSDelete(cmd *cobra.Command, args []string) error {
+	kmsID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromSecurity().KMS().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Security/kms/"+kmsID))
+		if err != nil {
+			return fmt.Errorf("dry-run: KMS not found or inaccessible: %w", err)
+		}
+		fmt.Println(msgDryRun("KMS", kmsID))
 		return nil
-	},
+	}
+
+	if err := client.FromSecurity().KMS().Delete(ctx, kmsRef(projectID, kmsID)); err != nil {
+		return fmt.Errorf("deleting KMS: %w", apiErrFromV2(err))
+	}
+	fmt.Println(msgDeleted("KMS", kmsID))
+	return nil
 }

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -86,335 +86,345 @@ Billing period: Hour (default), Month, or Year.`,
 	Example: `  acloud storage backup <volume-id> --name my-backup
   acloud storage backup <volume-id> --name weekly-full --type Full --retention-days 30`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		volumeID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		backupType, _ := cmd.Flags().GetString("type")
-		retentionDays, _ := cmd.Flags().GetInt("retention-days")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		volumeURI := "/projects/" + projectID + "/providers/Aruba.Storage/blockStorages/" + volumeID
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		_, err = client.FromStorage().Volumes().Get(ctx, aruba.URI(volumeURI))
-		if err != nil {
-			return fmt.Errorf("getting volume: %w", apiErrFromV2(err))
-		}
-
-		bkp := aruba.NewStorageBackup().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			OfType(aruba.StorageBackupType(backupType)).
-			FromVolume(aruba.URI(volumeURI)).
-			RetaggedAs(tags...)
-
-		if retentionDays > 0 {
-			bkp.RetainedForDays(retentionDays)
-		}
-		if billingPeriod != "" {
-			bkp.BilledBy(aruba.BillingPeriod(billingPeriod))
-		}
-
-		created, err := client.FromStorage().Backups().Create(ctx, bkp)
-		if err != nil {
-			return fmt.Errorf("creating backup: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "TYPE", Width: 15},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			typeVal := string(raw.Properties.Type)
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, typeVal, statusVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Storage backup", name))
-		}
-		return nil
-	},
+	RunE: runStorageBackup,
 }
 
 var storageBackupListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List storage backups",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromStorage().Backups().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "TYPE", Width: 12},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, bkp := range list.Items() {
-				raw := bkp.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				backupType := string(raw.Properties.Type)
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, backupType, status})
-			}
-
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No backups found")
-		}
-		return nil
-	},
+	RunE:  runStorageBackupList,
 }
 
 var storageBackupGetCmd = &cobra.Command{
 	Use:   "get [backup-id]",
 	Short: "Get storage backup details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		bkp, err := client.FromStorage().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
-		if err != nil {
-			return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
-		}
-
-		if bkp != nil && bkp.Raw() != nil {
-			raw := bkp.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(bkp, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nStorage Backup Details:")
-			fmt.Println("=======================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
-			if raw.Properties.Origin.URI != "" {
-				fmt.Printf("Source Volume:   %s\n", raw.Properties.Origin.URI)
-			}
-			if raw.Properties.RetentionDays != nil {
-				fmt.Printf("Retention Days:  %d\n", *raw.Properties.RetentionDays)
-			}
-			if raw.Properties.BillingPeriod != nil {
-				fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPeriod))
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-		} else {
-			fmt.Println("Backup not found")
-		}
-		return nil
-	},
+	RunE:  runStorageBackupGet,
 }
 
 var storageBackupUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id]",
 	Short: "Update a storage backup (name and/or tags)",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		bkp, err := client.FromStorage().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
-		if err != nil {
-			return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
-		}
-		if bkp == nil || bkp.Raw() == nil {
-			return fmt.Errorf("backup not found")
-		}
-
-		if name != "" {
-			bkp.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			bkp.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromStorage().Backups().Update(ctx, bkp)
-		if err != nil {
-			return fmt.Errorf("updating backup: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Backup", backupID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Backup", backupID))
-		}
-		return nil
-	},
+	RunE:  runStorageBackupUpdate,
 }
 
 var storageBackupDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id]",
 	Short: "Delete a storage backup",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
+	RunE:  runStorageBackupDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("backup", backupID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runStorageBackup(cmd *cobra.Command, args []string) error {
+	volumeID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	backupType, _ := cmd.Flags().GetString("type")
+	retentionDays, _ := cmd.Flags().GetInt("retention-days")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	volumeURI := "/projects/" + projectID + "/providers/Aruba.Storage/blockStorages/" + volumeID
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	_, err = client.FromStorage().Volumes().Get(ctx, aruba.URI(volumeURI))
+	if err != nil {
+		return fmt.Errorf("getting volume: %w", apiErrFromV2(err))
+	}
+
+	bkp := aruba.NewStorageBackup().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		OfType(aruba.StorageBackupType(backupType)).
+		FromVolume(aruba.URI(volumeURI)).
+		RetaggedAs(tags...)
+
+	if retentionDays > 0 {
+		bkp.RetainedForDays(retentionDays)
+	}
+	if billingPeriod != "" {
+		bkp.BilledBy(aruba.BillingPeriod(billingPeriod))
+	}
+
+	created, err := client.FromStorage().Backups().Create(ctx, bkp)
+	if err != nil {
+		return fmt.Errorf("creating backup: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "TYPE", Width: 15},
+			{Header: "STATUS", Width: 15},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		typeVal := string(raw.Properties.Type)
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, typeVal, statusVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Storage backup", name))
+	}
+	return nil
+}
+
+func runStorageBackupList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromStorage().Backups().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "TYPE", Width: 12},
+			{Header: "STATUS", Width: 15},
 		}
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromStorage().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
-			if err != nil {
-				return fmt.Errorf("dry-run: storage backup not found or inaccessible: %w", apiErrFromV2(err))
+		var rows [][]string
+		for _, bkp := range list.Items() {
+			raw := bkp.Raw()
+			if raw == nil {
+				continue
 			}
-			fmt.Println(msgDryRun("storage backup", backupID))
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			backupType := string(raw.Properties.Type)
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, backupType, status})
+		}
+
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No backups found")
+	}
+	return nil
+}
+
+func runStorageBackupGet(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	bkp, err := client.FromStorage().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
+	if err != nil {
+		return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
+	}
+
+	if bkp != nil && bkp.Raw() != nil {
+		raw := bkp.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(bkp, nil, nil)
 			return nil
 		}
 
-		err = client.FromStorage().Backups().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
-		if err != nil {
-			return fmt.Errorf("deleting backup: %w", apiErrFromV2(err))
+		fmt.Println("\nStorage Backup Details:")
+		fmt.Println("=======================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
 		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
+		if raw.Properties.Origin.URI != "" {
+			fmt.Printf("Source Volume:   %s\n", raw.Properties.Origin.URI)
+		}
+		if raw.Properties.RetentionDays != nil {
+			fmt.Printf("Retention Days:  %d\n", *raw.Properties.RetentionDays)
+		}
+		if raw.Properties.BillingPeriod != nil {
+			fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPeriod))
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+	} else {
+		fmt.Println("Backup not found")
+	}
+	return nil
+}
 
-		fmt.Println(msgDeleted("Backup", backupID))
+func runStorageBackupUpdate(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	bkp, err := client.FromStorage().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
+	if err != nil {
+		return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
+	}
+	if bkp == nil || bkp.Raw() == nil {
+		return fmt.Errorf("backup not found")
+	}
+
+	if name != "" {
+		bkp.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		bkp.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromStorage().Backups().Update(ctx, bkp)
+	if err != nil {
+		return fmt.Errorf("updating backup: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Backup", backupID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Backup", backupID))
+	}
+	return nil
+}
+
+func runStorageBackupDelete(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("backup", backupID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromStorage().Backups().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
+		if err != nil {
+			return fmt.Errorf("dry-run: storage backup not found or inaccessible: %w", apiErrFromV2(err))
+		}
+		fmt.Println(msgDryRun("storage backup", backupID))
 		return nil
-	},
+	}
+
+	err = client.FromStorage().Backups().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
+	if err != nil {
+		return fmt.Errorf("deleting backup: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Backup", backupID))
+	return nil
 }

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -113,350 +113,360 @@ Billing period: Hour (default), Month, or Year.`,
     --type Performance \
     --snapshot-id <snap-id>`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		zone, _ := cmd.Flags().GetString("zone")
-		size, _ := cmd.Flags().GetInt("size")
-		volumeType, _ := cmd.Flags().GetString("type")
-		billingPeriod, _ := cmd.Flags().GetString("billing-period")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-		snapshotID, _ := cmd.Flags().GetString("snapshot-id")
-		setBootable, _ := cmd.Flags().GetBool("set-bootable")
-		image, _ := cmd.Flags().GetString("image")
-
-		if size <= 0 {
-			return fmt.Errorf("--size must be greater than 0")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		vol := aruba.NewBlockStorage().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			SizedGB(size).
-			OfType(aruba.BlockStorageType(volumeType)).
-			BilledBy(aruba.BillingPeriod(billingPeriod)).
-			RetaggedAs(tags...)
-
-		if zone != "" {
-			vol.InZone(aruba.Zone(zone))
-		}
-		if snapshotID != "" {
-			vol.FromSnapshot(snapshotRef(projectID, snapshotID))
-		}
-		if setBootable {
-			vol.AsBootable()
-		}
-		if image != "" {
-			vol.FromImage(image)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromStorage().Volumes().Create(ctx, vol)
-		if err != nil {
-			return fmt.Errorf("creating block storage: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "SIZE(GB)", Width: 12},
-				{Header: "TYPE", Width: 15},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			sizeVal := fmt.Sprintf("%d", raw.Properties.SizeGB)
-			typeVal := string(raw.Properties.Type)
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, sizeVal, typeVal, statusVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Block storage", name))
-		}
-		return nil
-	},
+	RunE: runBlockStorageCreate,
 }
 
 var blockstorageGetCmd = &cobra.Command{
 	Use:   "get [volume-id]",
 	Short: "Get block storage details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		volumeID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		vol, err := client.FromStorage().Volumes().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
-		if err != nil {
-			return fmt.Errorf("getting block storage: %w", apiErrFromV2(err))
-		}
-
-		if vol != nil && vol.Raw() != nil {
-			raw := vol.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(vol, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nBlock Storage Details:")
-			fmt.Println("======================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			fmt.Printf("Size (GB):       %d\n", raw.Properties.SizeGB)
-			fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
-			fmt.Printf("Zone:            %s\n", string(raw.Properties.Zone))
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Properties.Bootable != nil {
-				fmt.Printf("Bootable:        %t\n", *raw.Properties.Bootable)
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Block storage not found")
-		}
-		return nil
-	},
+	RunE:  runBlockStorageGet,
 }
 
 var blockstorageUpdateCmd = &cobra.Command{
 	Use:   "update [volume-id]",
 	Short: "Update block storage (name and/or tags)",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		volumeID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		vol, err := client.FromStorage().Volumes().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
-		if err != nil {
-			return fmt.Errorf("getting block storage: %w", apiErrFromV2(err))
-		}
-		if vol == nil || vol.Raw() == nil {
-			return fmt.Errorf("block storage not found")
-		}
-
-		if name != "" {
-			vol.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			vol.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromStorage().Volumes().Update(ctx, vol)
-		if err != nil {
-			return fmt.Errorf("updating block storage: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Block storage", volumeID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-			fmt.Printf("Size (GB):       %d\n", raw.Properties.SizeGB)
-			fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
-		} else {
-			fmt.Println(msgUpdatedAsync("Block storage", volumeID))
-		}
-		return nil
-	},
+	RunE:  runBlockStorageUpdate,
 }
 
 var blockstorageDeleteCmd = &cobra.Command{
 	Use:   "delete [volume-id]",
 	Short: "Delete block storage",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		volumeID := args[0]
-
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("block storage", volumeID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromStorage().Volumes().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
-			if err != nil {
-				return fmt.Errorf("dry-run: block storage not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("block storage", volumeID))
-			return nil
-		}
-
-		err = client.FromStorage().Volumes().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
-		if err != nil {
-			return fmt.Errorf("deleting block storage: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("Block storage", volumeID))
-		return nil
-	},
+	RunE:  runBlockStorageDelete,
 }
 
 var blockstorageListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all block storage",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
+	RunE:  runBlockStorageList,
+}
+
+func runBlockStorageCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	zone, _ := cmd.Flags().GetString("zone")
+	size, _ := cmd.Flags().GetInt("size")
+	volumeType, _ := cmd.Flags().GetString("type")
+	billingPeriod, _ := cmd.Flags().GetString("billing-period")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	snapshotID, _ := cmd.Flags().GetString("snapshot-id")
+	setBootable, _ := cmd.Flags().GetBool("set-bootable")
+	image, _ := cmd.Flags().GetString("image")
+
+	if size <= 0 {
+		return fmt.Errorf("--size must be greater than 0")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	vol := aruba.NewBlockStorage().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		SizedGB(size).
+		OfType(aruba.BlockStorageType(volumeType)).
+		BilledBy(aruba.BillingPeriod(billingPeriod)).
+		RetaggedAs(tags...)
+
+	if zone != "" {
+		vol.InZone(aruba.Zone(zone))
+	}
+	if snapshotID != "" {
+		vol.FromSnapshot(snapshotRef(projectID, snapshotID))
+	}
+	if setBootable {
+		vol.AsBootable()
+	}
+	if image != "" {
+		vol.FromImage(image)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromStorage().Volumes().Create(ctx, vol)
+	if err != nil {
+		return fmt.Errorf("creating block storage: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "SIZE(GB)", Width: 12},
+			{Header: "TYPE", Width: 15},
+			{Header: "STATUS", Width: 15},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		sizeVal := fmt.Sprintf("%d", raw.Properties.SizeGB)
+		typeVal := string(raw.Properties.Type)
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, sizeVal, typeVal, statusVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Block storage", name))
+	}
+	return nil
+}
+
+func runBlockStorageGet(cmd *cobra.Command, args []string) error {
+	volumeID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	vol, err := client.FromStorage().Volumes().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
+	if err != nil {
+		return fmt.Errorf("getting block storage: %w", apiErrFromV2(err))
+	}
+
+	if vol != nil && vol.Raw() != nil {
+		raw := vol.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(vol, nil, nil)
+			return nil
+		}
+
+		fmt.Println("\nBlock Storage Details:")
+		fmt.Println("======================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		fmt.Printf("Size (GB):       %d\n", raw.Properties.SizeGB)
+		fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
+		fmt.Printf("Zone:            %s\n", string(raw.Properties.Zone))
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Properties.Bootable != nil {
+			fmt.Printf("Bootable:        %t\n", *raw.Properties.Bootable)
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Block storage not found")
+	}
+	return nil
+}
+
+func runBlockStorageUpdate(cmd *cobra.Command, args []string) error {
+	volumeID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	vol, err := client.FromStorage().Volumes().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
+	if err != nil {
+		return fmt.Errorf("getting block storage: %w", apiErrFromV2(err))
+	}
+	if vol == nil || vol.Raw() == nil {
+		return fmt.Errorf("block storage not found")
+	}
+
+	if name != "" {
+		vol.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		vol.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromStorage().Volumes().Update(ctx, vol)
+	if err != nil {
+		return fmt.Errorf("updating block storage: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Block storage", volumeID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+		fmt.Printf("Size (GB):       %d\n", raw.Properties.SizeGB)
+		fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
+	} else {
+		fmt.Println(msgUpdatedAsync("Block storage", volumeID))
+	}
+	return nil
+}
+
+func runBlockStorageDelete(cmd *cobra.Command, args []string) error {
+	volumeID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("block storage", volumeID)
 		if err != nil {
 			return err
 		}
+		if !ok {
+			return nil
+		}
+	}
 
-		client, err := GetArubaClient()
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromStorage().Volumes().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
 		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
+			return fmt.Errorf("dry-run: block storage not found or inaccessible: %w", apiErrFromV2(err))
 		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromStorage().Volumes().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing block storage: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "SIZE(GB)", Width: 12},
-				{Header: "REGION", Width: 15},
-				{Header: "ZONE", Width: 15},
-				{Header: "TYPE", Width: 15},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, vol := range list.Items() {
-				raw := vol.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				size := fmt.Sprintf("%d", raw.Properties.SizeGB)
-				region := ""
-				if raw.Metadata.LocationResponse != nil {
-					region = string(raw.Metadata.LocationResponse.Value)
-				}
-				zone := string(raw.Properties.Zone)
-				volumeType := string(raw.Properties.Type)
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, size, region, zone, volumeType, status})
-			}
-
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No block storage found")
-		}
+		fmt.Println(msgDryRun("block storage", volumeID))
 		return nil
-	},
+	}
+
+	err = client.FromStorage().Volumes().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/blockStorages/"+volumeID))
+	if err != nil {
+		return fmt.Errorf("deleting block storage: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Block storage", volumeID))
+	return nil
+}
+
+func runBlockStorageList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromStorage().Volumes().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing block storage: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "SIZE(GB)", Width: 12},
+			{Header: "REGION", Width: 15},
+			{Header: "ZONE", Width: 15},
+			{Header: "TYPE", Width: 15},
+			{Header: "STATUS", Width: 15},
+		}
+
+		var rows [][]string
+		for _, vol := range list.Items() {
+			raw := vol.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			size := fmt.Sprintf("%d", raw.Properties.SizeGB)
+			region := ""
+			if raw.Metadata.LocationResponse != nil {
+				region = string(raw.Metadata.LocationResponse.Value)
+			}
+			zone := string(raw.Properties.Zone)
+			volumeType := string(raw.Properties.Type)
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, size, region, zone, volumeType, status})
+		}
+
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No block storage found")
+	}
+	return nil
 }

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -94,326 +94,336 @@ backup data into the specified volume; ensure the volume is detached or otherwis
 idle before starting a restore to avoid data corruption.`,
 	Example: `  acloud storage restore <backup-id> <volume-id> --name my-restore`,
 	Args:    cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-		volumeID := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		backupURI := "/projects/" + projectID + "/providers/Aruba.Storage/backups/" + backupID
-		volumeURI := "/projects/" + projectID + "/providers/Aruba.Storage/blockStorages/" + volumeID
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		_, err = client.FromStorage().Backups().Get(ctx, aruba.URI(backupURI))
-		if err != nil {
-			return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
-		}
-
-		_, err = client.FromStorage().Volumes().Get(ctx, aruba.URI(volumeURI))
-		if err != nil {
-			return fmt.Errorf("getting volume: %w", apiErrFromV2(err))
-		}
-
-		restore := aruba.NewStorageRestore().
-			FromBackup(aruba.URI(backupURI)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			ToVolume(aruba.URI(volumeURI)).
-			RetaggedAs(tags...)
-
-		created, err := client.FromStorage().Restores().Create(ctx, restore)
-		if err != nil {
-			return fmt.Errorf("creating restore: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, statusVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Restore operation", name))
-		}
-		return nil
-	},
+	RunE:    runStorageRestore,
 }
 
 var storageRestoreListCmd = &cobra.Command{
 	Use:   "list [backup-id]",
 	Short: "List restore operations for a backup",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromStorage().Restores().List(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
-		if err != nil {
-			return fmt.Errorf("listing restores: %w", apiErrFromV2(err))
-		}
-
-		if list != nil && len(list.Items()) > 0 {
-			headers := []TableColumn{
-				{Header: "NAME", Width: 30},
-				{Header: "ID", Width: 26},
-				{Header: "STATUS", Width: 15},
-			}
-
-			var rows [][]string
-			for _, r := range list.Items() {
-				raw := r.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, status})
-			}
-
-			PrintOutput(list, headers, rows)
-		} else {
-			fmt.Println("No restores found for this backup")
-		}
-		return nil
-	},
+	RunE:  runStorageRestoreList,
 }
 
 var storageRestoreGetCmd = &cobra.Command{
 	Use:   "get [backup-id] [restore-id]",
 	Short: "Get restore operation details",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-		restoreID := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		restore, err := client.FromStorage().Restores().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
-		if err != nil {
-			return fmt.Errorf("getting restore: %w", apiErrFromV2(err))
-		}
-
-		if restore != nil && restore.Raw() != nil {
-			raw := restore.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(restore, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nRestore Operation Details:")
-			fmt.Println("==========================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Properties.Destination.URI != "" {
-				fmt.Printf("Target Volume:   %s\n", raw.Properties.Destination.URI)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Restore operation not found")
-		}
-		return nil
-	},
+	RunE:  runStorageRestoreGet,
 }
 
 var storageRestoreUpdateCmd = &cobra.Command{
 	Use:   "update [backup-id] [restore-id]",
 	Short: "Update a restore operation (name and/or tags)",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-		restoreID := args[1]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		restore, err := client.FromStorage().Restores().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
-		if err != nil {
-			return fmt.Errorf("getting restore: %w", apiErrFromV2(err))
-		}
-		if restore == nil || restore.Raw() == nil {
-			return fmt.Errorf("restore operation not found")
-		}
-
-		if name != "" {
-			restore.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			restore.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromStorage().Restores().Update(ctx, restore)
-		if err != nil {
-			return fmt.Errorf("updating restore: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Restore operation", restoreID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Restore operation", restoreID))
-		}
-		return nil
-	},
+	RunE:  runStorageRestoreUpdate,
 }
 
 var storageRestoreDeleteCmd = &cobra.Command{
 	Use:   "delete [backup-id] [restore-id]",
 	Short: "Delete a restore operation",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		backupID := args[0]
-		restoreID := args[1]
+	RunE:  runStorageRestoreDelete,
+}
 
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("restore operation", restoreID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
+func runStorageRestore(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+	volumeID := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	backupURI := "/projects/" + projectID + "/providers/Aruba.Storage/backups/" + backupID
+	volumeURI := "/projects/" + projectID + "/providers/Aruba.Storage/blockStorages/" + volumeID
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	_, err = client.FromStorage().Backups().Get(ctx, aruba.URI(backupURI))
+	if err != nil {
+		return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
+	}
+
+	_, err = client.FromStorage().Volumes().Get(ctx, aruba.URI(volumeURI))
+	if err != nil {
+		return fmt.Errorf("getting volume: %w", apiErrFromV2(err))
+	}
+
+	restore := aruba.NewStorageRestore().
+		FromBackup(aruba.URI(backupURI)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		ToVolume(aruba.URI(volumeURI)).
+		RetaggedAs(tags...)
+
+	created, err := client.FromStorage().Restores().Create(ctx, restore)
+	if err != nil {
+		return fmt.Errorf("creating restore: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
+		headers := []TableColumn{
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "STATUS", Width: 15},
+		}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
+		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, statusVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Restore operation", name))
+	}
+	return nil
+}
+
+func runStorageRestoreList(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromStorage().Restores().List(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID))
+	if err != nil {
+		return fmt.Errorf("listing restores: %w", apiErrFromV2(err))
+	}
+
+	if list != nil && len(list.Items()) > 0 {
+		headers := []TableColumn{
+			{Header: "NAME", Width: 30},
+			{Header: "ID", Width: 26},
+			{Header: "STATUS", Width: 15},
 		}
 
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromStorage().Restores().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
-			if err != nil {
-				return fmt.Errorf("dry-run: restore operation not found or inaccessible: %w", apiErrFromV2(err))
+		var rows [][]string
+		for _, r := range list.Items() {
+			raw := r.Raw()
+			if raw == nil {
+				continue
 			}
-			fmt.Println(msgDryRun("restore operation", restoreID))
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, status})
+		}
+
+		PrintOutput(list, headers, rows)
+	} else {
+		fmt.Println("No restores found for this backup")
+	}
+	return nil
+}
+
+func runStorageRestoreGet(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+	restoreID := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	restore, err := client.FromStorage().Restores().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
+	if err != nil {
+		return fmt.Errorf("getting restore: %w", apiErrFromV2(err))
+	}
+
+	if restore != nil && restore.Raw() != nil {
+		raw := restore.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(restore, nil, nil)
 			return nil
 		}
 
-		err = client.FromStorage().Restores().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
-		if err != nil {
-			return fmt.Errorf("deleting restore: %w", apiErrFromV2(err))
+		fmt.Println("\nRestore Operation Details:")
+		fmt.Println("==========================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
 		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Properties.Destination.URI != "" {
+			fmt.Printf("Target Volume:   %s\n", raw.Properties.Destination.URI)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Restore operation not found")
+	}
+	return nil
+}
 
-		fmt.Println(msgDeleted("Restore operation", restoreID))
+func runStorageRestoreUpdate(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+	restoreID := args[1]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	restore, err := client.FromStorage().Restores().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
+	if err != nil {
+		return fmt.Errorf("getting restore: %w", apiErrFromV2(err))
+	}
+	if restore == nil || restore.Raw() == nil {
+		return fmt.Errorf("restore operation not found")
+	}
+
+	if name != "" {
+		restore.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		restore.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromStorage().Restores().Update(ctx, restore)
+	if err != nil {
+		return fmt.Errorf("updating restore: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Restore operation", restoreID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Restore operation", restoreID))
+	}
+	return nil
+}
+
+func runStorageRestoreDelete(cmd *cobra.Command, args []string) error {
+	backupID := args[0]
+	restoreID := args[1]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("restore operation", restoreID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromStorage().Restores().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
+		if err != nil {
+			return fmt.Errorf("dry-run: restore operation not found or inaccessible: %w", apiErrFromV2(err))
+		}
+		fmt.Println(msgDryRun("restore operation", restoreID))
 		return nil
-	},
+	}
+
+	err = client.FromStorage().Restores().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/backups/"+backupID+"/restores/"+restoreID))
+	if err != nil {
+		return fmt.Errorf("deleting restore: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Restore operation", restoreID))
+	return nil
 }

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -94,326 +94,336 @@ or restore data with 'acloud storage blockstorage create --snapshot-id'.`,
 	Example: `  acloud storage snapshot create --name my-snap --region IT-BG \
     --volume-id <vol-id>`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		region, _ := cmd.Flags().GetString("region")
-		volumeID, _ := cmd.Flags().GetString("volume-id")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		snap := aruba.NewSnapshot().
-			InProject(aruba.URI("/projects/" + projectID)).
-			Named(name).
-			InRegion(aruba.Region(region)).
-			FromVolume(volumeRef(projectID, volumeID)).
-			RetaggedAs(tags...)
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		created, err := client.FromStorage().Snapshots().Create(ctx, snap)
-		if err != nil {
-			return fmt.Errorf("creating snapshot: %w", apiErrFromV2(err))
-		}
-
-		if created != nil && created.Raw() != nil {
-			raw := created.Raw()
-			headers := []TableColumn{
-				{Header: "ID", Width: 30},
-				{Header: "NAME", Width: 40},
-				{Header: "REGION", Width: 20},
-				{Header: "STATUS", Width: 15},
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			nameVal := ""
-			if raw.Metadata.Name != nil {
-				nameVal = *raw.Metadata.Name
-			}
-			regionVal := ""
-			if raw.Metadata.LocationResponse != nil {
-				regionVal = string(raw.Metadata.LocationResponse.Value)
-			}
-			statusVal := ""
-			if raw.Status.State != nil {
-				statusVal = string(*raw.Status.State)
-			}
-			PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
-		} else {
-			fmt.Println(msgCreatedAsync("Snapshot", name))
-		}
-		return nil
-	},
+	RunE: runSnapshotCreate,
 }
 
 var snapshotGetCmd = &cobra.Command{
 	Use:   "get [snapshot-id]",
 	Short: "Get snapshot details",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		snapshotID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		snap, err := client.FromStorage().Snapshots().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
-		if err != nil {
-			return fmt.Errorf("getting snapshot: %w", apiErrFromV2(err))
-		}
-
-		if snap != nil && snap.Raw() != nil {
-			raw := snap.Raw()
-
-			format := resolveOutputFormat()
-			if format == OutputFormatJSON || format == OutputFormatYAML {
-				PrintOutput(snap, nil, nil)
-				return nil
-			}
-
-			fmt.Println("\nSnapshot Details:")
-			fmt.Println("=================")
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.URI != nil {
-				fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if raw.Properties.SizeGB != nil {
-				fmt.Printf("Size (GB):       %d\n", *raw.Properties.SizeGB)
-			}
-			if raw.Properties.Volume != nil && raw.Properties.Volume.URI != nil {
-				fmt.Printf("Source Volume:   %s\n", *raw.Properties.Volume.URI)
-			}
-			if raw.Metadata.LocationResponse != nil {
-				fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-			}
-			if raw.Status.State != nil {
-				fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-			}
-			if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-				fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-			}
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			} else {
-				fmt.Printf("Tags:            []\n")
-			}
-			fmt.Println()
-		} else {
-			fmt.Println("Snapshot not found")
-		}
-		return nil
-	},
+	RunE:  runSnapshotGet,
 }
 
 var snapshotUpdateCmd = &cobra.Command{
 	Use:   "update [snapshot-id]",
 	Short: "Update a snapshot (name and/or tags only)",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		snapshotID := args[0]
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		name, _ := cmd.Flags().GetString("name")
-		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		if name == "" && !cmd.Flags().Changed("tags") {
-			return fmt.Errorf("at least one of --name or --tags must be provided")
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-		snap, err := client.FromStorage().Snapshots().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
-		if err != nil {
-			return fmt.Errorf("getting snapshot: %w", apiErrFromV2(err))
-		}
-		if snap == nil || snap.Raw() == nil {
-			return fmt.Errorf("snapshot not found")
-		}
-
-		if name != "" {
-			snap.Named(name)
-		}
-		if cmd.Flags().Changed("tags") {
-			snap.RetaggedAs(tags...)
-		}
-
-		updated, err := client.FromStorage().Snapshots().Update(ctx, snap)
-		if err != nil {
-			return fmt.Errorf("updating snapshot: %w", apiErrFromV2(err))
-		}
-
-		if updated != nil && updated.Raw() != nil {
-			raw := updated.Raw()
-			fmt.Printf("\n%s\n", msgUpdated("Snapshot", snapshotID))
-			if raw.Metadata.ID != nil {
-				fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-			}
-			if raw.Metadata.Name != nil {
-				fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-			}
-			if len(raw.Metadata.Tags) > 0 {
-				fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-			}
-		} else {
-			fmt.Println(msgUpdatedAsync("Snapshot", snapshotID))
-		}
-		return nil
-	},
+	RunE:  runSnapshotUpdate,
 }
 
 var snapshotDeleteCmd = &cobra.Command{
 	Use:   "delete [snapshot-id]",
 	Short: "Delete a snapshot",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		snapshotID := args[0]
-
-		confirm, _ := cmd.Flags().GetBool("yes")
-		if !confirm {
-			ok, err := confirmDelete("snapshot", snapshotID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return nil
-			}
-		}
-
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
-
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
-
-		ctx, cancel := newCtx()
-		defer cancel()
-
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			_, err = client.FromStorage().Snapshots().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
-			if err != nil {
-				return fmt.Errorf("dry-run: snapshot not found or inaccessible: %w", apiErrFromV2(err))
-			}
-			fmt.Println(msgDryRun("snapshot", snapshotID))
-			return nil
-		}
-
-		err = client.FromStorage().Snapshots().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
-		if err != nil {
-			return fmt.Errorf("deleting snapshot: %w", apiErrFromV2(err))
-		}
-
-		fmt.Println(msgDeleted("Snapshot", snapshotID))
-		return nil
-	},
+	RunE:  runSnapshotDelete,
 }
 
 var snapshotListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List snapshots for a block storage volume",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		projectID, err := GetProjectID(cmd)
-		if err != nil {
-			return err
-		}
+	RunE:  runSnapshotList,
+}
 
-		volumeID, _ := cmd.Flags().GetString("volume-id")
+func runSnapshotCreate(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
 
-		client, err := GetArubaClient()
-		if err != nil {
-			return fmt.Errorf("initializing client: %w", err)
-		}
+	name, _ := cmd.Flags().GetString("name")
+	region, _ := cmd.Flags().GetString("region")
+	volumeID, _ := cmd.Flags().GetString("volume-id")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
 
-		ctx, cancel := newCtx()
-		defer cancel()
-		list, err := client.FromStorage().Snapshots().List(ctx, aruba.URI("/projects/"+projectID))
-		if err != nil {
-			return fmt.Errorf("listing snapshots: %w", apiErrFromV2(err))
-		}
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
 
+	snap := aruba.NewSnapshot().
+		InProject(aruba.URI("/projects/" + projectID)).
+		Named(name).
+		InRegion(aruba.Region(region)).
+		FromVolume(volumeRef(projectID, volumeID)).
+		RetaggedAs(tags...)
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	created, err := client.FromStorage().Snapshots().Create(ctx, snap)
+	if err != nil {
+		return fmt.Errorf("creating snapshot: %w", apiErrFromV2(err))
+	}
+
+	if created != nil && created.Raw() != nil {
+		raw := created.Raw()
 		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "SIZE(GB)", Width: 12},
+			{Header: "ID", Width: 30},
+			{Header: "NAME", Width: 40},
+			{Header: "REGION", Width: 20},
 			{Header: "STATUS", Width: 15},
 		}
-
-		var rows [][]string
-		if list != nil {
-			for _, snap := range list.Items() {
-				if snap.VolumeURI() != volumeRef(projectID, volumeID).URI() {
-					continue
-				}
-				raw := snap.Raw()
-				if raw == nil {
-					continue
-				}
-				name := ""
-				if raw.Metadata.Name != nil {
-					name = *raw.Metadata.Name
-				}
-				id := ""
-				if raw.Metadata.ID != nil {
-					id = *raw.Metadata.ID
-				}
-				size := "0"
-				if raw.Properties.SizeGB != nil {
-					size = fmt.Sprintf("%d", *raw.Properties.SizeGB)
-				}
-				status := ""
-				if raw.Status.State != nil {
-					status = string(*raw.Status.State)
-				}
-				rows = append(rows, []string{name, id, size, status})
-			}
+		id := ""
+		if raw.Metadata.ID != nil {
+			id = *raw.Metadata.ID
 		}
+		nameVal := ""
+		if raw.Metadata.Name != nil {
+			nameVal = *raw.Metadata.Name
+		}
+		regionVal := ""
+		if raw.Metadata.LocationResponse != nil {
+			regionVal = string(raw.Metadata.LocationResponse.Value)
+		}
+		statusVal := ""
+		if raw.Status.State != nil {
+			statusVal = string(*raw.Status.State)
+		}
+		PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
+	} else {
+		fmt.Println(msgCreatedAsync("Snapshot", name))
+	}
+	return nil
+}
 
-		if len(rows) == 0 {
-			fmt.Printf("No snapshots found for volume: %s\n", volumeID)
+func runSnapshotGet(cmd *cobra.Command, args []string) error {
+	snapshotID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	snap, err := client.FromStorage().Snapshots().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
+	if err != nil {
+		return fmt.Errorf("getting snapshot: %w", apiErrFromV2(err))
+	}
+
+	if snap != nil && snap.Raw() != nil {
+		raw := snap.Raw()
+
+		format := resolveOutputFormat()
+		if format == OutputFormatJSON || format == OutputFormatYAML {
+			PrintOutput(snap, nil, nil)
 			return nil
 		}
 
-		PrintOutput(list, headers, rows)
+		fmt.Println("\nSnapshot Details:")
+		fmt.Println("=================")
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.URI != nil {
+			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if raw.Properties.SizeGB != nil {
+			fmt.Printf("Size (GB):       %d\n", *raw.Properties.SizeGB)
+		}
+		if raw.Properties.Volume != nil && raw.Properties.Volume.URI != nil {
+			fmt.Printf("Source Volume:   %s\n", *raw.Properties.Volume.URI)
+		}
+		if raw.Metadata.LocationResponse != nil {
+			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
+		}
+		if raw.Status.State != nil {
+			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+		}
+		if raw.Metadata.CreatedBy != nil {
+			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		} else {
+			fmt.Printf("Tags:            []\n")
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Snapshot not found")
+	}
+	return nil
+}
+
+func runSnapshotUpdate(cmd *cobra.Command, args []string) error {
+	snapshotID := args[0]
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+
+	if name == "" && !cmd.Flags().Changed("tags") {
+		return fmt.Errorf("at least one of --name or --tags must be provided")
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	snap, err := client.FromStorage().Snapshots().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
+	if err != nil {
+		return fmt.Errorf("getting snapshot: %w", apiErrFromV2(err))
+	}
+	if snap == nil || snap.Raw() == nil {
+		return fmt.Errorf("snapshot not found")
+	}
+
+	if name != "" {
+		snap.Named(name)
+	}
+	if cmd.Flags().Changed("tags") {
+		snap.RetaggedAs(tags...)
+	}
+
+	updated, err := client.FromStorage().Snapshots().Update(ctx, snap)
+	if err != nil {
+		return fmt.Errorf("updating snapshot: %w", apiErrFromV2(err))
+	}
+
+	if updated != nil && updated.Raw() != nil {
+		raw := updated.Raw()
+		fmt.Printf("\n%s\n", msgUpdated("Snapshot", snapshotID))
+		if raw.Metadata.ID != nil {
+			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		}
+		if raw.Metadata.Name != nil {
+			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		}
+		if len(raw.Metadata.Tags) > 0 {
+			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+	} else {
+		fmt.Println(msgUpdatedAsync("Snapshot", snapshotID))
+	}
+	return nil
+}
+
+func runSnapshotDelete(cmd *cobra.Command, args []string) error {
+	snapshotID := args[0]
+
+	confirm, _ := cmd.Flags().GetBool("yes")
+	if !confirm {
+		ok, err := confirmDelete("snapshot", snapshotID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		_, err = client.FromStorage().Snapshots().Get(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
+		if err != nil {
+			return fmt.Errorf("dry-run: snapshot not found or inaccessible: %w", apiErrFromV2(err))
+		}
+		fmt.Println(msgDryRun("snapshot", snapshotID))
 		return nil
-	},
+	}
+
+	err = client.FromStorage().Snapshots().Delete(ctx, aruba.URI("/projects/"+projectID+"/providers/Aruba.Storage/snapshots/"+snapshotID))
+	if err != nil {
+		return fmt.Errorf("deleting snapshot: %w", apiErrFromV2(err))
+	}
+
+	fmt.Println(msgDeleted("Snapshot", snapshotID))
+	return nil
+}
+
+func runSnapshotList(cmd *cobra.Command, args []string) error {
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return err
+	}
+
+	volumeID, _ := cmd.Flags().GetString("volume-id")
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return fmt.Errorf("initializing client: %w", err)
+	}
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	list, err := client.FromStorage().Snapshots().List(ctx, aruba.URI("/projects/"+projectID))
+	if err != nil {
+		return fmt.Errorf("listing snapshots: %w", apiErrFromV2(err))
+	}
+
+	headers := []TableColumn{
+		{Header: "NAME", Width: 30},
+		{Header: "ID", Width: 26},
+		{Header: "SIZE(GB)", Width: 12},
+		{Header: "STATUS", Width: 15},
+	}
+
+	var rows [][]string
+	if list != nil {
+		for _, snap := range list.Items() {
+			if snap.VolumeURI() != volumeRef(projectID, volumeID).URI() {
+				continue
+			}
+			raw := snap.Raw()
+			if raw == nil {
+				continue
+			}
+			name := ""
+			if raw.Metadata.Name != nil {
+				name = *raw.Metadata.Name
+			}
+			id := ""
+			if raw.Metadata.ID != nil {
+				id = *raw.Metadata.ID
+			}
+			size := "0"
+			if raw.Properties.SizeGB != nil {
+				size = fmt.Sprintf("%d", *raw.Properties.SizeGB)
+			}
+			status := ""
+			if raw.Status.State != nil {
+				status = string(*raw.Status.State)
+			}
+			rows = append(rows, []string{name, id, size, status})
+		}
+	}
+
+	if len(rows) == 0 {
+		fmt.Printf("No snapshots found for volume: %s\n", volumeID)
+		return nil
+	}
+
+	PrintOutput(list, headers, rows)
+	return nil
 }


### PR DESCRIPTION
…all cmd files

Eliminates all 137 anonymous RunE closures across 28 cmd files. Each inline func(cmd, args) has been extracted to a package-level named function following the runXxx convention (e.g. runCloudServerCreate, runBlockStorageList). Command struct definitions now only contain metadata fields (Use, Short, Long, Example, Args, RunE) with RunE pointing to the named function. Behaviour is unchanged and all existing tests pass.

Closes #137

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related issues

<!-- Closes #<issue-number> -->

## Type of change

- [ ] Bug fix
- [ ] New feature / command
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / release pipeline
- [ ] Other

## Changes

<!-- Bullet list of the notable changes made. -->

-

## Test plan

- [ ] Unit tests added / updated (`go test ./cmd/...`)
- [ ] Coverage remains above threshold (`go tool cover -func=coverage.txt`)
- [ ] Manually tested against a real Aruba Cloud account (or marked N/A)
- [ ] E2E tests passed (or marked N/A)

## Checklist

- [ ] `go fmt` / `gofmt -s` applied
- [ ] `go vet ./...` clean
- [ ] No secrets or credentials in the diff
- [ ] Relevant documentation updated (if applicable)
