### PR TITLE
chore: rename Go module path to canonical GitHub path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module acloud
+module github.com/Arubacloud/acloud-cli
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "acloud/cmd"
+import "github.com/Arubacloud/acloud-cli/cmd"
 
 // Version is set at build time via ldflags
 var Version string


### PR DESCRIPTION
## Summary
- rename module path in go.mod from acloud to github.com/Arubacloud/acloud-cli
- update main.go import from acloud/cmd to github.com/Arubacloud/acloud-cli/cmd
- reviewed CONTRIBUTING.md for module-path references (none found to update)

## Validation
- go build ./...
- go test ./... -count=1
- go test ./cmd -covermode=count -coverprofile=/tmp/cmd.cover.out

Closes #168