### PR TITLE
[v0.3.0] fix: remove --client-secret flag support from config set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ go mod download
 go build -o acloud
 
 # Configure credentials
-./acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET ./acloud config set --client-id YOUR_CLIENT_ID
 ```
 
 4. **Build and test**

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ check-env: ## Check development environment
 dev-setup: deps build ## Complete development setup
 	@echo "$(GREEN)Development environment ready!$(NC)"
 	@echo "$(YELLOW)Next steps:$(NC)"
-	@echo "  1. Configure credentials: ./$(BINARY_NAME) config set --client-id <id> --client-secret <secret>"
+	@echo "  1. Configure credentials: ACLOUD_CLIENT_SECRET=<secret> ./$(BINARY_NAME) config set --client-id <id>"
 	@echo "  2. Run tests: make test"
 	@echo "  3. Run E2E tests: make e2e-test"
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ acloud --version
 # Prompts for the secret with echo disabled (recommended)
 acloud config set --client-id YOUR_CLIENT_ID
 
-# Or pass both flags (suitable for CI/CD — prefer environment variables instead)
-acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+# CI/CD: provide secret via environment variable
+ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET acloud config set --client-id YOUR_CLIENT_ID
 ```
 
-> **Security note**: Avoid passing `--client-secret` in interactive sessions — it will appear in your shell history.
+> **Security note**: The CLI does not accept `--client-secret` as a flag to avoid exposure in process lists and shell history.
 
 Credentials are stored in `~/.acloud.yaml`.
 

--- a/ai/DEVEX.md
+++ b/ai/DEVEX.md
@@ -58,3 +58,23 @@ Install GoReleaser: `go install github.com/goreleaser/goreleaser/v2@latest`
 - Set `ACLOUD_TEST_SKIP_CLIENT=true` to skip tests that require live API credentials (used in CI).
 - E2E tests are bash scripts under `e2e/` organized by resource category.
 - Test files: `<file>_test.go` for standard tests; `<file>_test_enhanced.go` for extended fixtures/scenarios.
+
+## AI Agent Pre-PR Gate
+
+When an AI agent (Copilot/Claude) prepares a PR, it must complete this gate **before** opening a new issue branch or moving to the next issue:
+
+1. Run local tests for touched packages and full repository tests:
+    ```bash
+    go test ./... -count=1
+    ```
+2. Generate coverage and verify touched code paths are exercised:
+    ```bash
+    go test ./cmd -covermode=count -coverprofile=/tmp/cmd.cover.out
+    go tool cover -func=/tmp/cmd.cover.out
+    ```
+3. After pushing and opening the PR, verify check status and wait for completion:
+    ```bash
+    gh pr checks <PR_NUMBER> --repo Arubacloud/acloud-cli
+    ```
+4. If `codecov/patch` is failing, add targeted tests for changed lines and push again.
+5. Do not start the next issue until `codecov/patch` and required checks are green (or maintainer explicitly approves an exception).

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,7 +38,7 @@ var configCmd = &cobra.Command{
 var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set configuration values",
-	Long:  `Set configuration values for acloud, such as clientId and clientSecret.`,
+	Long:  `Set configuration values for acloud. Pass clientId as a flag; clientSecret is read from ACLOUD_CLIENT_SECRET or prompted securely.`,
 	RunE:  ConfigSetRun,
 }
 
@@ -57,7 +57,6 @@ func init() {
 
 	// Flags for config set command
 	configSetCmd.Flags().String("client-id", "", "Aruba Cloud API client ID (required)")
-	configSetCmd.Flags().String("client-secret", "", "Aruba Cloud API client secret (required)")
 	configSetCmd.Flags().String("base-url", "", "Base URL for Aruba Cloud API (optional, default: https://api.arubacloud.com)")
 	configSetCmd.Flags().String("token-issuer-url", "", "Token issuer URL for authentication (optional, default: https://login.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token)")
 }
@@ -167,9 +166,6 @@ func (a *ConfigSetArgs) ParseFromCobraCommand(cmd *cobra.Command) error {
 	if a.ClientID, err = cmd.Flags().GetString("client-id"); err != nil {
 		errs = append(errs, err)
 	}
-	if a.ClientSecret, err = cmd.Flags().GetString("client-secret"); err != nil {
-		errs = append(errs, err)
-	}
 	if a.BaseURL, err = cmd.Flags().GetString("base-url"); err != nil {
 		errs = append(errs, err)
 	}
@@ -198,11 +194,16 @@ func ConfigSet(_ context.Context, args ConfigSetArgs) error {
 	if config.ClientID == "" && args.ClientID == "" {
 		return fmt.Errorf("--client-id is required")
 	}
+	// ACLOUD_CLIENT_SECRET is accepted for automation and takes precedence over prompt.
+	if args.ClientSecret == "" {
+		args.ClientSecret = os.Getenv("ACLOUD_CLIENT_SECRET")
+	}
+
 	// If no client-secret is available, prompt interactively.
 	if config.ClientSecret == "" && args.ClientSecret == "" {
 		prompted, err := readSecret("Enter client secret: ")
 		if err != nil {
-			return fmt.Errorf("--client-secret is required: %w", err)
+			return fmt.Errorf("client secret is required (set ACLOUD_CLIENT_SECRET or provide interactive input): %w", err)
 		}
 		args.ClientSecret = prompted
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -327,7 +327,7 @@ func TestConfigSetCmd_Success(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	os.Setenv("USERPROFILE", tmpDir)
 	os.Unsetenv("ACLOUD_CLIENT_ID")
-	os.Unsetenv("ACLOUD_CLIENT_SECRET")
+	os.Setenv("ACLOUD_CLIENT_SECRET", "env-secret")
 	defer func() {
 		os.Setenv("HOME", origHome)
 		os.Setenv("USERPROFILE", origUserProfile)
@@ -335,7 +335,7 @@ func TestConfigSetCmd_Success(t *testing.T) {
 		os.Setenv("ACLOUD_CLIENT_SECRET", origSecret)
 	}()
 
-	out, err := runCmdCapture(nil, []string{"config", "set", "--client-id", "test-id", "--client-secret", "test-secret"})
+	out, err := runCmdCapture(nil, []string{"config", "set", "--client-id", "test-id"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestConfigSetCmd_MissingClientID(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	os.Setenv("USERPROFILE", tmpDir)
 	os.Unsetenv("ACLOUD_CLIENT_ID")
-	os.Unsetenv("ACLOUD_CLIENT_SECRET")
+	os.Setenv("ACLOUD_CLIENT_SECRET", "env-secret")
 	defer func() {
 		os.Setenv("HOME", origHome)
 		os.Setenv("USERPROFILE", origUserProfile)
@@ -361,12 +361,32 @@ func TestConfigSetCmd_MissingClientID(t *testing.T) {
 		os.Setenv("ACLOUD_CLIENT_SECRET", origSecret)
 	}()
 
-	_, err := runCmdCapture(nil, []string{"config", "set", "--client-secret", "test-secret"})
+	_, err := runCmdCapture(nil, []string{"config", "set"})
 	if err == nil {
 		t.Fatal("expected error for missing --client-id")
 	}
 	if !strings.Contains(err.Error(), "client-id") {
 		t.Errorf("expected client-id mention in error, got: %s", err.Error())
+	}
+}
+
+func TestConfigSetCmd_ClientSecretFlagRejected(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("USERPROFILE", origUserProfile)
+	}()
+
+	_, err := runCmdCapture(nil, []string{"config", "set", "--client-id", "test-id", "--client-secret", "test-secret"})
+	if err == nil {
+		t.Fatal("expected error for unknown --client-secret flag")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("expected unknown flag error, got: %s", err.Error())
 	}
 }
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -569,6 +569,39 @@ func TestConfigSet_Operation_UpdatesExistingConfig(t *testing.T) {
 	}
 }
 
+func TestConfigSet_Operation_UsesEnvClientSecret(t *testing.T) {
+	defer withTempHome(t)()
+	origSecret := os.Getenv("ACLOUD_CLIENT_SECRET")
+	os.Setenv("ACLOUD_CLIENT_SECRET", "env-op-secret")
+	defer os.Setenv("ACLOUD_CLIENT_SECRET", origSecret)
+
+	err := ConfigSet(context.Background(), ConfigSetArgs{ClientID: "env-op-id"})
+	if err != nil {
+		t.Fatalf("ConfigSet() error: %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if loaded.ClientSecret != "env-op-secret" {
+		t.Errorf("ClientSecret = %q, want env-op-secret", loaded.ClientSecret)
+	}
+}
+
+func TestConfigSet_Operation_MissingClientSecret_NonInteractive(t *testing.T) {
+	defer withTempHome(t)()
+	os.Unsetenv("ACLOUD_CLIENT_SECRET")
+
+	err := ConfigSet(context.Background(), ConfigSetArgs{ClientID: "id-without-secret"})
+	if err == nil {
+		t.Fatal("expected error when no secret is available in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "set ACLOUD_CLIENT_SECRET") {
+		t.Errorf("expected ACLOUD_CLIENT_SECRET guidance, got: %v", err)
+	}
+}
+
 func TestConfigShow_Operation_WithConfig(t *testing.T) {
 	defer withTempHome(t)()
 	os.Unsetenv("ACLOUD_CLIENT_ID")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,7 +122,7 @@ func GetArubaClient() (aruba.Client, error) {
 	}
 
 	if config.ClientID == "" || config.ClientSecret == "" {
-		return nil, fmt.Errorf("client ID or client secret not configured. Set ACLOUD_CLIENT_ID / ACLOUD_CLIENT_SECRET env vars or run 'acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET'")
+		return nil, fmt.Errorf("client ID or client secret not configured. Set ACLOUD_CLIENT_ID / ACLOUD_CLIENT_SECRET env vars or run 'acloud config set --client-id YOUR_CLIENT_ID'")
 	}
 
 	// Get base URL and token issuer URL from config, or use defaults
@@ -320,7 +320,7 @@ func confirmDelete(resourceType, id string) (bool, error) {
 func readSecret(prompt string) (string, error) {
 	fi, err := os.Stdin.Stat()
 	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
-		return "", fmt.Errorf("cannot read secret interactively: stdin is not a terminal; pass the flag explicitly instead")
+		return "", fmt.Errorf("cannot read secret interactively: stdin is not a terminal; set ACLOUD_CLIENT_SECRET instead")
 	}
 	fmt.Fprint(os.Stderr, prompt)
 	secret, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/docs/website/docs/installation.md
+++ b/docs/website/docs/installation.md
@@ -120,12 +120,12 @@ The Aruba Cloud CLI requires API credentials to authenticate with Aruba Cloud se
    # Enter client secret: (hidden input, does not appear in shell history)
    ```
 
-   For CI/automation where shell history is not a concern, both flags may be passed together:
+  For CI/automation, set the secret via environment variable:
    ```bash
-   acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+  ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET acloud config set --client-id YOUR_CLIENT_ID
    ```
 
-   > **Security note**: Avoid passing `--client-secret` interactively — it will appear in your shell history. Omitting the flag causes the CLI to prompt for it with echo disabled.
+  > **Security note**: `--client-secret` is intentionally not supported to avoid exposing secrets in process lists and shell history.
 
 3. **Verify configuration**:
    ```bash
@@ -151,14 +151,14 @@ The CLI configuration allows you to manage API credentials and optional settings
 
 **Required Settings:**
 
-`--client-id` is required. `--client-secret` may be passed on the command line or omitted to be prompted securely with echo disabled (recommended for interactive use):
+`--client-id` is required. `clientSecret` is sourced from `ACLOUD_CLIENT_SECRET` (automation) or prompted securely with echo disabled (interactive):
 
 ```bash
 # Recommended: secret entered via hidden prompt (does not appear in shell history)
 acloud config set --client-id YOUR_CLIENT_ID
 
-# CI/automation: pass both flags on the command line
-acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+# CI/automation: provide secret via environment variable
+ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET acloud config set --client-id YOUR_CLIENT_ID
 ```
 
 **Optional Settings:**
@@ -176,9 +176,9 @@ acloud config set --token-issuer-url "https://login.aruba.it/auth/realms/cmp-new
 You can also set all values at once:
 
 ```bash
+ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET \
 acloud config set \
   --client-id YOUR_CLIENT_ID \
-  --client-secret YOUR_CLIENT_SECRET \
   --base-url "https://api.arubacloud.com" \
   --token-issuer-url "https://login.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token"
 ```
@@ -223,16 +223,16 @@ You can update individual settings without affecting others:
 
 ```bash
 # Update only the client secret
-acloud config set --client-secret NEW_SECRET
+ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config set --client-id YOUR_CLIENT_ID
 
 # Update only the base URL
 acloud config set --base-url "https://custom-api.example.com"
 ```
 
-**Note**: Both `--client-id` and `--client-secret` must always be present in the configuration. If you're updating one, make sure the other is already set or provide both. When updating the secret interactively, omit `--client-secret` to be prompted with echo disabled:
+**Note**: Both `clientId` and `clientSecret` must always be present in the configuration. If you're updating one, make sure the other is already set in config/environment. For interactive secret updates, run with `--client-id` and provide the secret when prompted:
 
 ```bash
-acloud config set --client-secret   # prompted securely
+acloud config set --client-id YOUR_CLIENT_ID   # prompted securely
 ```
 
 ## Context Management

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,7 +25,7 @@ Before running the tests, ensure you have:
 
 1. **Configured CLI credentials:**
    ```bash
-   acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+   ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET acloud config set --client-id YOUR_CLIENT_ID
    ```
 
 2. **Set required environment variables** (see each test script for specific requirements):


### PR DESCRIPTION
## Summary
- remove `--client-secret` flag registration from `acloud config set`
- stop parsing `client-secret` from Cobra flags; source secrets from `ACLOUD_CLIENT_SECRET` or secure interactive prompt
- update error/help text to avoid recommending secret-in-argv usage
- add regression test that `--client-secret` is rejected as unknown flag
- update `README.md`, `CONTRIBUTING.md`, `Makefile`, `docs/website/docs/installation.md`, and `e2e/README.md` examples to env-var/prompt flow

## Validation
- `go test ./cmd -run 'ConfigSet|ConfigShow|GetArubaClient|readSecret' -count=1`
- `go test ./cmd -count=1`
- `go test ./... -count=1`

Closes #166
