### PR TITLE
docs: update documentation for v0.2.0 release (issue #160)

### DIFF
--- a/docs/website/docs/examples/basic-usage.md
+++ b/docs/website/docs/examples/basic-usage.md
@@ -183,7 +183,7 @@ acloud version
 Example output:
 
 ```text
-Aruba Cloud CLI version 1.2.0
+Aruba Cloud CLI version 0.2.0
 ```
 
 ---

--- a/docs/website/docs/examples/cloudserver.md
+++ b/docs/website/docs/examples/cloudserver.md
@@ -71,25 +71,20 @@ Choose a subnet with `STATUS` as `Active` and note its `ID` and `CIDR`. If no su
 
 ---
 
-## Step 3: Extract the Subnet URI
+## Step 3: Confirm the Subnet ID
 
-Once you have chosen a subnet, extract its URI for use in the provisioning command. Run:
+Note the `ID` of the chosen subnet from the list output. You will pass this directly to the cloud server create command using `--subnet-id`.
 
 ```bash
-acloud network subnet get <vpc-id> <subnet-id> | grep URI
+acloud network subnet get <vpc-id> <subnet-id>
 ```
 
 Example:
 ```bash
-acloud network subnet get 69495ef64d0cdc87949b71ec 694ba1737712ac0032dbe50a | grep URI
+acloud network subnet get 69495ef64d0cdc87949b71ec 694ba1737712ac0032dbe50a
 ```
 
-Example output:
-```
-URI:             /projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a
-```
-
-> **Note:** Save this URI for the cloud server provisioning step.
+> **Note:** Note the subnet `ID`. Only proceed if the subnet `STATUS` is `Active`.
 
 ---
 
@@ -115,25 +110,20 @@ Choose a security group with `STATUS` as `Active` and note its `ID`. If no suita
 
 ---
 
-## Step 5: Extract the Elastic IP URI (if using public access)
+## Step 5: Note the Elastic IP ID (if using public access)
 
-If you chose an Elastic IP, extract its URI for use in the provisioning command. Run:
+If you want public access for your server, note the Elastic IP `ID` from `acloud network elasticip list`. You can verify it with:
 
 ```bash
-acloud network elasticip get <elasticip-id> | grep URI
+acloud network elasticip get <elasticip-id>
 ```
 
 Example:
 ```bash
-acloud network elasticip get 694bb7897712ac0032dbe60c | grep URI
+acloud network elasticip get 694bb7897712ac0032dbe60c
 ```
 
-Example output:
-```
-URI:             /projects/68398923fb2cb026400d4d31/providers/Aruba.Network/elasticIps/694bb7897712ac0032dbe60c
-```
-
-> **Note:** Save this URI for the cloud server provisioning step. Skip this step if you do not need public access.
+> **Note:** Note the Elastic IP `ID`. Skip this step if you do not need public access. You can associate an Elastic IP after server creation as well.
 
 ---
 
@@ -234,43 +224,25 @@ Example output:
 URI:             /projects/68398923fb2cb026400d4d31/providers/Aruba.Compute/keyPairs/69007ebf4e7d691466d8621e
 ```
 
-> **Note:** Save this URI for the `--keypair-uri` flag in the next step.
+> **Note:** Note the keypair `ID` (e.g., `69007ebf4e7d691466d8621e`). Pass it to `--keypair-id` in the create command.
 
 ---
 
-## Step 8: Extract the Boot Disk URI
+## Step 8: Confirm Boot Disk ID and Status
 
-After creating your bootable block storage, extract its URI to use as the --boot-disk-uri when provisioning your cloud server.
-
-Run:
+Note the `ID` of your bootable block storage. The block storage must be in `NotUsed` status before it can be used as a boot disk.
 
 ```bash
-acloud storage blockstorage get <volume-id> | grep URI
-```
-
-Example:
-```bash
-acloud storage blockstorage get 697b3a0dce7dfeef9153256a | grep URI
+acloud storage blockstorage list
 ```
 
 Example output:
 ```
-URI:             /projects/68398923fb2cb026400d4d31/providers/Aruba.Storage/blockStorages/697b3a0dce7dfeef9153256a
+NAME         ID                         SIZE(GB)  REGION         ZONE  TYPE         STATUS
+boot-ubuntu  697b3a0dce7dfeef9153256a   20        ITBG-Bergamo         Performance  NotUsed
 ```
 
-> **Note:** Save this URI for the --boot-disk-uri flag in the next step.
-
-> **Note:** The block storage must be in `NotUsed` status before it can be used as a boot disk for a cloud server. You can check the status with:
->
-> ```bash
-> acloud storage blockstorage list
-> ```
->
-> Example output:
-> ```
-> NAME         ID                         SIZE(GB)  REGION         ZONE  TYPE         STATUS
-> boot-ubuntu  697b3a0dce7dfeef9153256a   20        ITBG-Bergamo         Performance  NotUsed
-> ```
+> **Note:** Note the boot disk `ID`. Only proceed when the status is `NotUsed` or `Active`.
 
 ---
 
@@ -295,7 +267,9 @@ Replace `<hashed-password>` with a valid hashed password (see cloud-init docs fo
 
 ---
 
-## Step 10: Create the Cloud Server - Command
+## Step 10: Create the Cloud Server
+
+Use the IDs collected in the previous steps to create the cloud server:
 
 ```bash
 acloud compute cloudserver create \
@@ -303,29 +277,26 @@ acloud compute cloudserver create \
   --region "ITBG-Bergamo" \
   --zone "ITBG-1" \
   --flavor "CSO4A8" \
-  --boot-disk-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Storage/blockStorages/697b3a0dce7dfeef9153256a" \
-  --vpc-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec" \
-  --subnet-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a" \
-  --security-group-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b75f9" \
-  --keypair-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Compute/keyPairs/69007ebf4e7d691466d8621e" \
+  --boot-disk-id "697b3a0dce7dfeef9153256a" \
+  --vpc-id "69495ef64d0cdc87949b71ec" \
+  --subnet-id "694ba1737712ac0032dbe50a" \
+  --security-group-id "694b05ac4d0cdc87949b75f9" \
+  --keypair-id "69007ebf4e7d691466d8621e" \
   --user-data-file "cloud-init.yaml" \
+  --billing-period Hour \
   --tags "production"
-
 ```
 
 Example output:
 ```
 ID                             NAME         FLAVOR    CPU   RAM(GB)   HD(GB)   REGION
-my-server                      my-server    CSO4A8    4     8         0        ITBG-Bergamo
+697c62605b79733376b3386a       my-server    CSO4A8    4     8         0        ITBG-Bergamo
 ```
 
-- Replace the values above with your actual project, VPC, subnet, security group, keypair, and zone values as needed.
+- Replace the IDs above with your actual VPC, subnet, security group, keypair, and boot disk IDs.
 - The `--user-data-file` flag is optional and can be omitted if not needed.
-- You can specify multiple subnets or security groups by repeating the flag or using comma-separated values.
-
-- All networking flags (`--vpc-uri`, `--subnet-uri`, `--security-group-uri`) and the `--zone` flag are required.
-- The server will be provisioned in the specified region and attached to the provided network resources.
-<!-- For more details, see the documentation for cloud server creation. (Link removed: file not found) -->
+- You can specify multiple subnets or security groups using comma-separated values.
+- All networking flags (`--vpc-id`, `--subnet-id`, `--security-group-id`) and the `--zone` flag are required.
 
 ---
 

--- a/docs/website/docs/examples/kubernetes.md
+++ b/docs/website/docs/examples/kubernetes.md
@@ -71,25 +71,20 @@ Choose a subnet with `STATUS` as `Active` and note its `ID` and `CIDR`. If no su
 
 ---
 
-## Step 3: Extract the Subnet URI
+## Step 3: Confirm the Subnet ID
 
-Once you have chosen a subnet, extract its URI for use in the provisioning command. Run:
+Note the `ID` of the chosen subnet from the list output. You will pass it directly to `acloud container kaas create` using `--subnet-id`.
 
 ```bash
-acloud network subnet get <vpc-id> <subnet-id> | grep URI
+acloud network subnet get <vpc-id> <subnet-id>
 ```
 
 Example:
 ```bash
-acloud network subnet get 69495ef64d0cdc87949b71ec 694ba1737712ac0032dbe50a | grep URI
+acloud network subnet get 69495ef64d0cdc87949b71ec 694ba1737712ac0032dbe50a
 ```
 
-Example output:
-```
-URI:             /projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a
-```
-
-> **Note:** Save this URI for the Kubernetes provisioning step.
+> **Note:** Note the subnet `ID`. Only proceed if the subnet `STATUS` is `Active`.
 
 ---
 
@@ -121,22 +116,17 @@ Here is a real example of creating a Kubernetes cluster with a single node pool:
 acloud container kaas create \
   --name "test-cluster" \
   --region "ITBG-Bergamo" \
-  --vpc-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec" \
-  --subnet-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a" \
-  --node-cidr-address "10.0.0.0/16" \
+  --vpc-id "69495ef64d0cdc87949b71ec" \
+  --subnet-id "694ba1737712ac0032dbe50a" \
+  --node-cidr-address "10.0.0.0/24" \
   --node-cidr-name "node-cidr" \
   --security-group-name "kaas-sg" \
   --kubernetes-version "1.33.2" \
   --node-pool-name "default-pool" \
-  --node-pool-autoscaling \
-  --node-pool-max-count 5 \
-  --node-pool-min-count 1 \
-  --node-pool-nodes 3 \
-  --node-pool-instance "K4A8" \
+  --node-pool-nodes 1 \
+  --node-pool-instance "K2A4" \
   --node-pool-zone "ITBG-1" \
-  --tags "production,kubernetes" \
-  --ha \
-  --billing-period "Hour"
+  --tags "production,kubernetes"
 ```
 
 Example output:

--- a/docs/website/docs/resources/container.md
+++ b/docs/website/docs/resources/container.md
@@ -42,11 +42,11 @@ acloud container containerregistry get <registry-id>
 acloud container containerregistry create \
   --name "my-registry" \
   --region "ITBG-Bergamo" \
-  --public-ip-uri "/projects/{id}/providers/Aruba.Network/elasticIps/{eip-id}" \
-  --vpc-uri "/projects/{id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-  --subnet-uri "/projects/{id}/providers/Aruba.Network/subnets/{subnet-id}" \
-  --security-group-uri "/projects/{id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-  --block-storage-uri "/projects/{id}/providers/Aruba.Storage/volumes/{volume-id}"
+  --public-ip-id "<eip-id>" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --block-storage-id "<volume-id>"
 
 # Update a container registry
 acloud container containerregistry update <registry-id> --name "new-name"
@@ -103,12 +103,12 @@ acloud container kaas update <cluster-id> \
    acloud container containerregistry create \
      --name "my-registry" \
      --region "ITBG-Bergamo" \
-     --public-ip-uri "/projects/{id}/providers/Aruba.Network/elasticIps/{eip-id}" \
-     --vpc-uri "/projects/{id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-     --subnet-uri "/projects/{id}/providers/Aruba.Network/subnets/{subnet-id}" \
-     --security-group-uri "/projects/{id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-     --block-storage-uri "/projects/{id}/providers/Aruba.Storage/volumes/{volume-id}" \
-     --billing-period "Month"
+     --public-ip-id "<eip-id>" \
+     --vpc-id "<vpc-id>" \
+     --subnet-id "<subnet-id>" \
+     --security-group-id "<sg-id>" \
+     --block-storage-id "<volume-id>" \
+     --billing-period Hour
    ```
 
 3. **Wait for the registry to be ready** and check status:

--- a/docs/website/docs/resources/database.md
+++ b/docs/website/docs/resources/database.md
@@ -41,8 +41,8 @@ acloud database dbaas database get <dbaas-id> <database-name>
 # Create a database
 acloud database dbaas database create <dbaas-id> --name "my-database"
 
-# Update a database (rename)
-acloud database dbaas database update <dbaas-id> <database-name> --name "new-name"
+# Update a database (rename — not supported by API, returns 405)
+# acloud database dbaas database update <dbaas-id> <database-name> --name "new-name"
 
 # Delete a database
 acloud database dbaas database delete <dbaas-id> <database-name>
@@ -63,11 +63,30 @@ acloud database dbaas user get <dbaas-id> <username>
 # Create a user
 acloud database dbaas user create <dbaas-id> --username "my-user" --password "secure-password"
 
-# Update a user (change password)
-acloud database dbaas user update <dbaas-id> <username> --password "new-password"
+# Update a user (change password — not supported by API, returns 405)
+# acloud database dbaas user update <dbaas-id> <username> --password "new-password"
 
 # Delete a user
 acloud database dbaas user delete <dbaas-id> <username>
+```
+
+### [DBaaS Grants](database/dbaas.grant.md)
+
+Grants control which users can access which databases within a DBaaS instance and at what privilege level.
+
+**Quick Commands:**
+```bash
+# List all grants on a database
+acloud database dbaas grant list <dbaas-id> <database-name>
+
+# Get grant details
+acloud database dbaas grant get <dbaas-id> <database-name> <grant-id>
+
+# Create a grant
+acloud database dbaas grant create <dbaas-id> <database-name> --username "my-user" --role "liteadmin"
+
+# Revoke a grant
+acloud database dbaas grant delete <dbaas-id> <database-name> <grant-id>
 ```
 
 ### [Database Backups](database/backup.md)

--- a/docs/website/docs/resources/database/dbaas.database.md
+++ b/docs/website/docs/resources/database/dbaas.database.md
@@ -92,6 +92,8 @@ acloud database dbaas database get 69455aa70d0972656501d45d "my-database"
 
 Rename a database.
 
+> **Note:** Database rename (PUT) is **not supported** by the API and returns HTTP 405. Use `delete` followed by `create` to rename a database.
+
 ### Usage
 
 ```bash
@@ -148,5 +150,6 @@ acloud database dbaas database delete 69455aa70d0972656501d45d "my-database" --y
 
 - [DBaaS](dbaas.md) - Manage DBaaS instances
 - [DBaaS Users](dbaas.user.md) - Manage users for databases
+- [DBaaS Grants](dbaas.grant.md) - Control user access to databases
 - [Database Backups](backup.md) - Create backups of databases
 

--- a/docs/website/docs/resources/database/dbaas.grant.md
+++ b/docs/website/docs/resources/database/dbaas.grant.md
@@ -1,0 +1,153 @@
+# DBaaS Grant Management
+
+Grants define which users have access to which databases within a DBaaS instance, and at what privilege level (e.g., `liteadmin`).
+
+## Available Commands
+
+- `acloud database dbaas grant create` - Grant a user access to a database
+- `acloud database dbaas grant list` - List all grants on a database
+- `acloud database dbaas grant get` - Get details of a specific grant
+- `acloud database dbaas grant delete` - Revoke a grant
+
+## Create Grant
+
+Grant a user access to a specific database within a DBaaS instance.
+
+### Usage
+
+```bash
+acloud database dbaas grant create <dbaas-id> <database-name> --username <username> --role <role> [flags]
+```
+
+### Arguments
+
+- `dbaas-id` (required): The unique ID of the DBaaS instance
+- `database-name` (required): The name of the database to grant access to
+
+### Required Flags
+
+- `--username` - The username to grant access to
+- `--role` - The privilege role (e.g., `liteadmin`)
+
+### Optional Flags
+
+- `--project-id` - Project ID (uses context if not specified)
+
+### Example
+
+```bash
+acloud database dbaas grant create 69455aa70d0972656501d45d "my-database" \
+  --username "restapi" \
+  --role "liteadmin"
+```
+
+> **Note:** The DBaaS instance must be in `Active` state before creating grants. The grant update (PUT) operation is not supported by the API — revoke and re-create to change a grant's role.
+
+## List Grants
+
+List all grants on a specific database within a DBaaS instance.
+
+### Usage
+
+```bash
+acloud database dbaas grant list <dbaas-id> <database-name> [flags]
+```
+
+### Arguments
+
+- `dbaas-id` (required): The unique ID of the DBaaS instance
+- `database-name` (required): The name of the database
+
+### Flags
+
+- `--project-id` - Project ID (uses context if not specified)
+
+### Example
+
+```bash
+acloud database dbaas grant list 69455aa70d0972656501d45d "my-database"
+```
+
+## Get Grant Details
+
+Retrieve details of a specific grant.
+
+### Usage
+
+```bash
+acloud database dbaas grant get <dbaas-id> <database-name> <grant-id> [flags]
+```
+
+### Arguments
+
+- `dbaas-id` (required): The unique ID of the DBaaS instance
+- `database-name` (required): The name of the database
+- `grant-id` (required): The unique ID of the grant
+
+### Flags
+
+- `--project-id` - Project ID (uses context if not specified)
+
+### Example
+
+```bash
+acloud database dbaas grant get 69455aa70d0972656501d45d "my-database" 69455aa70d0972656501d4ab
+```
+
+## Delete Grant
+
+Revoke a user's access to a database.
+
+### Usage
+
+```bash
+acloud database dbaas grant delete <dbaas-id> <database-name> <grant-id> [--yes] [flags]
+```
+
+### Arguments
+
+- `dbaas-id` (required): The unique ID of the DBaaS instance
+- `database-name` (required): The name of the database
+- `grant-id` (required): The unique ID of the grant to revoke
+
+### Flags
+
+- `--project-id` - Project ID (uses context if not specified)
+- `--yes, -y` - Skip confirmation prompt
+
+### Example
+
+```bash
+acloud database dbaas grant delete 69455aa70d0972656501d45d "my-database" 69455aa70d0972656501d4ab --yes
+```
+
+> **Note:** Grants are also removed when the parent database or DBaaS instance is deleted.
+
+## Typical Workflow
+
+```bash
+# 1. Create a DBaaS instance and wait for Active status
+acloud database dbaas create --name "my-dbaas" --region "ITBG-Bergamo" --zone "ITBG-1" \
+  --engine-id "mysql-8.0" --flavor "DBO4A8" --storage-size 50 \
+  --vpc-id "<vpc-id>" --subnet-id "<subnet-id>" --security-group-id "<sg-id>" \
+  --elastic-ip-id "<eip-id>"
+
+# 2. Create a database
+acloud database dbaas database create <dbaas-id> --name "appdb"
+
+# 3. Create a user
+acloud database dbaas user create <dbaas-id> --username "restapi" --password "SecurePass123!"
+
+# 4. Grant the user access
+acloud database dbaas grant create <dbaas-id> "appdb" --username "restapi" --role "liteadmin"
+
+# 5. Verify the grant
+acloud database dbaas grant list <dbaas-id> "appdb"
+```
+
+## Related Resources
+
+- [DBaaS](dbaas.md) - Manage DBaaS instances
+- [DBaaS Databases](dbaas.database.md) - Manage databases within DBaaS instances
+- [DBaaS Users](dbaas.user.md) - Manage users for DBaaS instances
+- [Database Backups](backup.md) - Create and manage database backups

--- a/docs/website/docs/resources/database/dbaas.md
+++ b/docs/website/docs/resources/database/dbaas.md
@@ -155,5 +155,6 @@ acloud database dbaas delete 69455aa70d0972656501d45d --yes
 
 - [DBaaS Databases](dbaas.database.md) - Manage databases within DBaaS instances
 - [DBaaS Users](dbaas.user.md) - Manage users for DBaaS instances
+- [DBaaS Grants](dbaas.grant.md) - Control user access to databases
 - [Database Backups](backup.md) - Create and manage database backups
 

--- a/docs/website/docs/resources/database/dbaas.user.md
+++ b/docs/website/docs/resources/database/dbaas.user.md
@@ -94,6 +94,8 @@ acloud database dbaas user get 69455aa70d0972656501d45d "app-user"
 
 Change a user's password.
 
+> **Note:** User password update (PUT) is **not supported** by the API and returns HTTP 405. Use `delete` followed by `create` to replace a user.
+
 ### Usage
 
 ```bash
@@ -158,5 +160,6 @@ acloud database dbaas user delete 69455aa70d0972656501d45d "app-user" --yes
 
 - [DBaaS](dbaas.md) - Manage DBaaS instances
 - [DBaaS Databases](dbaas.database.md) - Manage databases
+- [DBaaS Grants](dbaas.grant.md) - Control user access to databases
 - [Database Backups](backup.md) - Create backups of databases
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/basic-usage.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/basic-usage.md
@@ -183,7 +183,7 @@ acloud version
 Esempio output:
 
 ```text
-Aruba Cloud CLI version 1.2.0
+Aruba Cloud CLI version 0.2.0
 ```
 
 ---

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/cloudserver.md
@@ -44,13 +44,15 @@ Scegli una subnet con `STATUS` pari a `Active` e annota il suo `ID` e `CIDR`. Se
 
 ---
 
-## Step 3: Estrai la URI della Subnet
+## Step 3: Verifica l'ID della Subnet
+
+Annota l'`ID` della subnet scelta dall'output del comando list. Lo userai direttamente nel comando di creazione con `--subnet-id`.
 
 ```bash
-acloud network subnet get <vpc-id> <subnet-id> | grep URI
+acloud network subnet get <vpc-id> <subnet-id>
 ```
 
-Salva questa URI per il provisioning del cloud server.
+> **Nota:** Annota l'`ID` della subnet. Procedi solo se lo `STATUS` è `Active`.
 
 ---
 
@@ -66,15 +68,15 @@ Scegli un security group con `STATUS` pari a `Active` e annota il suo `ID`. Se n
 
 ---
 
-## Step 5: Estrai la URI dell'Elastic IP (se serve accesso pubblico)
+## Step 5: Annota l'ID dell'Elastic IP (se serve accesso pubblico)
 
-Se vuoi assegnare un Elastic IP, estrai la sua URI:
+Se vuoi accesso pubblico per il server, annota l'`ID` dell'Elastic IP dall'output di `acloud network elasticip list`. Puoi verificarlo con:
 
 ```bash
-acloud network elasticip get <elasticip-id> | grep URI
+acloud network elasticip get <elasticip-id>
 ```
 
-Salva questa URI per il provisioning. Salta questo step se non ti serve accesso pubblico.
+> **Nota:** Annota l'`ID` dell'Elastic IP. Salta questo step se non ti serve accesso pubblico.
 
 ---
 
@@ -115,15 +117,21 @@ acloud compute keypair create --name my-keypair --public-key "$(cat ~/.ssh/id_rs
 
 ---
 
-## Step 8: Estrai la URI del disco di avvio
+## Step 8: Verifica l'ID e lo stato del disco di avvio
 
-Dopo aver creato il block storage avviabile, estrai la sua URI:
+Annota l'`ID` del block storage avviabile. Il block storage deve essere in stato `NotUsed` prima di poterlo usare come disco di avvio.
 
 ```bash
-acloud storage blockstorage get <volume-id> | grep URI
+acloud storage blockstorage list
 ```
 
-Assicurati che il block storage sia in stato `NotUsed` prima di usarlo come disco di avvio.
+Esempio output:
+```
+NAME         ID                         SIZE(GB)  REGION         ZONE  TYPE         STATUS
+boot-ubuntu  697b3a0dce7dfeef9153256a   20        ITBG-Bergamo         Performance  NotUsed
+```
+
+> **Nota:** Annota l'`ID` del disco. Procedi solo quando lo stato è `NotUsed` o `Active`.
 
 ---
 
@@ -147,7 +155,40 @@ Sostituisci `<hashed-password>` con una password hash valida (consulta la docume
 
 ---
 
-## Step 10: Attendi che il Cloud Server sia Attivo
+## Step 10: Crea il Cloud Server
+
+Usa gli ID raccolti nei passaggi precedenti per creare il cloud server:
+
+```bash
+acloud compute cloudserver create \
+  --name "my-server" \
+  --region "ITBG-Bergamo" \
+  --zone "ITBG-1" \
+  --flavor "CSO4A8" \
+  --boot-disk-id "697b3a0dce7dfeef9153256a" \
+  --vpc-id "69495ef64d0cdc87949b71ec" \
+  --subnet-id "694ba1737712ac0032dbe50a" \
+  --security-group-id "694b05ac4d0cdc87949b75f9" \
+  --keypair-id "69007ebf4e7d691466d8621e" \
+  --user-data-file "cloud-init.yaml" \
+  --billing-period Hour \
+  --tags "production"
+```
+
+Esempio output:
+```
+ID                             NAME         FLAVOR    CPU   RAM(GB)   HD(GB)   REGION
+697c62605b79733376b3386a       my-server    CSO4A8    4     8         0        ITBG-Bergamo
+```
+
+- Sostituisci gli ID con i tuoi valori reali di VPC, subnet, security group, keypair e disco di avvio.
+- Il flag `--user-data-file` è opzionale e può essere omesso se non necessario.
+- Puoi specificare più subnet o security group usando valori separati da virgola.
+- Tutti i flag di rete (`--vpc-id`, `--subnet-id`, `--security-group-id`) e il flag `--zone` sono richiesti.
+
+---
+
+## Step 11: Attendi che il Cloud Server sia Attivo
 
 Una volta eseguito il comando di creazione, puoi controllare lo stato del server con:
 
@@ -163,7 +204,7 @@ my-server                 697c62605b79733376b3386a       ITBG-Bergamo    CSO4A8 
 
 ---
 
-## Step 11: Connettersi al Cloud Server
+## Step 12: Connettersi al Cloud Server
 
 Per connetterti al cloud server, usa il comando `acloud compute cloudserver connect` specificando l'utente in base all'immagine di avvio. Ad esempio, per Ubuntu usa l'utente `ubuntu`:
 
@@ -182,7 +223,7 @@ Connect by running: ssh ubuntu@85.235.152.94
 
 ---
 
-## Step 12: Spegnere o Accendere il Cloud Server
+## Step 13: Spegnere o Accendere il Cloud Server
 
 Puoi spegnere o accendere il cloud server in qualsiasi momento con i seguenti comandi:
 
@@ -214,7 +255,7 @@ Status: Updating
 
 ---
 
-## Step 13: Eliminare il Cloud Server
+## Step 14: Eliminare il Cloud Server
 
 Per eliminare il cloud server quando non serve più, usa il comando:
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/kubernetes.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/kubernetes.md
@@ -71,25 +71,20 @@ Scegli una subnet con `STATUS` pari a `Active` e annota il suo `ID` e `CIDR`. Se
 
 ---
 
-## Step 3: Estrai l'URI della Subnet
+## Step 3: Verifica l'ID della Subnet
 
-Una volta scelta la subnet, estrai il suo URI per usarlo nel comando di provisioning. Esegui:
+Annota l'`ID` della subnet scelta dall'output del comando list. Lo userai direttamente nel comando di creazione con `--subnet-id`.
 
 ```bash
-acloud network subnet get <vpc-id> <subnet-id> | grep URI
+acloud network subnet get <vpc-id> <subnet-id>
 ```
 
 Esempio:
 ```bash
-acloud network subnet get 69495ef64d0cdc87949b71ec 694ba1737712ac0032dbe50a | grep URI
+acloud network subnet get 69495ef64d0cdc87949b71ec 694ba1737712ac0032dbe50a
 ```
 
-Esempio output:
-```
-URI:             /projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a
-```
-
-> **Nota:** Salva questo URI per il provisioning Kubernetes.
+> **Nota:** Annota l'`ID` della subnet. Procedi solo se lo `STATUS` è `Active`.
 
 ---
 
@@ -121,22 +116,17 @@ Esempio reale di creazione di un cluster Kubernetes con un singolo node pool:
 acloud container kaas create \
   --name "test-cluster" \
   --region "ITBG-Bergamo" \
-  --vpc-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec" \
-  --subnet-uri "/projects/68398923fb2cb026400d4d31/providers/Aruba.Network/vpcs/69495ef64d0cdc87949b71ec/subnets/694ba1737712ac0032dbe50a" \
-  --node-cidr-address "10.0.0.0/16" \
+  --vpc-id "69495ef64d0cdc87949b71ec" \
+  --subnet-id "694ba1737712ac0032dbe50a" \
+  --node-cidr-address "10.0.0.0/24" \
   --node-cidr-name "node-cidr" \
   --security-group-name "kaas-sg" \
   --kubernetes-version "1.33.2" \
   --node-pool-name "default-pool" \
-  --node-pool-autoscaling \
-  --node-pool-max-count 5 \
-  --node-pool-min-count 1 \
-  --node-pool-nodes 3 \
-  --node-pool-instance "K4A8" \
+  --node-pool-nodes 1 \
+  --node-pool-instance "K2A4" \
   --node-pool-zone "ITBG-1" \
-  --tags "production,kubernetes" \
-  --ha \
-  --billing-period "Hour"
+  --tags "production,kubernetes"
 ```
 
 Esempio output:

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/container.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/container.md
@@ -42,11 +42,11 @@ acloud container containerregistry get <registry-id>
 acloud container containerregistry create \
   --name "my-registry" \
   --region "ITBG-Bergamo" \
-  --public-ip-uri "/projects/{id}/providers/Aruba.Network/elasticIps/{eip-id}" \
-  --vpc-uri "/projects/{id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-  --subnet-uri "/projects/{id}/providers/Aruba.Network/subnets/{subnet-id}" \
-  --security-group-uri "/projects/{id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-  --block-storage-uri "/projects/{id}/providers/Aruba.Storage/volumes/{volume-id}"
+  --public-ip-id "<eip-id>" \
+  --vpc-id "<vpc-id>" \
+  --subnet-id "<subnet-id>" \
+  --security-group-id "<sg-id>" \
+  --block-storage-id "<volume-id>"
 
 # Aggiorna un container registry
 acloud container containerregistry update <registry-id> --name "new-name"
@@ -103,12 +103,12 @@ acloud container kaas update <cluster-id> \
    acloud container containerregistry create \
      --name "my-registry" \
      --region "ITBG-Bergamo" \
-     --public-ip-uri "/projects/{id}/providers/Aruba.Network/elasticIps/{eip-id}" \
-     --vpc-uri "/projects/{id}/providers/Aruba.Network/vpcs/{vpc-id}" \
-     --subnet-uri "/projects/{id}/providers/Aruba.Network/subnets/{subnet-id}" \
-     --security-group-uri "/projects/{id}/providers/Aruba.Network/securityGroups/{sg-id}" \
-     --block-storage-uri "/projects/{id}/providers/Aruba.Storage/volumes/{volume-id}" \
-     --billing-period "Month"
+     --public-ip-id "<eip-id>" \
+     --vpc-id "<vpc-id>" \
+     --subnet-id "<subnet-id>" \
+     --security-group-id "<sg-id>" \
+     --block-storage-id "<volume-id>" \
+     --billing-period Hour
    ```
 
 3. **Attendi che il registry sia pronto** e controlla lo stato:

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database.md
@@ -41,8 +41,8 @@ acloud database dbaas database get <dbaas-id> <database-name>
 # Crea un database
 acloud database dbaas database create <dbaas-id> --name "my-database"
 
-# Aggiorna un database (rinomina)
-acloud database dbaas database update <dbaas-id> <database-name> --name "new-name"
+# Aggiorna un database (rinomina — non supportato dall'API, restituisce 405)
+# acloud database dbaas database update <dbaas-id> <database-name> --name "new-name"
 
 # Elimina un database
 acloud database dbaas database delete <dbaas-id> <database-name>
@@ -63,11 +63,30 @@ acloud database dbaas user get <dbaas-id> <username>
 # Crea un utente
 acloud database dbaas user create <dbaas-id> --username "my-user" --password "secure-password"
 
-# Aggiorna un utente (cambia password)
-acloud database dbaas user update <dbaas-id> <username> --password "new-password"
+# Aggiorna un utente (cambia password — non supportato dall'API, restituisce 405)
+# acloud database dbaas user update <dbaas-id> <username> --password "new-password"
 
 # Elimina un utente
 acloud database dbaas user delete <dbaas-id> <username>
+```
+
+### [Grant DBaaS](database/dbaas.grant.md)
+
+I grant controllano quali utenti possono accedere a quali database all'interno di un'istanza DBaaS e con quale livello di privilegi.
+
+**Comandi Rapidi:**
+```bash
+# Elenca tutti i grant su un database
+acloud database dbaas grant list <dbaas-id> <database-name>
+
+# Ottieni i dettagli del grant
+acloud database dbaas grant get <dbaas-id> <database-name> <grant-id>
+
+# Crea un grant
+acloud database dbaas grant create <dbaas-id> <database-name> --username "my-user" --role "liteadmin"
+
+# Revoca un grant
+acloud database dbaas grant delete <dbaas-id> <database-name> <grant-id>
 ```
 
 ### [Backup Database](database/backup.md)

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.database.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.database.md
@@ -92,6 +92,8 @@ acloud database dbaas database get 69455aa70d0972656501d45d "my-database"
 
 Rinomina un database.
 
+> **Nota:** La rinomina del database (PUT) **non è supportata** dall'API e restituisce HTTP 405. Usa `delete` seguito da `create` per rinominare un database.
+
 ### Utilizzo
 
 ```bash
@@ -148,4 +150,5 @@ acloud database dbaas database delete 69455aa70d0972656501d45d "my-database" --y
 
 - [DBaaS](dbaas.md) - Gestisci istanze DBaaS
 - [Utenti DBaaS](dbaas.user.md) - Gestisci utenti per database
+- [Grant DBaaS](dbaas.grant.md) - Controlla l'accesso degli utenti ai database
 - [Backup Database](backup.md) - Crea backup di database

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.grant.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.grant.md
@@ -1,0 +1,153 @@
+# Gestione Grant DBaaS
+
+I grant definiscono quali utenti hanno accesso a quali database all'interno di un'istanza DBaaS, e con quale livello di privilegi (es. `liteadmin`).
+
+## Comandi Disponibili
+
+- `acloud database dbaas grant create` - Concede a un utente l'accesso a un database
+- `acloud database dbaas grant list` - Elenca tutti i grant su un database
+- `acloud database dbaas grant get` - Ottieni i dettagli di un grant specifico
+- `acloud database dbaas grant delete` - Revoca un grant
+
+## Crea Grant
+
+Concede a un utente l'accesso a un database specifico all'interno di un'istanza DBaaS.
+
+### Utilizzo
+
+```bash
+acloud database dbaas grant create <dbaas-id> <database-name> --username <username> --role <role> [flags]
+```
+
+### Argomenti
+
+- `dbaas-id` (richiesto): L'ID univoco dell'istanza DBaaS
+- `database-name` (richiesto): Il nome del database a cui concedere l'accesso
+
+### Flag Richiesti
+
+- `--username` - Il nome utente a cui concedere l'accesso
+- `--role` - Il ruolo di privilegio (es. `liteadmin`)
+
+### Flag Opzionali
+
+- `--project-id` - ID progetto (usa il contesto se non specificato)
+
+### Esempio
+
+```bash
+acloud database dbaas grant create 69455aa70d0972656501d45d "my-database" \
+  --username "restapi" \
+  --role "liteadmin"
+```
+
+> **Nota:** L'istanza DBaaS deve essere in stato `Active` prima di creare i grant. L'operazione di aggiornamento grant (PUT) non è supportata dall'API — revoca e ricrea il grant per modificare il ruolo.
+
+## Elenca Grant
+
+Elenca tutti i grant su un database specifico all'interno di un'istanza DBaaS.
+
+### Utilizzo
+
+```bash
+acloud database dbaas grant list <dbaas-id> <database-name> [flags]
+```
+
+### Argomenti
+
+- `dbaas-id` (richiesto): L'ID univoco dell'istanza DBaaS
+- `database-name` (richiesto): Il nome del database
+
+### Flag
+
+- `--project-id` - ID progetto (usa il contesto se non specificato)
+
+### Esempio
+
+```bash
+acloud database dbaas grant list 69455aa70d0972656501d45d "my-database"
+```
+
+## Ottieni Dettagli Grant
+
+Recupera i dettagli di un grant specifico.
+
+### Utilizzo
+
+```bash
+acloud database dbaas grant get <dbaas-id> <database-name> <grant-id> [flags]
+```
+
+### Argomenti
+
+- `dbaas-id` (richiesto): L'ID univoco dell'istanza DBaaS
+- `database-name` (richiesto): Il nome del database
+- `grant-id` (richiesto): L'ID univoco del grant
+
+### Flag
+
+- `--project-id` - ID progetto (usa il contesto se non specificato)
+
+### Esempio
+
+```bash
+acloud database dbaas grant get 69455aa70d0972656501d45d "my-database" 69455aa70d0972656501d4ab
+```
+
+## Elimina Grant
+
+Revoca l'accesso di un utente a un database.
+
+### Utilizzo
+
+```bash
+acloud database dbaas grant delete <dbaas-id> <database-name> <grant-id> [--yes] [flags]
+```
+
+### Argomenti
+
+- `dbaas-id` (richiesto): L'ID univoco dell'istanza DBaaS
+- `database-name` (richiesto): Il nome del database
+- `grant-id` (richiesto): L'ID univoco del grant da revocare
+
+### Flag
+
+- `--project-id` - ID progetto (usa il contesto se non specificato)
+- `--yes, -y` - Salta il prompt di conferma
+
+### Esempio
+
+```bash
+acloud database dbaas grant delete 69455aa70d0972656501d45d "my-database" 69455aa70d0972656501d4ab --yes
+```
+
+> **Nota:** I grant vengono rimossi anche quando il database padre o l'istanza DBaaS viene eliminata.
+
+## Flusso di Lavoro Tipico
+
+```bash
+# 1. Crea un'istanza DBaaS e attendi lo stato Active
+acloud database dbaas create --name "my-dbaas" --region "ITBG-Bergamo" --zone "ITBG-1" \
+  --engine-id "mysql-8.0" --flavor "DBO4A8" --storage-size 50 \
+  --vpc-id "<vpc-id>" --subnet-id "<subnet-id>" --security-group-id "<sg-id>" \
+  --elastic-ip-id "<eip-id>"
+
+# 2. Crea un database
+acloud database dbaas database create <dbaas-id> --name "appdb"
+
+# 3. Crea un utente
+acloud database dbaas user create <dbaas-id> --username "restapi" --password "SecurePass123!"
+
+# 4. Concedi l'accesso all'utente
+acloud database dbaas grant create <dbaas-id> "appdb" --username "restapi" --role "liteadmin"
+
+# 5. Verifica il grant
+acloud database dbaas grant list <dbaas-id> "appdb"
+```
+
+## Risorse Correlate
+
+- [DBaaS](dbaas.md) - Gestisci istanze DBaaS
+- [Database DBaaS](dbaas.database.md) - Gestisci database all'interno di istanze DBaaS
+- [Utenti DBaaS](dbaas.user.md) - Gestisci utenti per istanze DBaaS
+- [Backup Database](backup.md) - Crea e gestisci backup database

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.md
@@ -155,5 +155,6 @@ acloud database dbaas delete 69455aa70d0972656501d45d --yes
 
 - [Database DBaaS](dbaas.database.md) - Gestisci database all'interno di istanze DBaaS
 - [Utenti DBaaS](dbaas.user.md) - Gestisci utenti per istanze DBaaS
+- [Grant DBaaS](dbaas.grant.md) - Controlla l'accesso degli utenti ai database
 - [Backup Database](backup.md) - Crea e gestisci backup database
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.user.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.user.md
@@ -94,6 +94,8 @@ acloud database dbaas user get 69455aa70d0972656501d45d "app-user"
 
 Cambia la password di un utente.
 
+> **Nota:** L'aggiornamento della password utente (PUT) **non è supportato** dall'API e restituisce HTTP 405. Usa `delete` seguito da `create` per sostituire un utente.
+
 ### Utilizzo
 
 ```bash
@@ -158,4 +160,5 @@ acloud database dbaas user delete 69455aa70d0972656501d45d "app-user" --yes
 
 - [DBaaS](dbaas.md) - Gestisci istanze DBaaS
 - [Database DBaaS](dbaas.database.md) - Gestisci database
+- [Grant DBaaS](dbaas.grant.md) - Controlla l'accesso degli utenti ai database
 - [Backup Database](backup.md) - Crea backup di database


### PR DESCRIPTION
Closes #160

## Summary

- Fix wrong CLI flags in examples: `--boot-disk-uri`, `--vpc-uri`, `--subnet-uri`, `--security-group-uri`, `--keypair-uri` replaced with correct `--*-id` flags in cloudserver, kubernetes, and container registry examples (EN + IT)
- Add missing Step 10 (create command) to Italian cloudserver example — it was entirely absent
- New page `dbaas.grant.md` (EN + IT): documents `acloud database dbaas grant` CRUD operations based on the e2e test suite
- API limitation notes added to `dbaas.database.md` and `dbaas.user.md` (EN + IT): `update` (PUT) returns HTTP 405
- Version reference: `basic-usage.md` (EN + IT) updated `1.2.0` → `0.2.0`
- Cross-links: all database sub-pages now link to the new grant page

## Test plan
- [ ] cloudserver example flags match `e2e/compute/test.sh`
- [ ] kubernetes example flags match `e2e/container/test.sh`
- [ ] container registry flags match `e2e/container/test.sh`
- [ ] dbaas.grant.md commands match `e2e/database/test.sh` grant operations
- [ ] EN and IT pages render correctly in Docusaurus