### PR TITLE
docs: align website docs with actual CLI flags from e2e tests

### DIFF
--- a/docs/website/docs/resources/compute/cloudserver.md
+++ b/docs/website/docs/resources/compute/cloudserver.md
@@ -23,33 +23,34 @@ acloud compute cloudserver create [flags]
 **Required Flags:**
 - `--name <string>` - Name for the cloud server
 - `--region <string>` - Region code (e.g., `ITBG-Bergamo`)
-- `--flavor <string>` - Flavor name (e.g., `small`, `medium`, `large`)
-- `--boot-disk-uri <string>` - Bootable block storage URI (e.g., `/projects/{project-id}/providers/Aruba.Storage/blockStorages/{volume-id}`)
-- `--vpc-uri <string>` - VPC URI (e.g., `/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}`)
-- `--subnet-uri <stringSlice>` - Subnet URI(s) (comma-separated)
-- `--security-group-uri <stringSlice>` - Security Group URI(s) (comma-separated)
+- `--zone <string>` - Zone/datacenter code (e.g., `ITBG-1`)
+- `--flavor <string>` - Flavor code (e.g., `CSO4A8`)
+- `--boot-disk-id <string>` - Bootable block storage ID
+- `--vpc-id <string>` - VPC ID
+- `--subnet-id <stringSlice>` - Subnet ID(s) (comma-separated)
+- `--security-group-id <stringSlice>` - Security Group ID(s) (comma-separated)
 
 **Optional Flags:**
 - `--project-id <string>` - Project ID (uses context if not specified)
-- `--keypair <string>` - Key pair name for SSH access
+- `--keypair-id <string>` - Key pair ID for SSH access
 - `--tags <stringSlice>` - Tags (comma-separated)
 - `--user-data-file <string>` - Path to cloud-init YAML file (will be base64 encoded)
-- `--elasticip-uri <string>` - Elastic IP URI (optional)
-- `--billing-period <string>` - Billing period: Hour, Month, Year (optional, default: Hour)
+- `--billing-period <string>` - Billing period: Hour, Month, Year (default: Hour)
 
 **Example:**
 ```bash
 acloud compute cloudserver create \
   --name "web-server" \
   --region "ITBG-Bergamo" \
-  --flavor "small" \
-  --boot-disk-uri "/projects/{project-id}/providers/Aruba.Storage/blockStorages/{volume-id}" \
-  --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-  --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
-  --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-  --keypair-uri "/projects/{project-id}/providers/Aruba.Compute/keyPairs/{keypair-name}" \
+  --zone "ITBG-1" \
+  --flavor "CSO4A8" \
+  --boot-disk-id "<volume-id>" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --keypair-id "<keypair-id>" \
   --tags "production,web" \
-  --user-data-file "/path/to/cloud-init.yaml"
+  --billing-period Hour
 ```
 
 **Note:** The `--user-data-file` flag accepts a path to a cloud-init YAML file. The file content will be automatically base64 encoded and included in the cloud server creation request. This allows you to configure the server during initialization using cloud-init scripts.
@@ -322,13 +323,14 @@ acloud compute cloudserver connect <TAB>
    acloud compute cloudserver create \
      --name "app-server" \
      --region "ITBG-Bergamo" \
-     --flavor "medium" \
-     --boot-disk-uri "/projects/{project-id}/providers/Aruba.Storage/blockStorages/{volume-id}" \
-     --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-     --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
-     --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-     --keypair-uri "/projects/{project-id}/providers/Aruba.Compute/keyPairs/{keypair-name}" \
-     --user-data-file "/path/to/cloud-init.yaml"
+     --zone "ITBG-1" \
+     --flavor "CSO4A8" \
+     --boot-disk-id "<volume-id>" \
+     --vpc-id "<vpc-id>" \
+     --subnet-id "<subnet-id>" \
+     --security-group-id "<sg-id>" \
+     --keypair-id "<keypair-id>" \
+     --billing-period Hour
    ```
 
 3. **Wait for the server to be ready** and check status:

--- a/docs/website/docs/resources/compute/keypair.md
+++ b/docs/website/docs/resources/compute/keypair.md
@@ -22,6 +22,7 @@ acloud compute keypair create [flags]
 **Required Flags:**
 - `--name <string>` - Name for the key pair
 - `--public-key <string>` - Public key value (SSH public key)
+- `--region <string>` - Region code (e.g., `ITBG-Bergamo`)
 
 **Optional Flags:**
 - `--project-id <string>` - Project ID (uses context if not specified)
@@ -31,11 +32,13 @@ acloud compute keypair create [flags]
 # Using a file
 acloud compute keypair create \
   --name "my-keypair" \
+  --region "ITBG-Bergamo" \
   --public-key "$(cat ~/.ssh/id_rsa.pub)"
 
 # Or directly
 acloud compute keypair create \
   --name "my-keypair" \
+  --region "ITBG-Bergamo" \
   --public-key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... user@host"
 ```
 
@@ -92,25 +95,15 @@ The command displays:
 
 ### `update`
 
-Update a key pair's public key (useful for key rotation).
+**Not supported.** The API does not support updating a key pair's public key. Running this command prints an error and exits without making any changes.
 
-**Syntax:**
+To rotate a key pair, delete it and recreate it with the same name:
+
 ```bash
-acloud compute keypair update <keypair-name> [flags]
-```
-
-**Arguments:**
-- `<keypair-name>` - The name of the key pair
-
-**Required Flags:**
-- `--public-key <string>` - New public key value
-
-**Optional Flags:**
-- `--project-id <string>` - Project ID (uses context if not specified)
-
-**Example:**
-```bash
-acloud compute keypair update "my-keypair" \
+acloud compute keypair delete "my-keypair" --yes
+acloud compute keypair create \
+  --name "my-keypair" \
+  --region "ITBG-Bergamo" \
   --public-key "$(cat ~/.ssh/id_rsa_new.pub)"
 ```
 
@@ -153,6 +146,7 @@ acloud compute keypair delete <TAB>
 # If you already have an SSH key pair
 acloud compute keypair create \
   --name "my-laptop-key" \
+  --region "ITBG-Bergamo" \
   --public-key "$(cat ~/.ssh/id_rsa.pub)"
 ```
 
@@ -167,6 +161,7 @@ acloud compute keypair create \
    ```bash
    acloud compute keypair create \
      --name "aruba-key" \
+     --region "ITBG-Bergamo" \
      --public-key "$(cat ~/.ssh/aruba_key.pub)"
    ```
 
@@ -175,32 +170,38 @@ acloud compute keypair create \
    acloud compute cloudserver create \
      --name "my-server" \
      --region "ITBG-Bergamo" \
-     --flavor "small" \
-     --image "your-image-id" \
-     --keypair "aruba-key"
+     --zone "ITBG-1" \
+     --flavor "CSO4A8" \
+     --boot-disk-id "<volume-id>" \
+     --vpc-id "<vpc-id>" \
+     --subnet-id "<subnet-id>" \
+     --security-group-id "<sg-id>" \
+     --keypair-id "<keypair-id>"
    ```
 
 ### Rotating Keys
 
-1. **Generate a new key pair**:
+Since keypair update is not supported by the API, key rotation requires delete + recreate:
+
+1. **Generate a new SSH key pair**:
    ```bash
-   ssh-keygen -t rsa -b 4096 -f ~/.ssh/aruba_key_new -N ""
+   ssh-keygen -t ed25519 -f ~/.ssh/aruba_key_new -N ""
    ```
 
-2. **Update the key pair**:
+2. **Delete the existing key pair**:
    ```bash
-   acloud compute keypair update "aruba-key" \
+   acloud compute keypair delete "aruba-key" --yes
+   ```
+
+3. **Recreate it with the new public key**:
+   ```bash
+   acloud compute keypair create \
+     --name "aruba-key" \
+     --region "ITBG-Bergamo" \
      --public-key "$(cat ~/.ssh/aruba_key_new.pub)"
    ```
 
-3. **Update your local SSH config** to use the new private key
-
-4. **Test the connection** to your servers
-
-5. **Delete the old key pair** (if no longer needed):
-   ```bash
-   acloud compute keypair delete "old-keypair" --yes
-   ```
+4. **Update your local SSH config** to use the new private key and test the connection.
 
 ## Best Practices
 

--- a/docs/website/docs/resources/container/containerregistry.md
+++ b/docs/website/docs/resources/container/containerregistry.md
@@ -22,32 +22,36 @@ acloud container containerregistry create [flags]
 **Required Flags:**
 - `--name <string>` - Name for the container registry
 - `--region <string>` - Region code (e.g., `ITBG-Bergamo`)
-- `--public-ip-uri <string>` - Public IP URI (e.g., `/projects/{project-id}/providers/Aruba.Network/elasticIps/{elasticip-id}`)
-- `--vpc-uri <string>` - VPC URI (e.g., `/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}`)
-- `--subnet-uri <string>` - Subnet URI (e.g., `/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}`)
-- `--security-group-uri <string>` - Security group URI
-- `--block-storage-uri <string>` - Block storage URI
+- `--public-ip-id <string>` - Elastic IP ID
+- `--vpc-id <string>` - VPC ID
+- `--subnet-id <string>` - Subnet ID
+- `--security-group-id <string>` - Security group ID
+- `--block-storage-id <string>` - Block storage ID
 
 **Optional Flags:**
 - `--project-id <string>` - Project ID (uses context if not specified)
 - `--tags <stringSlice>` - Tags (comma-separated)
-- `--billing-period <string>` - Billing period: Hour, Month, Year (optional)
-- `--admin-username <string>` - Administrator username (optional)
-- `--concurrent-users <string>` - Number of concurrent users (optional)
+- `--billing-period <string>` - Billing period: Hour, Month, Year (default: Hour)
+- `--admin-username <string>` - Administrator username
+- `--concurrent-users <string>` - Concurrent users plan (e.g., `Small`, or a numeric value like `20`)
 
 **Example:**
 ```bash
 acloud container containerregistry create \
   --name "my-registry" \
   --region "ITBG-Bergamo" \
-  --public-ip-uri "/projects/{project-id}/providers/Aruba.Network/elasticIps/{elasticip-id}" \
-  --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-  --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
-  --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-  --block-storage-uri "/projects/{project-id}/providers/Aruba.Storage/volumes/{volume-id}" \
-  --billing-period "Month" \
+  --public-ip-id "<eip-id>" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --block-storage-id "<vol-id>" \
+  --admin-username "adminuser" \
+  --concurrent-users "Small" \
+  --billing-period "Hour" \
   --tags "production,registry"
 ```
+
+**Note:** The security group must allow TCP/443 (HTTPS) ingress and allow egress traffic for the registry to function correctly.
 
 ### `list`
 
@@ -183,12 +187,14 @@ acloud container containerregistry delete <TAB>
    acloud container containerregistry create \
      --name "my-registry" \
      --region "ITBG-Bergamo" \
-     --public-ip-uri "/projects/{project-id}/providers/Aruba.Network/elasticIps/{elasticip-id}" \
-     --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-     --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
-     --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-     --block-storage-uri "/projects/{project-id}/providers/Aruba.Storage/volumes/{volume-id}" \
-     --billing-period "Month"
+     --public-ip-id "<eip-id>" \
+     --vpc-id "<vpc-id>" \
+     --subnet-id "<subnet-id>" \
+     --security-group-id "<sg-id>" \
+     --block-storage-id "<vol-id>" \
+     --admin-username "adminuser" \
+     --concurrent-users "Small" \
+     --billing-period "Hour"
    ```
 
 3. **Wait for the registry to be ready** and check status:

--- a/docs/website/docs/resources/container/kaas.md
+++ b/docs/website/docs/resources/container/kaas.md
@@ -22,16 +22,16 @@ acloud container kaas create [flags]
 **Required Flags:**
 - `--name <string>` - Name for the KaaS cluster
 - `--region <string>` - Region code (e.g., `ITBG-Bergamo`)
-- `--vpc-uri <string>` - VPC URI (e.g., `/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}`)
-- `--subnet-uri <string>` - Subnet URI (e.g., `/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}`)
-- `--node-cidr-address <string>` - Node CIDR address in CIDR notation (e.g., `10.0.0.0/16`)
+- `--vpc-id <string>` - VPC ID
+- `--subnet-id <string>` - Subnet ID
+- `--node-cidr-address <string>` - Node CIDR address in CIDR notation (e.g., `10.0.0.0/24`)
 - `--node-cidr-name <string>` - Node CIDR name
 - `--security-group-name <string>` - Security group name
-- `--kubernetes-version <string>` - Kubernetes version (e.g., `1.28.0`)
+- `--kubernetes-version <string>` - Kubernetes version (e.g., `1.33.2`)
 - `--node-pool-name <string>` - Node pool name
 - `--node-pool-nodes <int>` - Number of nodes in the node pool
-- `--node-pool-instance <string>` - Instance configuration name for nodes
-- `--node-pool-zone <string>` - Datacenter/zone code for nodes
+- `--node-pool-instance <string>` - Instance configuration code for nodes (e.g., `K2A4`)
+- `--node-pool-zone <string>` - Datacenter/zone code for nodes (e.g., `ITBG-1`)
 
 **Optional Flags:**
 - `--project-id <string>` - Project ID (uses context if not specified)
@@ -50,18 +50,17 @@ acloud container kaas create [flags]
 acloud container kaas create \
   --name "production-cluster" \
   --region "ITBG-Bergamo" \
-  --vpc-uri "/projects/66a10244f62b99c686572a9f/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec" \
-  --subnet-uri "/projects/66a10244f62b99c686572a9f/providers/Aruba.Network/subnets/694b05ac4d0cdc87949b75f9" \
-  --node-cidr-address "10.0.0.0/16" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --node-cidr-address "10.0.0.0/24" \
   --node-cidr-name "node-cidr" \
   --security-group-name "kaas-sg" \
-  --kubernetes-version "1.28.0" \
+  --kubernetes-version "1.33.2" \
   --node-pool-name "default-pool" \
-  --node-pool-nodes 3 \
-  --node-pool-instance "small" \
-  --node-pool-zone "ITBG-Bergamo-A" \
-  --tags "production,kubernetes" \
-  --ha
+  --node-pool-nodes 1 \
+  --node-pool-instance "K2A4" \
+  --node-pool-zone "ITBG-1" \
+  --tags "production,kubernetes"
 ```
 
 ### `list`
@@ -169,6 +168,8 @@ acloud container kaas update 69495ef64d0cdc87949b71ec \
 ```
 
 **Note:** You can update metadata (name, tags) and properties (Kubernetes version, node pools, etc.) in the same command.
+
+**Known limitation:** The SDK does not round-trip node pool fields from the GET response into the PUT body. Attempts to update node pool configuration will result in an API error ("nodepools not found"). Only metadata updates (`--name`, `--tags`) are reliably supported at this time.
 
 ### `delete`
 

--- a/docs/website/docs/resources/database/dbaas.md
+++ b/docs/website/docs/resources/database/dbaas.md
@@ -17,19 +17,25 @@ Create a new DBaaS instance in your project.
 ### Usage
 
 ```bash
-acloud database dbaas create --name <name> --region <region> --engine-id <engine-id> --flavor <flavor> [flags]
+acloud database dbaas create --name <name> --region <region> --zone <zone> --engine-id <engine-id> --flavor <flavor> --storage-size <gb> [flags]
 ```
 
 ### Required Flags
 
 - `--name` - Name for the DBaaS instance
 - `--region` - Region code (e.g., "ITBG-Bergamo")
-- `--engine-id` - Database engine ID
-- `--flavor` - Database flavor/plan name
+- `--zone` - Availability zone (e.g., "ITBG-1")
+- `--engine-id` - Database engine identifier (e.g., `mysql-8.0`)
+- `--flavor` - Database flavor/plan code (e.g., `DBO4A8`)
+- `--storage-size` - Storage size in GB (e.g., `50`)
 
 ### Optional Flags
 
 - `--project-id` - Project ID (uses context if not specified)
+- `--vpc-id` - VPC ID (required when the project has a VPC)
+- `--subnet-id` - Subnet ID (required when the project has a VPC)
+- `--security-group-id` - Security group ID (required when the project has a VPC)
+- `--elastic-ip-id` - Elastic IP ID for public access
 - `--tags` - Tags (comma-separated)
 
 ### Example
@@ -38,10 +44,18 @@ acloud database dbaas create --name <name> --region <region> --engine-id <engine
 acloud database dbaas create \
   --name "my-database" \
   --region "ITBG-Bergamo" \
-  --engine-id "69455aa70d0972656501d45d" \
-  --flavor "db.t3.micro" \
-  --tags "production,postgresql"
+  --zone "ITBG-1" \
+  --engine-id "mysql-8.0" \
+  --flavor "DBO4A8" \
+  --storage-size 50 \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --elastic-ip-id "<eip-id>" \
+  --tags "production,mysql"
 ```
+
+**Note:** Database and user `update` (PUT) operations are not supported by the API and will return HTTP 405. Use `delete` and `create` to replace a database or user.
 
 ## List DBaaS Instances
 

--- a/docs/website/docs/resources/schedule/job.md
+++ b/docs/website/docs/resources/schedule/job.md
@@ -33,7 +33,7 @@ Create a job that runs once at a specific time.
 ### Usage
 
 ```bash
-acloud schedule job create --name <name> --region <region> --job-type "OneShot" --schedule-at <datetime> [flags]
+acloud schedule job create --name <name> --region <region> --job-type "OneShot" --schedule-at <datetime> --step-resource-uri <uri> [flags]
 ```
 
 ### Required Flags
@@ -41,7 +41,16 @@ acloud schedule job create --name <name> --region <region> --job-type "OneShot" 
 - `--name` - Name for the job
 - `--region` - Region code (e.g., "ITBG-Bergamo")
 - `--job-type` - Must be "OneShot"
-- `--schedule-at` - Date and time when the job should run (ISO 8601 format, e.g., "2024-12-31T23:59:59Z")
+- `--schedule-at` - Date and time when the job should run (RFC3339 format, e.g., "2026-12-31T23:59:59Z")
+
+### Step Flags (required by the API)
+
+The schedule API requires at least one step with a valid resource URI. The step defines which resource the job acts on and what action to perform.
+
+- `--step-resource-uri` - URI of the resource to act on (e.g., `/projects/<pid>/providers/Aruba.Compute/cloudServers/<id>`)
+- `--step-action-uri` - Action to invoke on the resource (e.g., `poweroff`, `start`)
+- `--step-http-verb` - HTTP verb for the step action (default: `POST`)
+- `--step-name` - Display name for the step
 
 ### Optional Flags
 
@@ -53,13 +62,18 @@ acloud schedule job create --name <name> --region <region> --job-type "OneShot" 
 
 ```bash
 acloud schedule job create \
-  --name "deploy-release" \
+  --name "scheduled-poweroff" \
   --region "ITBG-Bergamo" \
   --job-type "OneShot" \
-  --schedule-at "2024-12-31T23:59:59Z" \
-  --enabled true \
-  --tags "deployment,production"
+  --schedule-at "2026-12-31T23:59:59Z" \
+  --step-resource-uri "/projects/<project-id>/providers/Aruba.Compute/cloudServers/<server-id>" \
+  --step-action-uri "poweroff" \
+  --step-http-verb "POST" \
+  --step-name "e2e-step" \
+  --tags "maintenance,oneshot"
 ```
+
+**Note:** The `--step-resource-uri` must point to a resource type registered with the scheduler (e.g., cloud servers). Not all resource types are supported. The API returns "Not found configuration for typology" if the resource type is not registered.
 
 ## Create Recurring Job
 
@@ -68,7 +82,7 @@ Create a job that runs on a recurring schedule.
 ### Usage
 
 ```bash
-acloud schedule job create --name <name> --region <region> --job-type "Recurring" --cron <cron-expression> --execute-until <datetime> [flags]
+acloud schedule job create --name <name> --region <region> --job-type "Recurring" --cron <cron-expression> --execute-until <datetime> --step-resource-uri <uri> [flags]
 ```
 
 ### Required Flags
@@ -77,24 +91,31 @@ acloud schedule job create --name <name> --region <region> --job-type "Recurring
 - `--region` - Region code (e.g., "ITBG-Bergamo")
 - `--job-type` - Must be "Recurring"
 - `--cron` - CRON expression defining the schedule
-- `--execute-until` - End date until which the job can run (ISO 8601 format)
+- `--execute-until` - End date until which the job can run (RFC3339 format)
+
+### Step Flags (required by the API)
+
+Same as OneShot jobs: `--step-resource-uri`, `--step-action-uri`, `--step-http-verb`, `--step-name`.
 
 ### Optional Flags
 
 - `--project-id` - Project ID (uses context if not specified)
-- `--enabled` - Enable the job (default: true)
+- `--enabled` - Enable or disable the job (default: true)
 - `--tags` - Tags (comma-separated)
 
 ### Example
 
 ```bash
 acloud schedule job create \
-  --name "daily-backup" \
+  --name "daily-poweroff" \
   --region "ITBG-Bergamo" \
   --job-type "Recurring" \
-  --cron "0 2 * * *" \
-  --execute-until "2025-12-31T23:59:59Z" \
-  --enabled true \
+  --cron "0 0 * * *" \
+  --execute-until "2027-01-01T00:00:00Z" \
+  --step-resource-uri "/projects/<project-id>/providers/Aruba.Compute/cloudServers/<server-id>" \
+  --step-action-uri "poweroff" \
+  --step-http-verb "POST" \
+  --step-name "daily-step" \
   --tags "backup,daily"
 ```
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/compute/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/compute/cloudserver.md
@@ -22,25 +22,34 @@ acloud compute cloudserver create [flags]
 **Flag Richiesti:**
 - `--name <string>` - Nome per il cloud server
 - `--region <string>` - Codice regione (es. `ITBG-Bergamo`)
-- `--flavor <string>` - Nome flavor (es. `small`, `medium`, `large`)
-- `--image <string>` - ID o nome immagine
+- `--zone <string>` - Codice zona/datacenter (es. `ITBG-1`)
+- `--flavor <string>` - Codice flavor (es. `CSO4A8`)
+- `--boot-disk-id <string>` - ID block storage avviabile
+- `--vpc-id <string>` - ID VPC
+- `--subnet-id <stringSlice>` - ID Subnet (separati da virgola)
+- `--security-group-id <stringSlice>` - ID Security Group (separati da virgola)
 
 **Flag Opzionali:**
 - `--project-id <string>` - ID progetto (usa il contesto se non specificato)
-- `--keypair <string>` - Nome coppia di chiavi per accesso SSH
+- `--keypair-id <string>` - ID coppia di chiavi per accesso SSH
 - `--tags <stringSlice>` - Tag (separati da virgola)
 - `--user-data-file <string>` - Percorso al file YAML cloud-init (verrà codificato in base64)
+- `--billing-period <string>` - Periodo di fatturazione: Hour, Month, Year (default: Hour)
 
 **Esempio:**
 ```bash
 acloud compute cloudserver create \
   --name "web-server" \
   --region "ITBG-Bergamo" \
-  --flavor "small" \
-  --image "ubuntu-22.04" \
-  --keypair "my-keypair" \
+  --zone "ITBG-1" \
+  --flavor "CSO4A8" \
+  --boot-disk-id "<volume-id>" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --keypair-id "<keypair-id>" \
   --tags "production,web" \
-  --user-data-file "/percorso/al/cloud-init.yaml"
+  --billing-period Hour
 ```
 
 **Nota:** Il flag `--user-data-file` accetta un percorso a un file YAML cloud-init. Il contenuto del file verrà automaticamente codificato in base64 e incluso nella richiesta di creazione del cloud server. Questo ti consente di configurare il server durante l'inizializzazione utilizzando script cloud-init.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/compute/keypair.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/compute/keypair.md
@@ -22,6 +22,7 @@ acloud compute keypair create [flags]
 **Flag Richiesti:**
 - `--name <string>` - Nome per la coppia di chiavi
 - `--public-key <string>` - Valore della chiave pubblica (chiave pubblica SSH)
+- `--region <string>` - Codice regione (es. `ITBG-Bergamo`)
 
 **Flag Opzionali:**
 - `--project-id <string>` - ID progetto (usa il contesto se non specificato)
@@ -31,11 +32,13 @@ acloud compute keypair create [flags]
 # Usando un file
 acloud compute keypair create \
   --name "my-keypair" \
+  --region "ITBG-Bergamo" \
   --public-key "$(cat ~/.ssh/id_rsa.pub)"
 
 # O direttamente
 acloud compute keypair create \
   --name "my-keypair" \
+  --region "ITBG-Bergamo" \
   --public-key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... user@host"
 ```
 
@@ -92,25 +95,15 @@ Il comando visualizza:
 
 ### `update`
 
-Aggiorna la chiave pubblica di una coppia di chiavi (utile per la rotazione delle chiavi).
+**Non supportato.** L'API non supporta l'aggiornamento della chiave pubblica di una coppia di chiavi. L'esecuzione di questo comando stampa un errore e termina senza apportare modifiche.
 
-**Sintassi:**
+Per ruotare una coppia di chiavi, eliminarla e ricrearla con lo stesso nome:
+
 ```bash
-acloud compute keypair update <keypair-name> [flags]
-```
-
-**Argomenti:**
-- `<keypair-name>` - Il nome della coppia di chiavi
-
-**Flag Richiesti:**
-- `--public-key <string>` - Nuovo valore della chiave pubblica
-
-**Flag Opzionali:**
-- `--project-id <string>` - ID progetto (usa il contesto se non specificato)
-
-**Esempio:**
-```bash
-acloud compute keypair update "my-keypair" \
+acloud compute keypair delete "my-keypair" --yes
+acloud compute keypair create \
+  --name "my-keypair" \
+  --region "ITBG-Bergamo" \
   --public-key "$(cat ~/.ssh/id_rsa_new.pub)"
 ```
 
@@ -153,6 +146,7 @@ acloud compute keypair delete <TAB>
 # Se hai già una coppia di chiavi SSH
 acloud compute keypair create \
   --name "my-laptop-key" \
+  --region "ITBG-Bergamo" \
   --public-key "$(cat ~/.ssh/id_rsa.pub)"
 ```
 
@@ -167,6 +161,7 @@ acloud compute keypair create \
    ```bash
    acloud compute keypair create \
      --name "aruba-key" \
+     --region "ITBG-Bergamo" \
      --public-key "$(cat ~/.ssh/aruba_key.pub)"
    ```
 
@@ -175,32 +170,38 @@ acloud compute keypair create \
    acloud compute cloudserver create \
      --name "my-server" \
      --region "ITBG-Bergamo" \
-     --flavor "small" \
-     --image "your-image-id" \
-     --keypair "aruba-key"
+     --zone "ITBG-1" \
+     --flavor "CSO4A8" \
+     --boot-disk-id "<volume-id>" \
+     --vpc-id "<vpc-id>" \
+     --subnet-id "<subnet-id>" \
+     --security-group-id "<sg-id>" \
+     --keypair-id "<keypair-id>"
    ```
 
 ### Rotazione delle Chiavi
 
-1. **Genera una nuova coppia di chiavi**:
+Poiché l'aggiornamento della coppia di chiavi non è supportato dall'API, la rotazione richiede eliminazione + ricreazione:
+
+1. **Genera una nuova coppia di chiavi SSH**:
    ```bash
-   ssh-keygen -t rsa -b 4096 -f ~/.ssh/aruba_key_new -N ""
+   ssh-keygen -t ed25519 -f ~/.ssh/aruba_key_new -N ""
    ```
 
-2. **Aggiorna la coppia di chiavi**:
+2. **Elimina la coppia di chiavi esistente**:
    ```bash
-   acloud compute keypair update "aruba-key" \
+   acloud compute keypair delete "aruba-key" --yes
+   ```
+
+3. **Ricreala con la nuova chiave pubblica**:
+   ```bash
+   acloud compute keypair create \
+     --name "aruba-key" \
+     --region "ITBG-Bergamo" \
      --public-key "$(cat ~/.ssh/aruba_key_new.pub)"
    ```
 
-3. **Aggiorna la tua configurazione SSH locale** per usare la nuova chiave privata
-
-4. **Testa la connessione** ai tuoi server
-
-5. **Elimina la vecchia coppia di chiavi** (se non più necessaria):
-   ```bash
-   acloud compute keypair delete "old-keypair" --yes
-   ```
+4. **Aggiorna la tua configurazione SSH locale** per usare la nuova chiave privata e testa la connessione.
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/container/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/container/containerregistry.md
@@ -22,32 +22,36 @@ acloud container containerregistry create [flags]
 **Flag Richiesti:**
 - `--name <string>` - Nome per il container registry
 - `--region <string>` - Codice regione (es. `ITBG-Bergamo`)
-- `--public-ip-uri <string>` - URI IP pubblico (es. `/projects/{project-id}/providers/Aruba.Network/elasticIps/{elasticip-id}`)
-- `--vpc-uri <string>` - URI VPC (es. `/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}`)
-- `--subnet-uri <string>` - URI Subnet (es. `/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}`)
-- `--security-group-uri <string>` - URI security group
-- `--block-storage-uri <string>` - URI block storage
+- `--public-ip-id <string>` - ID Elastic IP
+- `--vpc-id <string>` - ID VPC
+- `--subnet-id <string>` - ID Subnet
+- `--security-group-id <string>` - ID security group
+- `--block-storage-id <string>` - ID block storage
 
 **Flag Opzionali:**
 - `--project-id <string>` - ID progetto (usa il contesto se non specificato)
 - `--tags <stringSlice>` - Tag (separati da virgola)
-- `--billing-period <string>` - Periodo di fatturazione: Hour, Month, Year (opzionale)
-- `--admin-username <string>` - Nome utente amministratore (opzionale)
-- `--concurrent-users <string>` - Numero di utenti concorrenti (opzionale)
+- `--billing-period <string>` - Periodo di fatturazione: Hour, Month, Year (default: Hour)
+- `--admin-username <string>` - Nome utente amministratore
+- `--concurrent-users <string>` - Piano utenti concorrenti (es. `Small`, o valore numerico come `20`)
 
 **Esempio:**
 ```bash
 acloud container containerregistry create \
   --name "my-registry" \
   --region "ITBG-Bergamo" \
-  --public-ip-uri "/projects/{project-id}/providers/Aruba.Network/elasticIps/{elasticip-id}" \
-  --vpc-uri "/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-  --subnet-uri "/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}" \
-  --security-group-uri "/projects/{project-id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-  --block-storage-uri "/projects/{project-id}/providers/Aruba.Storage/volumes/{volume-id}" \
-  --billing-period "Month" \
+  --public-ip-id "<eip-id>" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --block-storage-id "<vol-id>" \
+  --admin-username "adminuser" \
+  --concurrent-users "Small" \
+  --billing-period "Hour" \
   --tags "production,registry"
 ```
+
+**Nota:** Il security group deve consentire traffico ingress TCP/443 (HTTPS) e traffico egress per il corretto funzionamento del registry.
 
 ### `list`
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/container/kaas.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/container/kaas.md
@@ -22,16 +22,16 @@ acloud container kaas create [flags]
 **Flag Richiesti:**
 - `--name <string>` - Nome per il cluster KaaS
 - `--region <string>` - Codice regione (es. `ITBG-Bergamo`)
-- `--vpc-uri <string>` - URI VPC (es. `/projects/{project-id}/providers/Aruba.Network/vpcs/{vpc-id}`)
-- `--subnet-uri <string>` - URI Subnet (es. `/projects/{project-id}/providers/Aruba.Network/subnets/{subnet-id}`)
-- `--node-cidr-address <string>` - Indirizzo CIDR nodo in notazione CIDR (es. `10.0.0.0/16`)
+- `--vpc-id <string>` - ID VPC
+- `--subnet-id <string>` - ID Subnet
+- `--node-cidr-address <string>` - Indirizzo CIDR nodo in notazione CIDR (es. `10.0.0.0/24`)
 - `--node-cidr-name <string>` - Nome CIDR nodo
 - `--security-group-name <string>` - Nome security group
-- `--kubernetes-version <string>` - Versione Kubernetes (es. `1.28.0`)
+- `--kubernetes-version <string>` - Versione Kubernetes (es. `1.33.2`)
 - `--node-pool-name <string>` - Nome node pool
 - `--node-pool-nodes <int>` - Numero di nodi nel node pool
-- `--node-pool-instance <string>` - Nome configurazione istanza per i nodi
-- `--node-pool-zone <string>` - Codice datacenter/zona per i nodi
+- `--node-pool-instance <string>` - Codice configurazione istanza per i nodi (es. `K2A4`)
+- `--node-pool-zone <string>` - Codice datacenter/zona per i nodi (es. `ITBG-1`)
 
 **Flag Opzionali:**
 - `--project-id <string>` - ID progetto (usa il contesto se non specificato)
@@ -50,18 +50,17 @@ acloud container kaas create [flags]
 acloud container kaas create \
   --name "production-cluster" \
   --region "ITBG-Bergamo" \
-  --vpc-uri "/projects/66a10244f62b99c686572a9f/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec" \
-  --subnet-uri "/projects/66a10244f62b99c686572a9f/providers/Aruba.Network/subnets/694b05ac4d0cdc87949b75f9" \
-  --node-cidr-address "10.0.0.0/16" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --node-cidr-address "10.0.0.0/24" \
   --node-cidr-name "node-cidr" \
   --security-group-name "kaas-sg" \
-  --kubernetes-version "1.28.0" \
+  --kubernetes-version "1.33.2" \
   --node-pool-name "default-pool" \
-  --node-pool-nodes 3 \
-  --node-pool-instance "small" \
-  --node-pool-zone "ITBG-Bergamo-A" \
-  --tags "production,kubernetes" \
-  --ha
+  --node-pool-nodes 1 \
+  --node-pool-instance "K2A4" \
+  --node-pool-zone "ITBG-1" \
+  --tags "production,kubernetes"
 ```
 
 ### `list`
@@ -169,6 +168,8 @@ acloud container kaas update 69495ef64d0cdc87949b71ec \
 ```
 
 **Nota:** Puoi aggiornare metadati (nome, tag) e proprietà (versione Kubernetes, node pool, ecc.) nello stesso comando.
+
+**Limitazione nota:** L'SDK non riporta i campi dei node pool dalla risposta GET nel body della PUT. I tentativi di aggiornare la configurazione dei node pool restituiranno un errore API ("nodepools not found"). Solo gli aggiornamenti di metadati (`--name`, `--tags`) sono supportati in modo affidabile al momento.
 
 ### `delete`
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.md
@@ -17,19 +17,25 @@ Crea una nuova istanza DBaaS nel tuo progetto.
 ### Utilizzo
 
 ```bash
-acloud database dbaas create --name <name> --region <region> --engine-id <engine-id> --flavor <flavor> [flags]
+acloud database dbaas create --name <name> --region <region> --zone <zone> --engine-id <engine-id> --flavor <flavor> --storage-size <gb> [flags]
 ```
 
 ### Flag Richiesti
 
 - `--name` - Nome per l'istanza DBaaS
 - `--region` - Codice regione (es. "ITBG-Bergamo")
-- `--engine-id` - ID engine database
-- `--flavor` - Nome flavor/piano database
+- `--zone` - Zona di disponibilità (es. "ITBG-1")
+- `--engine-id` - Identificatore engine database (es. `mysql-8.0`)
+- `--flavor` - Codice flavor/piano database (es. `DBO4A8`)
+- `--storage-size` - Dimensione storage in GB (es. `50`)
 
 ### Flag Opzionali
 
 - `--project-id` - ID progetto (usa il contesto se non specificato)
+- `--vpc-id` - ID VPC (richiesto quando il progetto ha una VPC)
+- `--subnet-id` - ID Subnet (richiesto quando il progetto ha una VPC)
+- `--security-group-id` - ID security group (richiesto quando il progetto ha una VPC)
+- `--elastic-ip-id` - ID Elastic IP per accesso pubblico
 - `--tags` - Tag (separati da virgola)
 
 ### Esempio
@@ -38,10 +44,18 @@ acloud database dbaas create --name <name> --region <region> --engine-id <engine
 acloud database dbaas create \
   --name "my-database" \
   --region "ITBG-Bergamo" \
-  --engine-id "69455aa70d0972656501d45d" \
-  --flavor "db.t3.micro" \
-  --tags "production,postgresql"
+  --zone "ITBG-1" \
+  --engine-id "mysql-8.0" \
+  --flavor "DBO4A8" \
+  --storage-size 50 \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --elastic-ip-id "<eip-id>" \
+  --tags "production,mysql"
 ```
+
+**Nota:** Le operazioni `update` (PUT) su database e utenti non sono supportate dall'API e restituiscono HTTP 405. Per sostituire un database o un utente, eliminarlo e ricrearlo.
 
 ## Elenca Istanze DBaaS
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/schedule/job.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/schedule/job.md
@@ -33,7 +33,7 @@ Crea un job che viene eseguito una volta a un orario specifico.
 ### Utilizzo
 
 ```bash
-acloud schedule job create --name <name> --region <region> --job-type "OneShot" --schedule-at <datetime> [flags]
+acloud schedule job create --name <name> --region <region> --job-type "OneShot" --schedule-at <datetime> --step-resource-uri <uri> [flags]
 ```
 
 ### Flag Richiesti
@@ -41,7 +41,16 @@ acloud schedule job create --name <name> --region <region> --job-type "OneShot" 
 - `--name` - Nome per il job
 - `--region` - Codice regione (es. "ITBG-Bergamo")
 - `--job-type` - Deve essere "OneShot"
-- `--schedule-at` - Data e ora in cui il job dovrebbe essere eseguito (formato ISO 8601, es. "2024-12-31T23:59:59Z")
+- `--schedule-at` - Data e ora in cui il job dovrebbe essere eseguito (formato RFC3339, es. "2026-12-31T23:59:59Z")
+
+### Flag Step (richiesti dall'API)
+
+L'API schedule richiede almeno uno step con un URI risorsa valido. Lo step definisce su quale risorsa il job agisce e quale azione eseguire.
+
+- `--step-resource-uri` - URI della risorsa su cui agire (es. `/projects/<pid>/providers/Aruba.Compute/cloudServers/<id>`)
+- `--step-action-uri` - Azione da invocare sulla risorsa (es. `poweroff`, `start`)
+- `--step-http-verb` - Verbo HTTP per l'azione dello step (default: `POST`)
+- `--step-name` - Nome visualizzato per lo step
 
 ### Flag Opzionali
 
@@ -53,13 +62,18 @@ acloud schedule job create --name <name> --region <region> --job-type "OneShot" 
 
 ```bash
 acloud schedule job create \
-  --name "deploy-release" \
+  --name "scheduled-poweroff" \
   --region "ITBG-Bergamo" \
   --job-type "OneShot" \
-  --schedule-at "2024-12-31T23:59:59Z" \
-  --enabled true \
-  --tags "deployment,production"
+  --schedule-at "2026-12-31T23:59:59Z" \
+  --step-resource-uri "/projects/<project-id>/providers/Aruba.Compute/cloudServers/<server-id>" \
+  --step-action-uri "poweroff" \
+  --step-http-verb "POST" \
+  --step-name "e2e-step" \
+  --tags "maintenance,oneshot"
 ```
+
+**Nota:** `--step-resource-uri` deve puntare a un tipo di risorsa registrata con lo scheduler (es. cloud server). L'API restituisce "Not found configuration for typology" se il tipo di risorsa non è registrato.
 
 ## Crea Job Ricorrente
 
@@ -68,7 +82,7 @@ Crea un job che viene eseguito su una pianificazione ricorrente.
 ### Utilizzo
 
 ```bash
-acloud schedule job create --name <name> --region <region> --job-type "Recurring" --cron <cron-expression> --execute-until <datetime> [flags]
+acloud schedule job create --name <name> --region <region> --job-type "Recurring" --cron <cron-expression> --execute-until <datetime> --step-resource-uri <uri> [flags]
 ```
 
 ### Flag Richiesti
@@ -77,24 +91,31 @@ acloud schedule job create --name <name> --region <region> --job-type "Recurring
 - `--region` - Codice regione (es. "ITBG-Bergamo")
 - `--job-type` - Deve essere "Recurring"
 - `--cron` - Espressione CRON che definisce la pianificazione
-- `--execute-until` - Data di fine fino alla quale il job può essere eseguito (formato ISO 8601)
+- `--execute-until` - Data di fine fino alla quale il job può essere eseguito (formato RFC3339)
+
+### Flag Step (richiesti dall'API)
+
+Stessi flag degli OneShot: `--step-resource-uri`, `--step-action-uri`, `--step-http-verb`, `--step-name`.
 
 ### Flag Opzionali
 
 - `--project-id` - ID progetto (usa il contesto se non specificato)
-- `--enabled` - Abilita il job (default: true)
+- `--enabled` - Abilita o disabilita il job (default: true)
 - `--tags` - Tag (separati da virgola)
 
 ### Esempio
 
 ```bash
 acloud schedule job create \
-  --name "daily-backup" \
+  --name "daily-poweroff" \
   --region "ITBG-Bergamo" \
   --job-type "Recurring" \
-  --cron "0 2 * * *" \
-  --execute-until "2025-12-31T23:59:59Z" \
-  --enabled true \
+  --cron "0 0 * * *" \
+  --execute-until "2027-01-01T00:00:00Z" \
+  --step-resource-uri "/projects/<project-id>/providers/Aruba.Compute/cloudServers/<server-id>" \
+  --step-action-uri "poweroff" \
+  --step-http-verb "POST" \
+  --step-name "daily-step" \
   --tags "backup,daily"
 ```
 


### PR DESCRIPTION
All flag discrepancies found by comparing e2e test scripts against the Go cmd source and the published website docs.

cloudserver create
- Replace URI flags (--boot-disk-uri, --vpc-uri, --subnet-uri, --security-group-uri, --keypair-uri) with ID flags that the CLI actually accepts (--boot-disk-id, --vpc-id, --subnet-id, --security-group-id, --keypair-id)
- Add missing required --zone flag
- Fix flavor examples (CSO4A8, not small/medium/large)
- Remove non-existent --elasticip-uri flag

keypair create
- Add missing required --region flag

keypair update
- Document as unsupported (API returns error); describe delete+recreate workaround for key rotation

kaas create
- Replace --vpc-uri / --subnet-uri with --vpc-id / --subnet-id
- Update example k8s version (1.33.2), instance (K2A4), zone (ITBG-1)
- Add known-limitation note: node pool fields not round-tripped by SDK, so only --name/--tags updates work reliably

containerregistry create
- Replace all five URI flags with ID flags (--public-ip-id, --vpc-id, --subnet-id, --security-group-id, --block-storage-id)
- Add note about required SG rules (TCP/443 ingress + egress)

dbaas create
- Add required --zone and --storage-size flags
- Add optional --vpc-id, --subnet-id, --security-group-id, --elastic-ip-id flags
- Fix --engine-id example (mysql-8.0, not a hex ID)
- Note that database/user update (PUT) returns HTTP 405

schedule job create
- Add step flags required by the API: --step-resource-uri, --step-action-uri, --step-http-verb, --step-name
- Note typology restriction (cloud servers supported; other resource types may not be registered with the scheduler)

All changes mirrored to Italian (i18n/it) translations.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related issues

<!-- Closes #<issue-number> -->

## Type of change

- [ ] Bug fix
- [ ] New feature / command
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / release pipeline
- [ ] Other

## Changes

<!-- Bullet list of the notable changes made. -->

-

## Test plan

- [ ] Unit tests added / updated (`go test ./cmd/...`)
- [ ] Coverage remains above threshold (`go tool cover -func=coverage.txt`)
- [ ] Manually tested against a real Aruba Cloud account (or marked N/A)
- [ ] E2E tests passed (or marked N/A)

## Checklist

- [ ] `go fmt` / `gofmt -s` applied
- [ ] `go vet ./...` clean
- [ ] No secrets or credentials in the diff
- [ ] Relevant documentation updated (if applicable)
