### PR TITLE
test(args): add Validate() unit tests for 5 missing resource families

### DIFF
--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -455,3 +455,94 @@ func TestDBaaSDatabaseCreateCmd_WithCreationDate(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ─── Layer 1: Validate ───────────────────────────────────────────────────────
+
+func TestDatabaseDBaaSDatabaseCreateArgs_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        DatabaseDBaaSDatabaseCreateArgs
+		wantErr     bool
+		errContains string
+	}{
+		{name: "valid", args: DatabaseDBaaSDatabaseCreateArgs{DBaaSID: "d-001", Name: "mydb"}, wantErr: false},
+		{name: "missing dbaas-id", args: DatabaseDBaaSDatabaseCreateArgs{Name: "mydb"}, wantErr: true, errContains: "DBaaS ID"},
+		{name: "name too short", args: DatabaseDBaaSDatabaseCreateArgs{DBaaSID: "d-001", Name: "ab"}, wantErr: true, errContains: "--name must be at least 3"},
+		{name: "name too long", args: DatabaseDBaaSDatabaseCreateArgs{DBaaSID: "d-001", Name: string(make([]byte, 65))}, wantErr: true, errContains: "--name must be at most 64"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.args.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDatabaseDBaaSDatabaseGetArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSDatabaseGetArgs{DBaaSID: "d-001", DatabaseName: "mydb"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noDB := DatabaseDBaaSDatabaseGetArgs{DatabaseName: "mydb"}
+	if err := noDB.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+	noName := DatabaseDBaaSDatabaseGetArgs{DBaaSID: "d-001"}
+	if err := noName.Validate(); err == nil {
+		t.Fatal("expected error for missing DatabaseName")
+	}
+}
+
+func TestDatabaseDBaaSDatabaseUpdateArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSDatabaseUpdateArgs{DBaaSID: "d-001", DatabaseName: "mydb", Name: "new"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noDB := DatabaseDBaaSDatabaseUpdateArgs{DatabaseName: "mydb", Name: "new"}
+	if err := noDB.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+	noDBName := DatabaseDBaaSDatabaseUpdateArgs{DBaaSID: "d-001", Name: "new"}
+	if err := noDBName.Validate(); err == nil {
+		t.Fatal("expected error for missing DatabaseName")
+	}
+	noNewName := DatabaseDBaaSDatabaseUpdateArgs{DBaaSID: "d-001", DatabaseName: "mydb"}
+	if err := noNewName.Validate(); err == nil {
+		t.Fatal("expected error for missing Name")
+	}
+}
+
+func TestDatabaseDBaaSDatabaseDeleteArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSDatabaseDeleteArgs{DBaaSID: "d-001", DatabaseName: "mydb"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noDB := DatabaseDBaaSDatabaseDeleteArgs{DatabaseName: "mydb"}
+	if err := noDB.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+	noName := DatabaseDBaaSDatabaseDeleteArgs{DBaaSID: "d-001"}
+	if err := noName.Validate(); err == nil {
+		t.Fatal("expected error for missing DatabaseName")
+	}
+}
+
+func TestDatabaseDBaaSDatabaseListArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSDatabaseListArgs{DBaaSID: "d-001"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	empty := DatabaseDBaaSDatabaseListArgs{}
+	if err := empty.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+}

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -446,3 +446,94 @@ func TestDBaaSUserCreateCmd_WithCreationDate(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ─── Layer 1: Validate ───────────────────────────────────────────────────────
+
+func TestDatabaseDBaaSUserCreateArgs_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        DatabaseDBaaSUserCreateArgs
+		wantErr     bool
+		errContains string
+	}{
+		{name: "valid", args: DatabaseDBaaSUserCreateArgs{DBaaSID: "d-001", Username: "alice", Password: "s3cr3t"}, wantErr: false},
+		{name: "missing dbaas-id", args: DatabaseDBaaSUserCreateArgs{Username: "alice", Password: "s3cr3t"}, wantErr: true, errContains: "DBaaS ID"},
+		{name: "missing username", args: DatabaseDBaaSUserCreateArgs{DBaaSID: "d-001", Password: "s3cr3t"}, wantErr: true, errContains: "--username"},
+		{name: "missing password", args: DatabaseDBaaSUserCreateArgs{DBaaSID: "d-001", Username: "alice"}, wantErr: true, errContains: "--password"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.args.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDatabaseDBaaSUserGetArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSUserGetArgs{DBaaSID: "d-001", Username: "alice"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noDB := DatabaseDBaaSUserGetArgs{Username: "alice"}
+	if err := noDB.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+	noUser := DatabaseDBaaSUserGetArgs{DBaaSID: "d-001"}
+	if err := noUser.Validate(); err == nil {
+		t.Fatal("expected error for missing Username")
+	}
+}
+
+func TestDatabaseDBaaSUserUpdateArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSUserUpdateArgs{DBaaSID: "d-001", Username: "alice", Password: "new"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noDB := DatabaseDBaaSUserUpdateArgs{Username: "alice", Password: "new"}
+	if err := noDB.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+	noUser := DatabaseDBaaSUserUpdateArgs{DBaaSID: "d-001", Password: "new"}
+	if err := noUser.Validate(); err == nil {
+		t.Fatal("expected error for missing Username")
+	}
+	noPwd := DatabaseDBaaSUserUpdateArgs{DBaaSID: "d-001", Username: "alice"}
+	if err := noPwd.Validate(); err == nil {
+		t.Fatal("expected error for missing Password")
+	}
+}
+
+func TestDatabaseDBaaSUserDeleteArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSUserDeleteArgs{DBaaSID: "d-001", Username: "alice"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	noDB := DatabaseDBaaSUserDeleteArgs{Username: "alice"}
+	if err := noDB.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+	noUser := DatabaseDBaaSUserDeleteArgs{DBaaSID: "d-001"}
+	if err := noUser.Validate(); err == nil {
+		t.Fatal("expected error for missing Username")
+	}
+}
+
+func TestDatabaseDBaaSUserListArgs_Validate(t *testing.T) {
+	valid := DatabaseDBaaSUserListArgs{DBaaSID: "d-001"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	empty := DatabaseDBaaSUserListArgs{}
+	if err := empty.Validate(); err == nil {
+		t.Fatal("expected error for missing DBaaSID")
+	}
+}

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
@@ -511,5 +512,79 @@ func TestBlockStorageCreateCmd_WithSnapshotID(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ─── Layer 1: Validate ───────────────────────────────────────────────────────
+
+func validStorageBlockStorageCreateArgs() StorageBlockStorageCreateArgs {
+	return StorageBlockStorageCreateArgs{
+		ProjectID: "proj-123",
+		Name:      "my-volume",
+		Region:    aruba.RegionITBGBergamo,
+		SizeGB:    50,
+	}
+}
+
+func TestStorageBlockStorageCreateArgs_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*StorageBlockStorageCreateArgs)
+		wantErr     bool
+		errContains string
+	}{
+		{name: "valid", wantErr: false},
+		{name: "name too short", mutate: func(a *StorageBlockStorageCreateArgs) { a.Name = "ab" }, wantErr: true, errContains: "--name must be at least 3"},
+		{name: "name too long", mutate: func(a *StorageBlockStorageCreateArgs) { a.Name = string(make([]byte, 65)) }, wantErr: true, errContains: "--name must be at most 64"},
+		{name: "invalid region", mutate: func(a *StorageBlockStorageCreateArgs) { a.Region = aruba.Region("ZZ-Invalid") }, wantErr: true, errContains: "--region"},
+		{name: "size zero", mutate: func(a *StorageBlockStorageCreateArgs) { a.SizeGB = 0 }, wantErr: true, errContains: "--size"},
+		{name: "size negative", mutate: func(a *StorageBlockStorageCreateArgs) { a.SizeGB = -1 }, wantErr: true, errContains: "--size"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := validStorageBlockStorageCreateArgs()
+			if tc.mutate != nil {
+				tc.mutate(&args)
+			}
+			err := args.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestStorageBlockStorageUpdateArgs_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        StorageBlockStorageUpdateArgs
+		wantErr     bool
+		errContains string
+	}{
+		{name: "valid with name", args: StorageBlockStorageUpdateArgs{Name: "new-name"}, wantErr: false},
+		{name: "valid with tags changed", args: StorageBlockStorageUpdateArgs{TagsChanged: true}, wantErr: false},
+		{name: "no fields provided", args: StorageBlockStorageUpdateArgs{}, wantErr: true, errContains: "at least one"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.args.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Adds direct Validate() unit tests for the five resource families that were missing coverage (no SDK, no HTTP, no filesystem):

- database.dbaas.database: Create (DBaaSID required, name length), Get, Update, Delete, List (DBaaSID required)
- database.dbaas.user: Create (DBaaSID, username, password all required), Get, Update, Delete, List
- storage.blockstorage: Create (name length, invalid region enum, size > 0), Update (at least one field)
- storage.restore: Create (name length, invalid region, backup-id, volume-id required), Get, Update, Delete, List
- storage.snapshot: Create (name length, invalid region, volume-id required), Get (ID required), Update (ID + at least one field), Delete (ID required)

Also adds the aruba SDK import to the three storage test files that now reference aruba.RegionITBGBergamo.

## Validation
- go test ./cmd -run 'Validate' -v -count=1: all 20 new test functions pass
- go test ./... -count=1: full suite green

Closes #172