### PR TITLE
fix(config): mask clientSecret in config show outputs

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,17 +14,33 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config represents the application configuration
+// Config represents the runtime application configuration.
 type Config struct {
+	ClientID       string
+	ClientSecret   string
+	BaseURL        string
+	TokenIssuerURL string
+}
+
+// configFile is the persisted representation stored in ~/.acloud.yaml.
+type configFile struct {
 	ClientID       string `yaml:"clientId"`
 	ClientSecret   string `yaml:"clientSecret"`
 	BaseURL        string `yaml:"baseUrl,omitempty"`
 	TokenIssuerURL string `yaml:"tokenIssuerUrl,omitempty"`
 }
 
+type configShowDisplay struct {
+	ClientID       string `json:"clientId" yaml:"clientId"`
+	ClientSecret   string `json:"clientSecret" yaml:"clientSecret"`
+	BaseURL        string `json:"baseUrl" yaml:"baseUrl"`
+	TokenIssuerURL string `json:"tokenIssuerUrl" yaml:"tokenIssuerUrl"`
+}
+
 const (
 	DefaultBaseURL        = "https://api.arubacloud.com"
 	DefaultTokenIssuerURL = "https://mylogin.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token"
+	maskedClientSecret    = "***"
 )
 
 // configCmd represents the config command
@@ -101,9 +117,11 @@ func LoadConfig() (*Config, error) {
 		return config, nil
 	}
 
-	if err2 := yaml.Unmarshal(data, config); err2 != nil {
+	fileCfg := &configFile{}
+	if err2 := yaml.Unmarshal(data, fileCfg); err2 != nil {
 		return nil, fmt.Errorf("config file %s is corrupted (%w). Delete it and run 'acloud config set' to reconfigure", configPath, err2)
 	}
+	*config = configFromFile(fileCfg)
 
 	// Env vars override file values — useful for CI/CD and e2e tests.
 	if v := os.Getenv("ACLOUD_CLIENT_ID"); v != "" {
@@ -129,12 +147,36 @@ func SaveConfig(config *Config) error {
 		return err
 	}
 
-	data, err := yaml.Marshal(config)
+	data, err := yaml.Marshal(fileFromConfig(config))
 	if err != nil {
 		return err
 	}
 
 	return os.WriteFile(configPath, data, FilePermConfig)
+}
+
+func configFromFile(fileCfg *configFile) Config {
+	if fileCfg == nil {
+		return Config{}
+	}
+	return Config{
+		ClientID:       fileCfg.ClientID,
+		ClientSecret:   fileCfg.ClientSecret,
+		BaseURL:        fileCfg.BaseURL,
+		TokenIssuerURL: fileCfg.TokenIssuerURL,
+	}
+}
+
+func fileFromConfig(config *Config) configFile {
+	if config == nil {
+		return configFile{}
+	}
+	return configFile{
+		ClientID:       config.ClientID,
+		ClientSecret:   config.ClientSecret,
+		BaseURL:        config.BaseURL,
+		TokenIssuerURL: config.TokenIssuerURL,
+	}
 }
 
 // ─── Config Set ───────────────────────────────────────────────────────────────
@@ -280,11 +322,28 @@ func ConfigShow(_ context.Context, _ ConfigShowArgs) error {
 		fmt.Println("No configuration found. Please run 'acloud config set' to create one.")
 		return nil
 	}
+	display := configShowDisplayFromConfig(config)
+
+	if resolveOutputFormat() == OutputFormatJSON || resolveOutputFormat() == OutputFormatYAML {
+		PrintOutput(display, nil, nil)
+		return nil
+	}
+	if resolveOutputFormat() == OutputFormatTableJSON || resolveOutputFormat() == OutputFormatTableYAML {
+		headers := []TableColumn{
+			{Header: "CLIENT_ID", Width: 24},
+			{Header: "CLIENT_SECRET", Width: 16},
+			{Header: "BASE_URL", Width: 40},
+			{Header: "TOKEN_ISSUER_URL", Width: 40},
+		}
+		rows := [][]string{{display.ClientID, display.ClientSecret, display.BaseURL, display.TokenIssuerURL}}
+		PrintOutput(nil, headers, rows)
+		return nil
+	}
 
 	fmt.Println("Current configuration:")
 	fmt.Printf("  Client ID: %s\n", config.ClientID)
 	if config.ClientSecret != "" {
-		fmt.Println("  Client Secret: ********")
+		fmt.Printf("  Client Secret: %s\n", maskedClientSecret)
 	} else {
 		fmt.Println("  Client Secret: (not set)")
 	}
@@ -299,6 +358,28 @@ func ConfigShow(_ context.Context, _ ConfigShowArgs) error {
 	}
 	fmt.Printf("  Token Issuer URL: %s\n", tokenIssuerURL)
 	return nil
+}
+
+func configShowDisplayFromConfig(config *Config) configShowDisplay {
+	secret := "(not set)"
+	if config.ClientSecret != "" {
+		secret = maskedClientSecret
+	}
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	tokenIssuerURL := config.TokenIssuerURL
+	if tokenIssuerURL == "" {
+		tokenIssuerURL = DefaultTokenIssuerURL
+	}
+
+	return configShowDisplay{
+		ClientID:       config.ClientID,
+		ClientSecret:   secret,
+		BaseURL:        baseURL,
+		TokenIssuerURL: tokenIssuerURL,
+	}
 }
 
 // ConfigShowRun is the RunE wiring for the config show command.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -412,8 +414,75 @@ func TestConfigShowCmd(t *testing.T) {
 	if !strings.Contains(out, "show-id") {
 		t.Errorf("expected client ID in output, got: %s", out)
 	}
-	if !strings.Contains(out, "********") {
+	if !strings.Contains(out, "***") {
 		t.Errorf("expected redacted secret in output, got: %s", out)
+	}
+	if strings.Contains(out, "show-secret") {
+		t.Errorf("plaintext secret leaked in output: %s", out)
+	}
+}
+
+func TestConfigShowCmd_JSONMasksClientSecret(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("USERPROFILE", origUserProfile)
+	}()
+
+	if err := SaveConfig(&Config{ClientID: "show-id", ClientSecret: "show-secret"}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	out, err := runCmdCapture(nil, []string{"config", "show", "--output", "json"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "show-secret") {
+		t.Fatalf("plaintext secret leaked in JSON output: %s", out)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected valid JSON output, got error: %v\noutput: %s", err, out)
+	}
+	if got["clientSecret"] != maskedClientSecret {
+		t.Fatalf("clientSecret = %v, want %q", got["clientSecret"], maskedClientSecret)
+	}
+}
+
+func TestConfigShowCmd_YAMLMasksClientSecret(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	os.Setenv("USERPROFILE", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("USERPROFILE", origUserProfile)
+	}()
+
+	if err := SaveConfig(&Config{ClientID: "show-id", ClientSecret: "show-secret"}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	out, err := runCmdCapture(nil, []string{"config", "show", "--output", "yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "show-secret") {
+		t.Fatalf("plaintext secret leaked in YAML output: %s", out)
+	}
+
+	var got map[string]any
+	if err := yaml.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected valid YAML output, got error: %v\noutput: %s", err, out)
+	}
+	if got["clientSecret"] != maskedClientSecret {
+		t.Fatalf("clientSecret = %v, want %q", got["clientSecret"], maskedClientSecret)
 	}
 }
 
@@ -621,8 +690,11 @@ func TestConfigShow_Operation_WithConfig(t *testing.T) {
 	if !strings.Contains(out, "show-op-id") {
 		t.Errorf("expected client ID in output, got: %s", out)
 	}
-	if !strings.Contains(out, "********") {
+	if !strings.Contains(out, "***") {
 		t.Errorf("expected redacted secret in output, got: %s", out)
+	}
+	if strings.Contains(out, "show-secret") {
+		t.Errorf("plaintext secret leaked in output: %s", out)
 	}
 	if !strings.Contains(out, DefaultBaseURL+" (default)") {
 		t.Errorf("expected default base URL label, got: %s", out)


### PR DESCRIPTION
## Summary
- mask clientSecret in all output formats of acloud config show
- split runtime config model from YAML persistence model (configFile)
- keep LoadConfig and SaveConfig behavior unchanged while making display mapping explicit
- add regression tests to ensure plaintext secret never appears in config show, including --output json and --output yaml

## Validation
- go test ./cmd -run Config -count=1
- go test ./... -count=1
- go test ./cmd -covermode=count -coverprofile=/tmp/cmd.cover.out

Closes #167