### PR TITLE
fix(network): resolve vpnroute Cloud Subnet always blank (TD-030)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -34,6 +34,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-036 | sdk-go bumped from v0.3.0 → v1.0.0 (GA, released 2026-05-29) on branch `upgrade-sdk-v1`. Breaking changes in `pkg/types`: strict role-suffix naming (`*PropertiesResult`→`*PropertiesResponse`, bare `*List`→`*ListResponse`, `*Common`-suffixed nested types). Production code impact: 7 compile-error fixes in `container.containerregistry.go`, `container.kaas.go`, `management.project.go`, `network.elasticip.go`, `network.subnet.go`, `network.vpcpeeringroute.go`, `network.vpntunnel.go`. Test files: ~46 type-rename substitutions across 28 `_test.go` files. Completion functions migrated to wrapper accessors (`.ID()`, `.Name()`) in 14 cmd files, eliminating ~50 `.Raw().Metadata.ID/Name` reads. |
 | TD-034 | VPN tunnel update handler manual IKE/ESP/PSK reattach block removed from `cmd/network.vpntunnel.go`. sdk-go v1.0.0 `fromResponse` now fully rehydrates IKE/ESP/PSK into the `*VPNIKE`/`*VPNESP`/`*VPNPSK` wrapper fields exposed via `IKE()`/`ESP()`/`PSK()` accessors; `toRequest()` builds the PUT body from those fields. Closed #132. Residual: `redactVPNTunnelSecrets` still mutates `t.response.Properties.VPNClientSettingsCommon.PSK.Secret` directly because `RawJSON()` serializes `t.response`; upstream `RedactPSK()` mutator still needed (tracked in #132 comment). |
 | TD-035 | Subnet update DHCP preservation block migrated to wrapper accessors in `cmd/network.subnet.go`. `subnet.Type()` replaces `subnet.Raw().Properties.Type`; `subnet.DHCP()` replaces `.Raw().Properties.DHCP` with full `IsEnabled()`/`Routes()`/`DNS()` read access on `*SubnetDHCPCommon`. Zero `.Raw()` calls remain for this code path. Closed #133. |
+| TD-030 | sdk-go v1.0.4 added `cidr` JSON field handling to `SubnetCIDROrRef.UnmarshalJSON`, fixing the field-path mismatch that caused `vpnroute get/list` to always show a blank Cloud Subnet. CLI migrated all four output blocks from `raw.Properties.CloudSubnet.CIDR` to `route.CloudSubnet()` and from `raw.Properties.OnPremSubnet` to `route.OnPremSubnet()`. Closed #135 / #130. |
 | TD-038 | All 137 Cobra `RunE` handlers decomposed into `<Family><Resource><Action>Args` struct + `ParseFromCobraCommand` + `Validate()` + pure `<Action>` operation function + thin `<Action>Run` wiring. `Validate()` methods cover typed-enum value-sets via `slices.Contains`. `ErrParsingFailed` / `ErrValidationFailed` sentinels added to `cmd/args.go`; cross-resource valid-value slices in `cmd/enums.go`. Closes the testability gap left by PR #138. |
 
 ---
@@ -76,27 +77,6 @@ The v0.2.0 SDK exposes `KeysClient` and `KmipsClient` sub-clients under `client.
 **Diagnosis:** Run `acloud --debug compute cloudserver update <id> --tags foo` and inspect `[DEBUG] response body:` to confirm which field(s) the API rejects.
 
 **Fix:** Map `networkInterfaces[].subnet` → `subnetRefs` and identify security-group URIs in `linkedResources[]` in the CLI update handler (or upstream in SDK `fromResponse`). Re-inject before calling `Update`. See #125.
-
----
-
-### TD-030 · VPN route Cloud Subnet always blank on `get` / `list`
-
-`acloud network vpnroute get` prints an empty `Cloud Subnet:` row even when the route
-was created with `--cloud-subnet 10.0.0.0/24`. The CLI reads
-`raw.Properties.CloudSubnet.CIDR`, but the GET response places the value under a
-different field path (likely `raw.Properties.CloudSubnet.Value` or a flat string).
-Confirmed blank in the network e2e run on 2026-06-03.
-
-**Root cause:** Structural mismatch between `types.VPNRoutePropertiesResponse` and the
-actual API response body — an sdk-go issue.
-
-**Fix (blocked on sdk-go):** Once the SDK aligns the type definition with the API
-contract, update the field read in `cmd/network.vpnroute.go` (both `get` and `list`
-output blocks).
-
-**Filed as:** https://github.com/Arubacloud/acloud-cli/issues/135
-
-**Upstream tracking:** https://github.com/Arubacloud/sdk-go/issues/327
 
 ---
 

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -485,13 +485,11 @@ func NetworkVPNRouteCreate(ctx context.Context, client aruba.Client, args Networ
 		if raw.Metadata.ID != nil {
 			id = *raw.Metadata.ID
 		}
-		cloudSubnetVal := raw.Properties.CloudSubnet.CIDR
-		onPremSubnetVal := raw.Properties.OnPremSubnet
 		status := ""
 		if raw.Status.State != nil {
 			status = string(*raw.Status.State)
 		}
-		row := []string{args.Name, id, cloudSubnetVal, onPremSubnetVal, status}
+		row := []string{args.Name, id, resp.CloudSubnet(), resp.OnPremSubnet(), status}
 		PrintOutput(resp, headers, [][]string{row})
 	} else {
 		fmt.Println(msgCreatedAsync("VPN route", args.Name))
@@ -522,8 +520,8 @@ func NetworkVPNRouteGet(ctx context.Context, client aruba.Client, args NetworkVP
 		if raw.Metadata.LocationResponse != nil {
 			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
 		}
-		fmt.Printf("Cloud Subnet:    %s\n", raw.Properties.CloudSubnet.CIDR)
-		fmt.Printf("OnPrem Subnet:   %s\n", raw.Properties.OnPremSubnet)
+		fmt.Printf("Cloud Subnet:    %s\n", route.CloudSubnet())
+		fmt.Printf("OnPrem Subnet:   %s\n", route.OnPremSubnet())
 		if raw.Metadata.CreationDate != nil {
 			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
 		}
@@ -584,13 +582,11 @@ func NetworkVPNRouteUpdate(ctx context.Context, client aruba.Client, args Networ
 		if raw.Metadata.ID != nil {
 			id = *raw.Metadata.ID
 		}
-		cloudSubnetVal := raw.Properties.CloudSubnet.CIDR
-		onPremSubnetVal := raw.Properties.OnPremSubnet
 		status := ""
 		if raw.Status.State != nil {
 			status = string(*raw.Status.State)
 		}
-		row := []string{nameVal, id, cloudSubnetVal, onPremSubnetVal, status}
+		row := []string{nameVal, id, updated.CloudSubnet(), updated.OnPremSubnet(), status}
 		PrintOutput(updated, headers, [][]string{row})
 	} else {
 		fmt.Println(msgUpdatedAsync("VPN route", args.RouteID))
@@ -647,13 +643,11 @@ func NetworkVPNRouteList(ctx context.Context, client aruba.Client, args NetworkV
 			if raw.Metadata.ID != nil {
 				id = *raw.Metadata.ID
 			}
-			cloudSubnet := raw.Properties.CloudSubnet.CIDR
-			onPremSubnet := raw.Properties.OnPremSubnet
 			status := ""
 			if raw.Status.State != nil {
 				status = string(*raw.Status.State)
 			}
-			rows = append(rows, []string{name, id, cloudSubnet, onPremSubnet, status})
+			rows = append(rows, []string{name, id, route.CloudSubnet(), route.OnPremSubnet(), status})
 		}
 		PrintOutput(list, headers, rows)
 	} else {

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -672,6 +672,92 @@ func TestNetworkVPNRouteCreate_HappyPath(t *testing.T) {
 	}
 }
 
+func TestNetworkVPNRouteCreate_CloudSubnetInOutput(t *testing.T) {
+	// Verifies that CloudSubnet() from the response is printed correctly — the
+	// previous bug (TD-030) caused it to always be blank because the SDK did not
+	// parse the {"cidr":"..."} JSON shape returned by the API.
+	srv := newArubaTestServer(t)
+	id, name := "route-new", "my-route"
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+		jsonResponse(200, types.VPNRouteResponse{
+			Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+			Properties: types.VPNRoutePropertiesResponse{
+				CloudSubnet:  types.SubnetCIDROrRef{CIDR: "10.0.0.0/24"},
+				OnPremSubnet: "192.168.1.0/24",
+			},
+		}))
+
+	out := captureStdout(func() {
+		err := NetworkVPNRouteCreate(context.Background(), srv.Client(), validNetworkVPNRouteCreateArgs())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "10.0.0.0/24") {
+		t.Errorf("CloudSubnet CIDR missing from create output; got: %s", out)
+	}
+	if !strings.Contains(out, "192.168.1.0/24") {
+		t.Errorf("OnPremSubnet CIDR missing from create output; got: %s", out)
+	}
+}
+
+func TestNetworkVPNRouteGet_CloudSubnetInOutput(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "route-001", "my-route"
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes/route-001",
+		jsonResponse(200, types.VPNRouteResponse{
+			Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+			Properties: types.VPNRoutePropertiesResponse{
+				CloudSubnet:  types.SubnetCIDROrRef{CIDR: "10.0.0.0/24"},
+				OnPremSubnet: "192.168.1.0/24",
+			},
+		}))
+
+	out := captureStdout(func() {
+		err := NetworkVPNRouteGet(context.Background(), srv.Client(), NetworkVPNRouteGetArgs{
+			ProjectID: "proj-123",
+			TunnelID:  "vpn-001",
+			RouteID:   "route-001",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "10.0.0.0/24") {
+		t.Errorf("CloudSubnet CIDR missing from get output; got: %s", out)
+	}
+}
+
+func TestNetworkVPNRouteList_CloudSubnetInOutput(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "route-001", "my-route"
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+		jsonResponse(200, types.VPNRouteListResponse{
+			Values: []types.VPNRouteResponse{
+				{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+					Properties: types.VPNRoutePropertiesResponse{
+						CloudSubnet:  types.SubnetCIDROrRef{CIDR: "10.0.0.0/24"},
+						OnPremSubnet: "192.168.1.0/24",
+					},
+				},
+			},
+		}))
+
+	out := captureStdout(func() {
+		err := NetworkVPNRouteList(context.Background(), srv.Client(), NetworkVPNRouteListArgs{
+			ProjectID: "proj-123",
+			TunnelID:  "vpn-001",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "10.0.0.0/24") {
+		t.Errorf("CloudSubnet CIDR missing from list output; got: %s", out)
+	}
+}
+
 func TestNetworkVPNRouteCreate_APIError(t *testing.T) {
 	srv := newArubaTestServer(t)
 	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module acloud
 go 1.25.0
 
 require (
-	github.com/Arubacloud/sdk-go v1.0.3
+	github.com/Arubacloud/sdk-go v1.0.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Arubacloud/sdk-go v1.0.2 h1:mJeCkS4aJ/gVw3sJD7p4yPwNWZD6YRrbW7hMDdCMz
 github.com/Arubacloud/sdk-go v1.0.2/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/Arubacloud/sdk-go v1.0.3 h1:katc1KIGwTCNmVZ019ZadTSljYwbmqQWe3OSez2yy1g=
 github.com/Arubacloud/sdk-go v1.0.3/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
+github.com/Arubacloud/sdk-go v1.0.4 h1:RUmmvojnIyHFAY0gE/jujfbbs7qY+ecpgv9fxEcp87w=
+github.com/Arubacloud/sdk-go v1.0.4/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
## Summary

- `acloud network vpnroute get` and `vpnroute list` always showed a blank **Cloud Subnet** field even when the route was created with `--cloud-subnet 10.0.0.0/24`
- **Root cause (sdk-go):** `SubnetCIDROrRef.UnmarshalJSON` did not handle the `{"cidr":"..."}` JSON shape the API returns on Get/List — only the plain-string Create shape was handled
- **sdk-go v1.0.4** adds the `cidr` field to the unmarshaler, fixing the root cause (sdk-go#327)

**CLI changes:**
- Bump sdk-go `v1.0.3 → v1.0.4`
- Migrate all four output blocks (Create/Get/Update/List) from `raw.Properties.CloudSubnet.CIDR` to `route.CloudSubnet()` and `raw.Properties.OnPremSubnet` to `route.OnPremSubnet()`
- Add `TestNetworkVPNRouteCreate/Get/List_CloudSubnetInOutput` tests that assert the CIDR value appears in output

## Test plan
- [ ] `go test ./cmd/ -run TestNetworkVPNRoute` — all pass including 3 new tests
- [ ] `acloud network vpnroute get <tunnel> <route>` now shows Cloud Subnet correctly

Closes #135 #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
