### PR TITLE
fix(network): clarify vpntunnel --subnet-cidr as routing reference (TD-025)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -34,6 +34,8 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-036 | sdk-go bumped from v0.3.0 → v1.0.0 (GA, released 2026-05-29) on branch `upgrade-sdk-v1`. Breaking changes in `pkg/types`: strict role-suffix naming (`*PropertiesResult`→`*PropertiesResponse`, bare `*List`→`*ListResponse`, `*Common`-suffixed nested types). Production code impact: 7 compile-error fixes in `container.containerregistry.go`, `container.kaas.go`, `management.project.go`, `network.elasticip.go`, `network.subnet.go`, `network.vpcpeeringroute.go`, `network.vpntunnel.go`. Test files: ~46 type-rename substitutions across 28 `_test.go` files. Completion functions migrated to wrapper accessors (`.ID()`, `.Name()`) in 14 cmd files, eliminating ~50 `.Raw().Metadata.ID/Name` reads. |
 | TD-034 | VPN tunnel update handler manual IKE/ESP/PSK reattach block removed from `cmd/network.vpntunnel.go`. sdk-go v1.0.0 `fromResponse` now fully rehydrates IKE/ESP/PSK into the `*VPNIKE`/`*VPNESP`/`*VPNPSK` wrapper fields exposed via `IKE()`/`ESP()`/`PSK()` accessors; `toRequest()` builds the PUT body from those fields. Closed #132. Residual: `redactVPNTunnelSecrets` still mutates `t.response.Properties.VPNClientSettingsCommon.PSK.Secret` directly because `RawJSON()` serializes `t.response`; upstream `RedactPSK()` mutator still needed (tracked in #132 comment). |
 | TD-035 | Subnet update DHCP preservation block migrated to wrapper accessors in `cmd/network.subnet.go`. `subnet.Type()` replaces `subnet.Raw().Properties.Type`; `subnet.DHCP()` replaces `.Raw().Properties.DHCP` with full `IsEnabled()`/`Routes()`/`DNS()` read access on `*SubnetDHCPCommon`. Zero `.Raw()` calls remain for this code path. Closed #133. |
+| TD-030 | sdk-go v1.0.4 added `cidr` JSON field handling to `SubnetCIDROrRef.UnmarshalJSON`, fixing the field-path mismatch that caused `vpnroute get/list` to always show a blank Cloud Subnet. CLI migrated all four output blocks from `raw.Properties.CloudSubnet.CIDR` to `route.CloudSubnet()` and from `raw.Properties.OnPremSubnet` to `route.OnPremSubnet()`. Closed #135 / #130. |
+| TD-025 | sdk-go v1.0.4 clarified `SubnetInfoCommon` as a routing reference (subnet must already exist; `cidr` must be unique per tunnel). Updated `--subnet-cidr`/`--subnet-name` flag descriptions and `vpntunnel create` Long doc to match. Closed #73. |
 | TD-038 | All 137 Cobra `RunE` handlers decomposed into `<Family><Resource><Action>Args` struct + `ParseFromCobraCommand` + `Validate()` + pure `<Action>` operation function + thin `<Action>Run` wiring. `Validate()` methods cover typed-enum value-sets via `slices.Contains`. `ErrParsingFailed` / `ErrValidationFailed` sentinels added to `cmd/args.go`; cross-resource valid-value slices in `cmd/enums.go`. Closes the testability gap left by PR #138. |
 
 ---
@@ -44,15 +46,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 `PrintTable(headers, rows)` is now a one-line shim around `PrintOutput(nil, headers, rows)`. All call sites that pass `nil` as the first arg produce `{}` for `-o json` / `-o yaml` instead of the actual resource data. Remaining direct `PrintTable` calls should be replaced with `PrintOutput(response.Data, headers, rows)` and the shim deleted.
 
 **Fix:** Grep for `PrintTable(` and migrate each site to `PrintOutput`, passing the typed SDK response as the first argument. Remove the `PrintTable` function once all sites are updated.
-
----
-
-### TD-025 · VPN tunnel subnet semantics: CLI says "existing", API says "overlap"
-`cmd/network.vpntunnel.go:28-29` documents `--subnet-cidr` as *"CIDR of existing subnet"* and `--subnet-name` as an alternative lookup — i.e. a reference to a pre-existing subnet. But when a subnet with the referenced CIDR already exists in the VPC, the API responds `ipConfigurations.subnet.cidr overlaps with an existing subnet`, suggesting it interprets the field as a *provisioning* instruction rather than a lookup. The two readings are contradictory and the e2e test cannot safely pre-create the subnet.
-
-**Fix:** Confirm with the API team whether `ipConfigurations.subnet` is a reference or a creation spec. If it is a lookup, surface a clearer error when the subnet is missing. If it is a creation field, update the CLI `Long`, flag descriptions, and `docs/website/docs/resources/network/vpntunnel.md` accordingly, and remove the pre-create step from the e2e test.
-
-**Upstream tracking:** https://github.com/Arubacloud/sdk-go/issues/328
 
 ---
 

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -124,8 +124,8 @@ func init() {
 	vpntunnelCreateCmd.Flags().String("region", "", "Region code (e.g., ITBG-Bergamo)")
 	vpntunnelCreateCmd.Flags().String("peer-ip", "", "Peer client public IP address")
 	vpntunnelCreateCmd.Flags().String("vpc-id", "", "VPC ID")
-	vpntunnelCreateCmd.Flags().String("subnet-cidr", "", "Subnet CIDR (e.g., 10.0.1.0/24)")
-	vpntunnelCreateCmd.Flags().String("subnet-name", "", "Subnet name (alternative to CIDR)")
+	vpntunnelCreateCmd.Flags().String("subnet-cidr", "", "CIDR of the routing subnet (must already exist in the VPC and be unique per tunnel)")
+	vpntunnelCreateCmd.Flags().String("subnet-name", "", "Name of the routing subnet (alternative lookup to --subnet-cidr)")
 	vpntunnelCreateCmd.Flags().String("elastic-ip-id", "", "Elastic IP ID")
 	vpntunnelCreateCmd.Flags().String("vpn-type", "Site-To-Site", "VPN type (default: Site-To-Site)")
 	vpntunnelCreateCmd.Flags().String("protocol", "ikev2", "VPN protocol (default: ikev2)")
@@ -243,8 +243,11 @@ var vpntunnelCreateCmd = &cobra.Command{
 	Short: "Create a new VPN tunnel",
 	Long: `Create a site-to-site VPN tunnel to an on-premises network.
 
-The VPC and Elastic IP must already exist. Specify the subnet the tunnel will
-use via --subnet-cidr (CIDR of existing subnet) or --subnet-name.
+The VPC and Elastic IP must already exist. Specify the routing subnet via
+--subnet-cidr or --subnet-name. The subnet must already exist in the VPC and
+its CIDR must be unique across all VPN tunnels in the project — it is a routing
+reference, not a provisioning instruction. The 400 "overlaps" error means the
+same CIDR is already associated with another tunnel configuration.
 
 VPN type defaults to Site-To-Site. Protocol defaults to ikev2.
 Billing period: Hour (default), Month, or Year.


### PR DESCRIPTION
## Summary

- `--subnet-cidr` was documented as "CIDR of existing subnet" but the API error "overlaps with an existing subnet" suggested it was a provisioning spec — contradictory
- **sdk-go v1.0.4** confirmed in `SubnetInfoCommon` docs: it is a **routing reference**, the subnet must pre-exist, and the CIDR must be unique per tunnel. The "overlaps" error means the same CIDR is already associated with another tunnel (sdk-go#328)

**CLI changes:**
- `--subnet-cidr` flag description updated to "routing subnet (must already exist in the VPC and be unique per tunnel)"
- `--subnet-name` flag description updated to "Name of the routing subnet (alternative lookup)"
- `vpntunnel create` Long doc updated to explain reference vs provisioning semantics and what the "overlaps" error means

## Test plan
- [ ] `acloud network vpntunnel create --help` shows updated flag descriptions
- [ ] Documentation reflects the correct subnet semantics

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
