### PR TITLE
fix(e2e): increase subnet/VPC cleanup timeouts from 120s to 300s

### DIFF
--- a/e2e/compute/test.sh
+++ b/e2e/compute/test.sh
@@ -76,12 +76,12 @@ cleanup() {
         echo "Deleting bootstrapped subnet: $BOOTSTRAP_SUBNET_ID"
         wait_for_status "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" '^(Active|Ready)$' 60 2>/dev/null || true
         $ACLOUD_CMD network subnet delete "$BOOTSTRAP_VPC_ID" "$BOOTSTRAP_SUBNET_ID" --yes 2>&1 || true
-        wait_for_removal "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" 120 2>/dev/null || true
+        wait_for_removal "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" 300 2>/dev/null || true
     fi
     if [ -n "$BOOTSTRAP_VPC_ID" ]; then
         echo "Deleting bootstrapped VPC: $BOOTSTRAP_VPC_ID"
         local vpc_del_elapsed=0
-        while [ "$vpc_del_elapsed" -lt 120 ]; do
+        while [ "$vpc_del_elapsed" -lt 300 ]; do
             vpc_out=$($ACLOUD_CMD network vpc delete "$BOOTSTRAP_VPC_ID" --yes 2>&1)
             if [ $? -eq 0 ]; then echo "$vpc_out"; break; fi
             if echo "$vpc_out" | grep -qi "404\|Not Found"; then echo "$vpc_out"; break; fi
@@ -89,7 +89,7 @@ cleanup() {
             sleep 15
             vpc_del_elapsed=$((vpc_del_elapsed + 15))
         done
-        wait_for_removal "$ACLOUD_CMD network vpc get $BOOTSTRAP_VPC_ID" 120 2>/dev/null || true
+        wait_for_removal "$ACLOUD_CMD network vpc get $BOOTSTRAP_VPC_ID" 300 2>/dev/null || true
     fi
 
     # Ephemeral key files

--- a/e2e/container/test.sh
+++ b/e2e/container/test.sh
@@ -95,7 +95,7 @@ cleanup() {
         echo "Deleting bootstrapped subnet: $BOOTSTRAP_SUBNET_ID"
         wait_for_status "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" '^(Active|Ready)$' 60 2>/dev/null || true
         $ACLOUD_CMD network subnet delete "$BOOTSTRAP_VPC_ID" "$BOOTSTRAP_SUBNET_ID" --yes 2>&1 || true
-        wait_for_removal "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" 120 2>/dev/null || true
+        wait_for_removal "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" 300 2>/dev/null || true
     fi
     if [ -n "$BOOTSTRAP_VPC_ID" ]; then
         echo "Deleting bootstrapped VPC: $BOOTSTRAP_VPC_ID"
@@ -117,7 +117,7 @@ cleanup() {
             sleep 15
             vpc_del_elapsed=$((vpc_del_elapsed + 15))
         done
-        wait_for_removal "$ACLOUD_CMD network vpc get $BOOTSTRAP_VPC_ID" 120 2>/dev/null || true
+        wait_for_removal "$ACLOUD_CMD network vpc get $BOOTSTRAP_VPC_ID" 300 2>/dev/null || true
     fi
 
     # Delete bootstrapped project last — retry because VPC/cluster deletions are async

--- a/e2e/database/test.sh
+++ b/e2e/database/test.sh
@@ -107,12 +107,12 @@ cleanup() {
         echo "Deleting bootstrapped subnet: $BOOTSTRAP_SUBNET_ID"
         wait_for_status "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" '^(Active|Ready)$' 60 2>/dev/null || true
         $ACLOUD_CMD network subnet delete "$BOOTSTRAP_VPC_ID" "$BOOTSTRAP_SUBNET_ID" --yes 2>&1 || true
-        wait_for_removal "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" 120 2>/dev/null || true
+        wait_for_removal "$ACLOUD_CMD network subnet get $BOOTSTRAP_VPC_ID $BOOTSTRAP_SUBNET_ID" 300 2>/dev/null || true
     fi
     if [ -n "$BOOTSTRAP_VPC_ID" ]; then
         echo "Deleting bootstrapped VPC: $BOOTSTRAP_VPC_ID"
         local vpc_del_elapsed=0
-        while [ "$vpc_del_elapsed" -lt 120 ]; do
+        while [ "$vpc_del_elapsed" -lt 300 ]; do
             vpc_out=$($ACLOUD_CMD network vpc delete "$BOOTSTRAP_VPC_ID" --yes 2>&1)
             if [ $? -eq 0 ]; then echo "$vpc_out"; break; fi
             # 404 means already gone — stop retrying immediately
@@ -121,7 +121,7 @@ cleanup() {
             sleep 15
             vpc_del_elapsed=$((vpc_del_elapsed + 15))
         done
-        wait_for_removal "$ACLOUD_CMD network vpc get $BOOTSTRAP_VPC_ID" 120 2>/dev/null || true
+        wait_for_removal "$ACLOUD_CMD network vpc get $BOOTSTRAP_VPC_ID" 300 2>/dev/null || true
     fi
 
     # Sweep for DBaaS instances that exist in the project but weren't tracked —


### PR DESCRIPTION
Subnets can remain in Deleting state for more than 2 minutes after the delete API returns success. The 120s wait_for_removal timeout expired before the subnet disappeared, causing the VPC delete to fail with "subnet is not in a valid status" and leaving the VPC and project orphaned.

Raises the three timeout values (subnet wait_for_removal, VPC retry loop, VPC wait_for_removal) from 120s to 300s in the database, compute, and container e2e suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)