### PR TITLE
fix(deps): bump sdk-go to v1.0.3; fully close TD-033 (#131)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -111,20 +111,15 @@ error rather than silently emitting an invalid payload.
 
 ---
 
-### TD-033 · `container.kaas.go` residual `pkg/types` import
+### ~~TD-033~~ · RESOLVED
 
-One residual `types.*` usage remains in production code after the v1.0.0 migration:
+~~`container.kaas.go` and `management.project.go` residual `pkg/types` and `.Raw()`~~
 
-1. **`cmd/container.kaas.go`** — `types.KaaSAPIServerAccessProfilePropertiesRequest` must be
-   referenced directly because sdk-go v1.0.2 provides no `aruba`-level constructor for
-   API server access profile settings. Remove the `pkg/types` import once sdk-go exposes
-   `aruba.NewAPIServerAccessProfile()` or an equivalent fluent setter.
+Fully resolved across two sdk-go releases:
+- **v1.0.2**: `responseMetadataMixin` gained `CreatedBy()`/`UpdatedBy()`/`CreatedUser()`/`UpdatedUser()` — removed `.Raw().Metadata.CreatedBy` calls in `management.project.go` and `container.kaas.go`.
+- **v1.0.3**: `KaaS` gained `WithPrivateCluster()` and `WithAuthorizedIPRanges(ranges ...string)` fluent setters — removed `types.KaaSAPIServerAccessProfilePropertiesRequest` and the `pkg/types` import from `container.kaas.go`.
 
-~~2. `cmd/management.project.go` and `cmd/container.kaas.go` — `.Raw().Metadata.CreatedBy` /
-   `.UpdatedBy` calls~~ Resolved in sdk-go v1.0.2: `responseMetadataMixin` now exposes
-   `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` on all Family-A wrappers.
-
-**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/131
+**Closed:** https://github.com/Arubacloud/acloud-cli/issues/131
 
 ---
 

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -111,17 +111,18 @@ error rather than silently emitting an invalid payload.
 
 ---
 
-### TD-033 · `container.kaas.go` and `management.project.go` residual `pkg/types` and `.Raw()`
+### TD-033 · `container.kaas.go` residual `pkg/types` import
 
-Two residual `.Raw()` / `types.*` usages remain in production code after the v1.0.0 migration:
+One residual `types.*` usage remains in production code after the v1.0.0 migration:
 
-1. **`cmd/container.kaas.go:221`** — `types.KaaSAPIServerAccessProfilePropertiesRequest` must be
-   referenced directly because sdk-go v1.0.0 provides no `aruba`-level constructor for
+1. **`cmd/container.kaas.go`** — `types.KaaSAPIServerAccessProfilePropertiesRequest` must be
+   referenced directly because sdk-go v1.0.2 provides no `aruba`-level constructor for
    API server access profile settings. Remove the `pkg/types` import once sdk-go exposes
    `aruba.NewAPIServerAccessProfile()` or an equivalent fluent setter.
-2. **`cmd/management.project.go`** — `p.Raw().Metadata.CreatedBy` / `.UpdatedBy` are read
-   because `*aruba.Project` in v1.0.0 does not expose `CreatedBy()` / `UpdatedBy()` wrapper
-   accessors. Remove once sdk-go adds these accessors to the `Project` wrapper.
+
+~~2. `cmd/management.project.go` and `cmd/container.kaas.go` — `.Raw().Metadata.CreatedBy` /
+   `.UpdatedBy` calls~~ Resolved in sdk-go v1.0.2: `responseMetadataMixin` now exposes
+   `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` on all Family-A wrappers.
 
 **Filed as:** https://github.com/Arubacloud/acloud-cli/issues/131
 

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -790,9 +790,8 @@ func ContainerKaaSGet(ctx context.Context, client aruba.Client, args ContainerKa
 		if !kaas.CreatedAt().IsZero() {
 			fmt.Printf("Creation Date:   %s\n", kaas.CreatedAt().Format(DateLayout))
 		}
-		// CreatedBy has no wrapper accessor in sdk-go v1.0.0 — TECH_DEBT: TD-033
-		if raw := kaas.Raw(); raw != nil && raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+		if v := kaas.CreatedBy(); v != "" {
+			fmt.Printf("Created By:      %s\n", v)
 		}
 		if tags := kaas.Tags(); len(tags) > 0 {
 			fmt.Printf("Tags:            %v\n", tags)

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
-	"github.com/Arubacloud/sdk-go/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -719,18 +718,11 @@ func ContainerKaaSCreate(ctx context.Context, client aruba.Client, args Containe
 	if args.BillingPeriod != "" {
 		kaas.BilledBy(args.BillingPeriod)
 	}
-	if len(args.APIServerAuthorizedIPRanges) > 0 || args.APIServerEnablePrivateCluster {
-		// TECH_DEBT: TD-033 (#131) — types.KaaSAPIServerAccessProfilePropertiesRequest must be
-		// referenced directly because the SDK provides no aruba-level constructor for
-		// this type yet. Remove the types import from this file once sdk-go exposes
-		// aruba.NewAPIServerAccessProfile() or an equivalent fluent setter.
-		profile := &types.KaaSAPIServerAccessProfilePropertiesRequest{
-			EnablePrivateCluster: args.APIServerEnablePrivateCluster,
-		}
-		if len(args.APIServerAuthorizedIPRanges) > 0 {
-			profile.AuthorizedIPRanges = &args.APIServerAuthorizedIPRanges
-		}
-		kaas.WithAPIServerAccessProfile(profile)
+	if args.APIServerEnablePrivateCluster {
+		kaas.WithPrivateCluster()
+	}
+	if len(args.APIServerAuthorizedIPRanges) > 0 {
+		kaas.WithAuthorizedIPRanges(args.APIServerAuthorizedIPRanges...)
 	}
 
 	created, err := client.FromContainer().KaaS().Create(ctx, kaas)

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -438,15 +438,11 @@ func ManagementProjectGet(ctx context.Context, client aruba.Client, args Managem
 		if !p.UpdatedAt().IsZero() {
 			fmt.Printf("Update Date:     %s\n", p.UpdatedAt().Format(DateLayout))
 		}
-		// CreatedBy / UpdatedBy have no wrapper accessors in sdk-go v1.0.0. TECH_DEBT: TD-033 (#131)
-		// See https://github.com/Arubacloud/acloud-cli/issues/131
-		if raw := p.Raw(); raw != nil {
-			if raw.Metadata.CreatedBy != nil {
-				fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-			}
-			if raw.Metadata.UpdatedBy != nil {
-				fmt.Printf("Updated By:      %s\n", *raw.Metadata.UpdatedBy)
-			}
+		if v := p.CreatedBy(); v != "" {
+			fmt.Printf("Created By:      %s\n", v)
+		}
+		if v := p.UpdatedBy(); v != "" {
+			fmt.Printf("Updated By:      %s\n", v)
 		}
 
 		tags := p.Tags()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module acloud
 go 1.25.0
 
 require (
-	github.com/Arubacloud/sdk-go v1.0.2
+	github.com/Arubacloud/sdk-go v1.0.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module acloud
 go 1.25.0
 
 require (
-	github.com/Arubacloud/sdk-go v1.0.0
+	github.com/Arubacloud/sdk-go v1.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Arubacloud/sdk-go v1.0.0 h1:/rupdcEqOgG7Qn7hIbbm8Hwx9ivixKECfO0llNfCntQ=
 github.com/Arubacloud/sdk-go v1.0.0/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
+github.com/Arubacloud/sdk-go v1.0.2 h1:mJeCkS4aJ/gVw3sJD7p4yPwNWZD6YRrbW7hMDdCMz4o=
+github.com/Arubacloud/sdk-go v1.0.2/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Arubacloud/sdk-go v1.0.0 h1:/rupdcEqOgG7Qn7hIbbm8Hwx9ivixKECfO0llNfCn
 github.com/Arubacloud/sdk-go v1.0.0/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/Arubacloud/sdk-go v1.0.2 h1:mJeCkS4aJ/gVw3sJD7p4yPwNWZD6YRrbW7hMDdCMz4o=
 github.com/Arubacloud/sdk-go v1.0.2/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
+github.com/Arubacloud/sdk-go v1.0.3 h1:katc1KIGwTCNmVZ019ZadTSljYwbmqQWe3OSez2yy1g=
+github.com/Arubacloud/sdk-go v1.0.3/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
## Summary

- Bump `github.com/Arubacloud/sdk-go` `v1.0.0` → `v1.0.3`
- **v1.0.2**: Replace `.Raw().Metadata.CreatedBy`/`.UpdatedBy` in `management.project.go` and `container.kaas.go` with the new `CreatedBy()`/`UpdatedBy()` wrapper accessors from `responseMetadataMixin`
- **v1.0.3**: Replace `types.KaaSAPIServerAccessProfilePropertiesRequest` block in `container.kaas.go` with the new `WithPrivateCluster()` and `WithAuthorizedIPRanges(ranges ...string)` fluent setters; drop the `pkg/types` import entirely
- Mark TD-033 as fully resolved in `ai/TECH_DEBT.md`

Closes #131

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all unit tests green)
- [ ] `TestProjectGetCmd_FullDetail` — `CreatedBy`/`UpdatedBy` appear in `project get` output
- [ ] `TestKaaSGetCmd_FullDetail` — `CreatedBy` appears in `container kaas get` output
- [ ] `container.kaas.go` no longer imports `github.com/Arubacloud/sdk-go/pkg/types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)