### PR TITLE
fix(schedule): ensure schedule job create sends steps[]

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -37,6 +37,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | TD-030 | sdk-go v1.0.4 added `cidr` JSON field handling to `SubnetCIDROrRef.UnmarshalJSON`, fixing the field-path mismatch that caused `vpnroute get/list` to always show a blank Cloud Subnet. CLI migrated all four output blocks from `raw.Properties.CloudSubnet.CIDR` to `route.CloudSubnet()` and from `raw.Properties.OnPremSubnet` to `route.OnPremSubnet()`. Closed #135 / #130. |
 | TD-025 | sdk-go v1.0.4 clarified `SubnetInfoCommon` as a routing reference (subnet must already exist; `cidr` must be unique per tunnel). Updated `--subnet-cidr`/`--subnet-name` flag descriptions and `vpntunnel create` Long doc to match. Closed #73. |
 | TD-038 | All 137 Cobra `RunE` handlers decomposed into `<Family><Resource><Action>Args` struct + `ParseFromCobraCommand` + `Validate()` + pure `<Action>` operation function + thin `<Action>Run` wiring. `Validate()` methods cover typed-enum value-sets via `slices.Contains`. `ErrParsingFailed` / `ErrValidationFailed` sentinels added to `cmd/args.go`; cross-resource valid-value slices in `cmd/enums.go`. Closes the testability gap left by PR #138. |
+| TD-031 | `schedule job create` now enforces `--step-resource-uri` as required, validates it in `ScheduleJobCreateArgs.Validate()`, and wires step payloads via `aruba.NewJobStep()` + `job.WithSteps(step)`. Regression test captures POST body and asserts non-empty `steps[]` content. Closed #170. |
 
 ---
 
@@ -62,21 +63,6 @@ The v0.2.0 SDK exposes `KeysClient` and `KmipsClient` sub-clients under `client.
 **Diagnosis:** Run `acloud --debug compute cloudserver update <id> --tags foo` and inspect `[DEBUG] response body:` to confirm which field(s) the API rejects.
 
 **Fix:** Map `networkInterfaces[].subnet` → `subnetRefs` and identify security-group URIs in `linkedResources[]` in the CLI update handler (or upstream in SDK `fromResponse`). Re-inject before calling `Update`. See #125.
-
----
-
-### TD-031 · Schedule job create does not send `steps[]` — API rejects with 400
-
-`acloud schedule job create` always returns HTTP 400 because the payload contains no
-`steps[]`. The `--step-resource-uri` / `--step-action-uri` / `--step-http-verb` /
-`--step-name` flags are declared in `init()` but the `RunE` never reads them and the
-SDK builder had no `AddStep` / `WithStep` method in v0.3.0. sdk-go v1.0.0 added
-`Job.Steps()` (a read accessor) but it is unclear whether a write/builder API was
-added. Check `aruba.Job` in v1.0.0 for `AddStep`/`WithStep` before implementing.
-
-**Fix:** If v1.0.0 added a step builder, read the four flags and append the step before
-calling `Create`. Otherwise, the command should return a clear "not yet implemented"
-error rather than silently emitting an invalid payload.
 
 ---
 

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -40,6 +40,7 @@ func init() {
 	jobCreateCmd.MarkFlagRequired("name")
 	jobCreateCmd.MarkFlagRequired("region")
 	jobCreateCmd.MarkFlagRequired("job-type")
+	jobCreateCmd.MarkFlagRequired("step-resource-uri")
 
 	jobGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 
@@ -419,6 +420,9 @@ func (a *ScheduleJobCreateArgs) Validate() error {
 	}
 	if !slices.Contains(validJobTypes, a.JobType) {
 		errs = append(errs, fmt.Errorf("--job-type %q: must be one of %v", a.JobType, validJobTypes))
+	}
+	if a.StepResourceURI == "" {
+		errs = append(errs, errors.New("--step-resource-uri is required"))
 	}
 
 	// Mutually exclusive schedule modes.

--- a/cmd/schedule.job_test.go
+++ b/cmd/schedule.job_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -160,6 +162,7 @@ func TestJobCreateCmd(t *testing.T) {
 		"--region", "ITBG-Bergamo",
 		"--job-type", "OneShot",
 		"--schedule-at", "2026-06-01T10:00:00Z",
+		"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 	}
 	tests := []struct {
 		name        string
@@ -195,6 +198,12 @@ func TestJobCreateCmd(t *testing.T) {
 			args:        removeFlag(baseShotArgs, "--job-type", "OneShot"),
 			wantErr:     true,
 			errContains: "job-type",
+		},
+		{
+			name:        "missing required flag --step-resource-uri",
+			args:        removeFlag(baseShotArgs, "--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001"),
+			wantErr:     true,
+			errContains: "step-resource-uri",
 		},
 		{
 			name: "server error propagates",
@@ -389,6 +398,7 @@ func TestJobCreateCmd_Recurring(t *testing.T) {
 				"--job-type", "Recurring",
 				"--cron", "0 * * * *",
 				"--execute-until", "2027-01-01T00:00:00Z",
+				"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 			},
 			setupSrv: func(srv *arubaTestServer) {
 				id, name := "job-new", "my-recurring-job"
@@ -406,6 +416,7 @@ func TestJobCreateCmd_Recurring(t *testing.T) {
 				"--region", "ITBG-Bergamo",
 				"--job-type", "Recurring",
 				"--execute-until", "2027-01-01T00:00:00Z",
+				"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 			},
 			wantErr:     true,
 			errContains: "cron",
@@ -419,6 +430,7 @@ func TestJobCreateCmd_Recurring(t *testing.T) {
 				"--region", "ITBG-Bergamo",
 				"--job-type", "Recurring",
 				"--cron", "0 * * * *",
+				"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 			},
 			wantErr:     true,
 			errContains: "execute-until",
@@ -432,6 +444,7 @@ func TestJobCreateCmd_Recurring(t *testing.T) {
 				"--region", "ITBG-Bergamo",
 				"--job-type", "Invalid",
 				"--schedule-at", "2026-06-01T10:00:00Z",
+				"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 			},
 			wantErr:     true,
 			errContains: "job-type",
@@ -444,6 +457,7 @@ func TestJobCreateCmd_Recurring(t *testing.T) {
 				"--name", "my-job",
 				"--region", "ITBG-Bergamo",
 				"--job-type", "OneShot",
+				"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 			},
 			wantErr:     true,
 			errContains: "schedule-at",
@@ -493,6 +507,7 @@ func TestJobCreateCmd_Disabled(t *testing.T) {
 		"--region", "ITBG-Bergamo",
 		"--job-type", "OneShot",
 		"--schedule-at", "2026-06-01T10:00:00Z",
+		"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 		"--enabled=false",
 	})
 	if err != nil {
@@ -509,6 +524,7 @@ func TestJobCreateCmd_InvalidScheduleAt(t *testing.T) {
 		"--region", "ITBG-Bergamo",
 		"--job-type", "OneShot",
 		"--schedule-at", "not-a-date",
+		"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid --schedule-at, got nil")
@@ -528,6 +544,7 @@ func TestJobCreateCmd_InvalidExecuteUntil(t *testing.T) {
 		"--job-type", "Recurring",
 		"--cron", "0 0 * * *",
 		"--execute-until", "not-a-date",
+		"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid --execute-until, got nil")
@@ -561,6 +578,7 @@ func TestJobCreateCmd_WithEnabledAndLocation(t *testing.T) {
 		"--region", "ITBG-Bergamo",
 		"--job-type", "OneShot",
 		"--schedule-at", "2026-06-01T10:00:00Z",
+		"--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -683,7 +701,7 @@ func TestJobUpdateCmd_WithEnabledAndTags(t *testing.T) {
 func TestScheduleJobCreateRun_ValidationError(t *testing.T) {
 	// --name "x" is too short (< 3 chars) — triggers ErrValidationFailed
 	srv := newArubaTestServer(t)
-	err := runCmd(srv.Client(), []string{"schedule", "job", "create", "--project-id", "proj-123", "--name", "x", "--region", "ITBG-Bergamo", "--job-type", "OneShot", "--schedule-at", "2026-06-01T10:00:00Z"})
+	err := runCmd(srv.Client(), []string{"schedule", "job", "create", "--project-id", "proj-123", "--name", "x", "--region", "ITBG-Bergamo", "--job-type", "OneShot", "--schedule-at", "2026-06-01T10:00:00Z", "--step-resource-uri", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001"})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -715,13 +733,55 @@ func TestScheduleJobListRun_NoProjectID(t *testing.T) {
 
 func validScheduleJobCreateArgs() ScheduleJobCreateArgs {
 	return ScheduleJobCreateArgs{
-		ProjectID: "proj-123",
-		Name:      "my-job",
-		Region:    aruba.RegionITBGBergamo,
-		JobType:   aruba.JobTypeOneShot,
-		Enabled:   true,
-		Tags:      []string{},
-		ShotTime:  "2026-06-01T10:00:00Z",
+		ProjectID:       "proj-123",
+		Name:            "my-job",
+		Region:          aruba.RegionITBGBergamo,
+		JobType:         aruba.JobTypeOneShot,
+		Enabled:         true,
+		Tags:            []string{},
+		ShotTime:        "2026-06-01T10:00:00Z",
+		StepResourceURI: "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001",
+	}
+}
+
+func TestJobCreateCmd_RequestBodyContainsSteps(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "job-001", "my-job"
+	stepURI := "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-001"
+	stepAction := "/actions/powerOff"
+
+	var capturedBody []byte
+	srv.OnPost("/projects/proj-123/providers/Aruba.Schedule/jobs", func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		jsonResponse(200, types.JobResponse{
+			Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		})(w, r)
+	})
+
+	err := runCmd(srv.Client(), []string{
+		"schedule", "job", "create",
+		"--project-id", "proj-123",
+		"--name", "my-job",
+		"--region", "ITBG-Bergamo",
+		"--job-type", "OneShot",
+		"--schedule-at", "2026-06-01T10:00:00Z",
+		"--step-resource-uri", stepURI,
+		"--step-action-uri", stepAction,
+		"--step-http-verb", "POST",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := string(capturedBody)
+	if !strings.Contains(body, "\"steps\"") {
+		t.Fatalf("request body missing steps array: %s", body)
+	}
+	if !strings.Contains(body, stepURI) {
+		t.Fatalf("request body missing step resource URI %q: %s", stepURI, body)
+	}
+	if !strings.Contains(body, stepAction) {
+		t.Fatalf("request body missing step action URI %q: %s", stepAction, body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce --step-resource-uri as required in schedule job create
- add explicit args validation for --step-resource-uri in ScheduleJobCreateArgs.Validate()
- keep step payload wiring through aruba.NewJobStep() + job.WithSteps(step)
- add regression test that captures POST request body and asserts non-empty steps[] content
- update ai/TECH_DEBT.md: move TD-031 out of open backlog into resolved entries

## Validation
- go test ./cmd -run 'JobCreate|ScheduleJobCreate|ScheduleJobCreateRun|ScheduleJobCreateArgs' -count=1
- go build ./...
- go test ./... -count=1
- go test ./cmd -covermode=count -coverprofile=/tmp/cmd.cover.out

Closes #170