### PR TITLE
fix(container): extend registry wait to 900s and track skipped steps

### DIFF
--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -38,12 +38,19 @@ if [ -z "${ACLOUD_CMD:-}" ]; then
     unset _ACLOUD_COMMON_DIR
 fi
 
-# --- Failure tracking ----------------------------------------------------
+# --- Failure / skip tracking ---------------------------------------------
 # Scripts can call fail() on each red ✗ to feed a non-zero exit code.
+# Scripts can call skip() on each yellow ⚠ to surface skipped steps in the
+# final summary without treating them as failures.
 FAILURES=0
+SKIPS=0
 fail() {
     FAILURES=$((FAILURES + 1))
     echo -e "${RED}✗ $*${NC}"
+}
+skip() {
+    SKIPS=$((SKIPS + 1))
+    echo -e "${YELLOW}⚠ $*${NC}"
 }
 
 # --- Validators ----------------------------------------------------------

--- a/e2e/container/test.sh
+++ b/e2e/container/test.sh
@@ -372,7 +372,7 @@ test_containerregistry() {
 
     echo "Waiting for registry $REGISTRY_ID to be Active..."
     local registry_ready=0
-    wait_for_status "$ACLOUD_CMD container containerregistry get $REGISTRY_ID" '^(Active|Ready)$' 600 && registry_ready=1
+    wait_for_status "$ACLOUD_CMD container containerregistry get $REGISTRY_ID" '^(Active|Ready)$' 900 && registry_ready=1
     echo ""
 
     echo -e "${GREEN}[GET]${NC} Getting registry details..."
@@ -387,7 +387,7 @@ test_containerregistry() {
             --concurrent-users 20 2>&1 || true
         echo ""
     else
-        echo -e "${YELLOW}[UPDATE]${NC} Skipping — registry did not reach Active after 600s."
+        skip "[UPDATE] container registry: did not reach Active after 900s — update step skipped"
         echo ""
     fi
 
@@ -433,6 +433,9 @@ else
 fi
 echo ""
 
+if [ "$SKIPS" -gt 0 ]; then
+    echo -e "${YELLOW}⚠ Skipped steps: $SKIPS${NC}"
+fi
 if [ "$FAILURES" -eq 0 ]; then
     echo -e "${GREEN}=== Container E2E: all checks passed ===${NC}"
     exit 0


### PR DESCRIPTION
## Summary

- Raise `wait_for_status` timeout for Container Registry from 600s to 900s (matches the KaaS cluster wait; provisioning is legitimately slow)
- Add `SKIPS` counter and `skip()` helper to `e2e/common.sh` — mirrors the existing `FAILURES`/`fail()` pattern
- Use `skip()` in `test_containerregistry` so a timed-out UPDATE step is counted and printed in the final test summary instead of being silently dropped

Fixes #155.

## Test plan

- [ ] Run `make container-e2e-test` and confirm the suite completes without timeout (900s window)
- [ ] If provisioning still exceeds 900s: confirm the summary prints `⚠ Skipped steps: 1` and the suite still exits 0 (skip ≠ failure)
- [ ] Confirm no regression in other suites (`common.sh` change is additive — `SKIPS` starts at 0 and `skip()` is unused elsewhere)