### PR TITLE
fix(compute): re-inject security groups from linkedResources on cloudserver update

### DIFF
--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -895,6 +895,16 @@ func ComputeCloudServerUpdate(ctx context.Context, client aruba.Client, args Com
 		return fmt.Errorf("cloud server not found")
 	}
 
+	// The SDK's fromResponse hydrates subnetRefs from NetworkInterfaces[].Subnet but
+	// cannot extract securityGroupRefs because the API surfaces them only inside
+	// linkedResources[] without a distinguishable type field. Re-inject them here so
+	// the PUT body keeps them; without them the API strips all SGs and returns 400.
+	for _, lr := range server.Raw().Properties.LinkedResources {
+		if strings.Contains(lr.URI, "/securityGroups/") {
+			server.WithSecurityGroups(aruba.URI(lr.URI))
+		}
+	}
+
 	if args.Name != "" {
 		server.Named(args.Name)
 	}

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -1179,6 +1181,46 @@ func TestComputeCloudServerUpdate_HappyPath(t *testing.T) {
 	})
 	if !strings.Contains(out, "cs-001") {
 		t.Errorf("expected ID in output, got: %s", out)
+	}
+}
+
+func TestComputeCloudServerUpdate_SecurityGroupsReinjected(t *testing.T) {
+	// Verifies that security group URIs from linkedResources[] on the GET
+	// response are forwarded in the PUT body.  Without the fix the PUT body
+	// omits securityGroups and the API returns 400.
+	srv := newArubaTestServer(t)
+	id, name := "cs-001", "my-server"
+	sgURI := "/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001"
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Properties: types.CloudServerPropertiesResponse{
+			LinkedResources: []types.LinkedResourceCommon{{URI: sgURI}},
+		},
+	}))
+
+	var capturedBody []byte
+	newName := "updated-server"
+	srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedBody, _ = io.ReadAll(r.Body)
+			jsonResponse(200, types.CloudServerResponse{
+				Metadata: types.ResourceMetadataResponse{ID: &id, Name: &newName},
+			})(w, r)
+		})
+
+	captureStdout(func() {
+		err := ComputeCloudServerUpdate(context.Background(), srv.Client(), ComputeCloudServerUpdateArgs{
+			ProjectID: "proj-123",
+			ID:        "cs-001",
+			Name:      "updated-server",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(string(capturedBody), sgURI) {
+		t.Errorf("PUT body missing security group URI %q; body: %s", sgURI, capturedBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

- \cloud compute cloudserver update\ always returned HTTP 400 because the PUT body omitted the \securityGroups\ array
- The SDK\s \romResponse\ hydrates \subnetRefs\ from \NetworkInterfaces[].Subnet\ correctly, but **cannot** extract \securityGroupRefs\: the API surfaces them only in \linkedResources[]\ without a distinguishable type field (SDK comment explicitly notes this)
- Without re-injection the API interprets the missing array as a request to strip all SGs → validation failure

**Fix:** in \ComputeCloudServerUpdate\, scan the GET response\s \LinkedResources\ for URIs containing \/securityGroups/\ and call \WithSecurityGroups()\ before \Update\.

Added \TestComputeCloudServerUpdate_SecurityGroupsReinjected\ to assert that the security group URI from \linkedResources\ appears in the captured PUT body.

## Test plan
- [ ] \go test ./cmd/ -run TestComputeCloudServerUpdate\ — all pass
- [ ] \cloud compute cloudserver update <id> --name new-name\ no longer returns 400

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)