### PR TITLE
fix(e2e): replace pattern-substitution array removal with exact-match…

### DIFF
--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -206,6 +206,19 @@ gen_ephemeral_pubkey() {
     cat "${path}.pub"
 }
 
+# --- Array helpers -------------------------------------------------------
+# Remove every exact-match element from a named array.
+# Usage: array_remove ARRAY_NAME value
+array_remove() {
+    local -n _arr_ref=$1
+    local _val=$2
+    local _new=()
+    for _e in "${_arr_ref[@]+"${_arr_ref[@]}"}"; do
+        [[ "$_e" != "$_val" ]] && _new+=("$_e")
+    done
+    _arr_ref=("${_new[@]+"${_new[@]}"}")
+}
+
 # --- Project-ID extraction from any resource URI -------------------------
 # URIs look like: /projects/<24hex>/providers/...
 resolve_project_id_from_uri() {

--- a/e2e/management/test.sh
+++ b/e2e/management/test.sh
@@ -214,7 +214,7 @@ test_project() {
     DELETE_EXIT=$?
     echo "$DELETE_OUTPUT"
     if [ $DELETE_EXIT -eq 0 ]; then
-        CREATED_PROJECTS=("${CREATED_PROJECTS[@]/$crud_project_id}")
+        array_remove CREATED_PROJECTS "$crud_project_id"
         echo -e "${GREEN}✓ Project CRUD test completed successfully!${NC}\n"
     else
         fail "DELETE project $crud_project_id failed (exit $DELETE_EXIT)"

--- a/e2e/network/test.sh
+++ b/e2e/network/test.sh
@@ -827,7 +827,7 @@ test_vpc_peering_route() {
     echo -e "${GREEN}[DELETE]${NC} Deleting VPC Peering Route..."
     $ACLOUD_CMD network vpcpeeringroute delete "$VPC_ID" "$PEERING_ID" "$route_id" --yes 2>&1 || true
     # Remove from cleanup list since we already deleted it inline
-    CREATED_PEERING_ROUTES=("${CREATED_PEERING_ROUTES[@]/$route_id}")
+    array_remove CREATED_PEERING_ROUTES "$route_id"
     echo ""
 
     echo -e "${GREEN}✓ VPC Peering Route test completed successfully!${NC}\n"
@@ -1106,7 +1106,7 @@ test_vpn_route() {
 
     echo -e "${GREEN}[DELETE]${NC} Deleting VPN Route..."
     if $ACLOUD_CMD network vpnroute delete "$VPN_TUNNEL_ID" "$vpn_route_id" --yes 2>&1; then
-        CREATED_VPN_ROUTES=("${CREATED_VPN_ROUTES[@]/$vpn_route_id}")
+        array_remove CREATED_VPN_ROUTES "$vpn_route_id"
     fi
     echo ""
 
@@ -1116,7 +1116,7 @@ test_vpn_route() {
     local subnet_del_elapsed=0
     while [ "$subnet_del_elapsed" -lt 120 ]; do
         if $ACLOUD_CMD network subnet delete "$VPC_ID" "$route_subnet_id" --yes 2>&1; then
-            CREATED_SUBNETS=("${CREATED_SUBNETS[@]/$route_subnet_id}")
+            array_remove CREATED_SUBNETS "$route_subnet_id"
             echo "  → Cloud subnet $route_subnet_id deleted"
             break
         fi

--- a/e2e/storage/test.sh
+++ b/e2e/storage/test.sh
@@ -443,7 +443,7 @@ test_restore() {
     DELETE_OUTPUT=$($ACLOUD_CMD storage restore delete "$backup_id" "$restore_id" --yes 2>&1)
     if [ $? -eq 0 ]; then
         echo "$DELETE_OUTPUT"
-        CREATED_RESTORES=("${CREATED_RESTORES[@]/$restore_id}")
+        array_remove CREATED_RESTORES "$restore_id"
     else
         echo -e "${YELLOW}DELETE failed — cleanup trap will retry:${NC}"
         echo "$DELETE_OUTPUT" | head -3


### PR DESCRIPTION
---
Summary

- Fixes the "restore ID is required" error emitted during storage e2e cleanup (issue #154)
- Root cause: ${arr[@]/$id} is a bash substring substitution — it blanks out matching elements but keeps them in the array as empty strings, which then get passed to the CLI as empty arguments
- Added array_remove() to e2e/common.sh that filters by exact equality using a loop
- Replaced all 5 occurrences of the broken pattern across e2e/storage/test.sh, e2e/management/test.sh, and e2e/network/test.sh

Test plan

- [x] Run make storage-e2e-test — cleanup should complete without "restore ID is required" error
- [x] Run make network-e2e-test — peering route, VPN route, and subnet cleanup should be clean
- [x] Run make management-e2e-test — project CRUD cleanup should be clean

Closes #154