### PR TITLE
fix(database): add --zone flag to backup create command

### DIFF
--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -21,6 +21,7 @@ func init() {
 	backupCreateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	backupCreateCmd.Flags().String("name", "", "Backup name (required)")
 	backupCreateCmd.Flags().String("region", "", "Region code (required)")
+	backupCreateCmd.Flags().String("zone", "", "Availability zone (e.g. ITBG-1); defaults to region when omitted")
 	backupCreateCmd.Flags().String("dbaas-id", "", "DBaaS instance ID (required)")
 	backupCreateCmd.Flags().String("database-name", "", "Database name (required)")
 	backupCreateCmd.Flags().String("billing-period", string(aruba.BillingPeriodHour), "Billing period: Hour, Month, Year")
@@ -95,7 +96,7 @@ The backup will be stored and can be restored later.
 
 Billing period: Hour (default), Month, or Year.`,
 	Example: `  acloud database backup create \
-    --name my-backup --region ITBG-Bergamo \
+    --name my-backup --region ITBG-Bergamo --zone ITBG-1 \
     --dbaas-id <dbaas-id> \
     --database-name myapp_db`,
 	Args: cobra.NoArgs,
@@ -132,6 +133,7 @@ type DatabaseDBaaSBackupCreateArgs struct {
 	ProjectID     string
 	Name          string
 	Region        aruba.Region
+	Zone          string
 	DBaaSID       string
 	DatabaseName  string
 	BillingPeriod aruba.BillingPeriod
@@ -228,6 +230,9 @@ func (a *DatabaseDBaaSBackupCreateArgs) ParseFromCobraCommand(cmd *cobra.Command
 	if s, err := cmd.Flags().GetString("region"); err == nil {
 		a.Region = aruba.Region(s)
 	} else {
+		errs = append(errs, err)
+	}
+	if a.Zone, err = cmd.Flags().GetString("zone"); err != nil {
 		errs = append(errs, err)
 	}
 	if a.DBaaSID, err = cmd.Flags().GetString("dbaas-id"); err != nil {
@@ -365,6 +370,10 @@ func DatabaseDBaaSBackupCreate(ctx context.Context, client aruba.Client, args Da
 		FromDatabase(databaseRef(args.ProjectID, args.DBaaSID, args.DatabaseName)).
 		BilledBy(args.BillingPeriod).
 		RetaggedAs(args.Tags...)
+
+	if args.Zone != "" {
+		bkp.InZone(aruba.Zone(args.Zone))
+	}
 
 	created, err := client.FromDatabase().Backups().Create(ctx, bkp)
 	if err != nil {

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
+	"github.com/spf13/cobra"
 )
 
 func TestDBBackupListCmd(t *testing.T) {
@@ -750,6 +751,27 @@ func TestDatabaseDBaaSBackupDelete_APIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "deleting backup") {
 		t.Errorf("error %q does not contain 'deleting backup'", err.Error())
+	}
+}
+
+// TestDatabaseDBaaSBackupCreateArgs_ParseZoneFlagError covers the GetString("zone") error
+// branch in ParseFromCobraCommand by using a command where "zone" is not registered.
+func TestDatabaseDBaaSBackupCreateArgs_ParseZoneFlagError(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("project-id", "proj-123", "")
+	cmd.Flags().String("name", "my-backup", "")
+	cmd.Flags().String("region", "ITBG-Bergamo", "")
+	// "zone" intentionally omitted so GetString("zone") returns an error
+	cmd.Flags().String("dbaas-id", "dbaas-001", "")
+	cmd.Flags().String("database-name", "mydb", "")
+	cmd.Flags().String("billing-period", "Hour", "")
+	cmd.Flags().StringSlice("tags", []string{}, "")
+	_ = cmd.Flags().Set("project-id", "proj-123")
+
+	args := &DatabaseDBaaSBackupCreateArgs{}
+	err := args.ParseFromCobraCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when zone flag is not registered")
 	}
 }
 

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -208,6 +208,29 @@ func TestDBBackupCreateCmd(t *testing.T) {
 			errContains: "dbaas-id",
 		},
 		{
+			name: "success with --zone",
+			args: []string{
+				"database", "backup", "create",
+				"--project-id", "proj-123",
+				"--name", "my-backup",
+				"--region", "ITBG-Bergamo",
+				"--zone", "ITBG-1",
+				"--dbaas-id", "dbaas-001",
+				"--database-name", "mydb",
+			},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-zone", "my-backup"
+				srv.OnPost("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupResponse{
+					Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if !strings.Contains(out, "my-backup") {
+					t.Errorf("expected name in output, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: createArgs,
 			setupSrv: func(srv *arubaTestServer) {
@@ -774,6 +797,27 @@ func TestDatabaseDBaaSBackupCreate_WithTagsAndRegion(t *testing.T) {
 		}
 	})
 	if !strings.Contains(out, "bkp-tags") {
+		t.Errorf("expected ID in output, got: %s", out)
+	}
+}
+
+// TestDatabaseDBaaSBackupCreate_WithZone verifies that an explicit --zone value is forwarded to the builder.
+func TestDatabaseDBaaSBackupCreate_WithZone(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "bkp-zone", "my-backup"
+	srv.OnPost("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.BackupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+	}))
+
+	out := captureStdout(func() {
+		args := validDatabaseDBaaSBackupCreateArgs()
+		args.Zone = "ITBG-1"
+		err := DatabaseDBaaSBackupCreate(context.Background(), srv.Client(), args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "bkp-zone") {
 		t.Errorf("expected ID in output, got: %s", out)
 	}
 }


### PR DESCRIPTION
Fixes #152

## Summary

- `database backup create` had no `--zone` flag, causing the e2e test to fail with `Error: unknown flag: --zone`
- Added optional `--zone` flag (e.g. `ITBG-1`) mirroring the pattern used in `database dbaas create`
- When `--zone` is omitted the SDK derives it from `--region` (no regression)
- Wired `InZone()` on the `DBaaSBackup` builder when a zone value is provided

## Test plan

- All existing unit tests pass (30/30)
- Build is clean
- e2e: `database backup create --zone ITBG-1 ...` no longer returns `unknown flag: --zone`
- e2e: `database backup create` without `--zone` still works (zone derived from region)

Generated with [Claude Code](https://claude.com/claude-code)