### PR TITLE
feat: set user-agent to acloud-cli@<version> on SDK client

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,6 +180,8 @@ func GetArubaClient() (aruba.Client, error) {
 		options = options.WithDefaultLogger()
 	}
 
+	options = options.WithUserAgent("acloud-cli@" + rootCmd.Version)
+
 	client, err := aruba.NewClient(options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Aruba Cloud client: %w", err)


### PR DESCRIPTION
Passes WithUserAgent("acloud-cli@<version>") to the SDK options chain in GetArubaClient() so every API request carries the CLI identity instead of the default sdk-go@<version> header.

The version string comes from rootCmd.Version, which is already populated at startup via ldflags (main.go → SetVersion). Dev builds report "acloud-cli@dev"; release builds report e.g. "acloud-cli@0.0.16".

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related issues

<!-- Closes #<issue-number> -->

## Type of change

- [ ] Bug fix
- [ ] New feature / command
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / release pipeline
- [ ] Other

## Changes

<!-- Bullet list of the notable changes made. -->

-

## Test plan

- [ ] Unit tests added / updated (`go test ./cmd/...`)
- [ ] Coverage remains above threshold (`go tool cover -func=coverage.txt`)
- [ ] Manually tested against a real Aruba Cloud account (or marked N/A)
- [ ] E2E tests passed (or marked N/A)

## Checklist

- [ ] `go fmt` / `gofmt -s` applied
- [ ] `go vet ./...` clean
- [ ] No secrets or credentials in the diff
- [ ] Relevant documentation updated (if applicable)
