### PR TITLE
fix(output): migrate PrintTable callers and remove shim

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -19,7 +19,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-012 | `--debug` flag description updated to warn about credential/token exposure in HTTP headers |
 | TD-013 | `Args: cobra.NoArgs` added to all `create` and `list` commands that take no positional arguments |
 | TD-014 | `cmd/constants.go` created with `StateInCreation`, `DateLayout`, `FilePermConfig`, `FilePermDirAll`; all magic strings replaced |
-| TD-016 | Multi-mode output implemented: 5 canonical formats (`table`, `table-json`, `table-yaml`, `json`, `yaml`) via `resolveOutputFormat` + `PrintOutput`; `PrintTable` is now a shim; `-o json`/`-o yaml` emit full SDK response (breaking change from original PR #30 flat shape) |
+| TD-016 | Multi-mode output implemented: 5 canonical formats (`table`, `table-json`, `table-yaml`, `json`, `yaml`) via `resolveOutputFormat` + `PrintOutput`; `-o json`/`-o yaml` emit full SDK response (breaking change from original PR #30 flat shape). Legacy `PrintTable` shim was removed later in #169 after all call sites were migrated. |
 | TD-017 | `listParams(cmd)` helper added; `--limit`/`--offset` flags added to all 25 list commands; list RunE handlers now pass pagination params to SDK |
 | TD-018 | Global client cache vars encapsulated in `clientState` struct with `resetClientState()` helper; all test reset blocks updated to use it |
 | TD-010 | Table-driven `RunE` tests added for all 23 testable command files (24 including pre-existing `network.vpc_test.go`); mock infrastructure in `cmd/mock_test.go` covers all sub-clients; `security.kms_test.go` added via `arubaTestServer` harness in #109 (was previously skipped — concrete SDK type blocked concrete mocking); nil-pointer bugs in `LocationResponse.Value` and `CreationDate.IsZero()` fixed as a side effect of test authoring; redundant double nil-check blocks left by AWK generation cleaned up in 5 files |
@@ -41,13 +41,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 ---
 
 ## Low
-
-### TD-023 · Remove `PrintTable` shim
-`PrintTable(headers, rows)` is now a one-line shim around `PrintOutput(nil, headers, rows)`. All call sites that pass `nil` as the first arg produce `{}` for `-o json` / `-o yaml` instead of the actual resource data. Remaining direct `PrintTable` calls should be replaced with `PrintOutput(response.Data, headers, rows)` and the shim deleted.
-
-**Fix:** Grep for `PrintTable(` and migrate each site to `PrintOutput`, passing the typed SDK response as the first argument. Remove the `PrintTable` function once all sites are updated.
-
----
 
 ### TD-026 · VPC Peering Route lifecycle ends in `Failed` due to API ACL
 `network vpcpeeringroute create` against the e2e tenant now returns 200 (the v0.1.26→v0.1.27 SDK URL-path fix removed the bare 403 at CREATE), but the resulting route transitions to `Failed` shortly after creation. No `errors` array is exposed via GET; the route is simply unhealthy. This points at an API-side IAM/ACL on the `Aruba.Network/vpcPeerings/{id}/vpcPeeringRoutes` provisioning step scoped to this tenant — not a CLI bug. The e2e suite handles this via `wait_for_status`'s terminal-failure short-circuit: UPDATE is skipped, DELETE runs with `|| true`, and the function returns 0 so the suite stays green.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -632,12 +632,6 @@ func rowsToRecords(headers []TableColumn, rows [][]string) []yaml.Node {
 	return records
 }
 
-// PrintTable is a compatibility shim that delegates to PrintOutput with no rich object.
-// New code should call PrintOutput directly to pass the full SDK response object.
-func PrintTable(headers []TableColumn, rows [][]string) {
-	PrintOutput(nil, headers, rows)
-}
-
 // extractIDFromURI returns the last path segment of a URI string.
 // e.g. "/projects/p-1/providers/Aruba.Network/elasticIps/eip-42" → "eip-42"
 func extractIDFromURI(uri string) string {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -207,7 +207,7 @@ func TestPrintTable(t *testing.T) {
 	}
 
 	// Should not panic
-	PrintTable(headers, rows)
+	PrintOutput(nil, headers, rows)
 }
 
 func TestPrintTable_EmptyRows(t *testing.T) {
@@ -219,7 +219,7 @@ func TestPrintTable_EmptyRows(t *testing.T) {
 	rows := [][]string{}
 
 	// Should not panic with empty rows
-	PrintTable(headers, rows)
+	PrintOutput(nil, headers, rows)
 }
 
 func TestPrintTable_LongValues(t *testing.T) {
@@ -232,7 +232,7 @@ func TestPrintTable_LongValues(t *testing.T) {
 	}
 
 	// Should truncate long values
-	PrintTable(headers, rows)
+	PrintOutput(nil, headers, rows)
 }
 
 func TestPrintTable_MismatchedColumns(t *testing.T) {
@@ -247,7 +247,7 @@ func TestPrintTable_MismatchedColumns(t *testing.T) {
 	}
 
 	// Should not panic with mismatched columns
-	PrintTable(headers, rows)
+	PrintOutput(nil, headers, rows)
 }
 
 func TestNormalizeHeaderKey(t *testing.T) {
@@ -331,7 +331,7 @@ func TestPrintTable_TableJSONFormat(t *testing.T) {
 
 	out := captureStdout(func() {
 		rootCmd.PersistentFlags().Set("output", "table-json")
-		PrintTable(headers, rows)
+		PrintOutput(nil, headers, rows)
 		rootCmd.PersistentFlags().Set("output", "table")
 	})
 
@@ -359,7 +359,7 @@ func TestPrintTable_TableJSONFormat_Empty(t *testing.T) {
 
 	out := captureStdout(func() {
 		rootCmd.PersistentFlags().Set("output", "table-json")
-		PrintTable(headers, rows)
+		PrintOutput(nil, headers, rows)
 		rootCmd.PersistentFlags().Set("output", "table")
 	})
 
@@ -385,7 +385,7 @@ func TestPrintTable_TableYAMLFormat(t *testing.T) {
 
 	out := captureStdout(func() {
 		rootCmd.PersistentFlags().Set("output", "table-yaml")
-		PrintTable(headers, rows)
+		PrintOutput(nil, headers, rows)
 		rootCmd.PersistentFlags().Set("output", "table")
 	})
 
@@ -468,7 +468,7 @@ func TestPrintOutput_AliasStdJSON(t *testing.T) {
 
 	out := captureStdout(func() {
 		rootCmd.PersistentFlags().Set("output", "std-json")
-		PrintTable(headers, rows)
+		PrintOutput(nil, headers, rows)
 		rootCmd.PersistentFlags().Set("output", "table")
 	})
 


### PR DESCRIPTION
## Summary
- remove the exported PrintTable compatibility shim from cmd/root.go
- migrate remaining test usages from PrintTable(headers, rows) to PrintOutput(nil, headers, rows)
- verify there are no remaining func PrintTable declarations

## Validation
- go build ./...
- go test ./... -count=1
- go test ./cmd -covermode=count -coverprofile=/tmp/cmd.cover.out
- grep check confirms no func PrintTable remains in cmd/root.go

Closes #169