### PR TITLE
feat(root): add --timeout global flag to override hardcoded 30s API timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging (WARNING: may expose credentials and tokens in HTTP headers)")
 	// Add global output format flag (TD-016)
 	rootCmd.PersistentFlags().StringP("output", "o", OutputFormatTable, "Output format: table|std|standard, table-json|std-json, table-yaml|std-yaml, json, yaml")
+	// Add global timeout flag (#175)
+	rootCmd.PersistentFlags().String("timeout", "30s", "Timeout for API calls (e.g. 30s, 2m, 5m)")
 }
 
 // projectRef returns an opaque aruba.Ref for /projects/<projectID>. (TD-022)
@@ -215,9 +217,18 @@ func GetProjectID(cmd *cobra.Command) (string, error) {
 	return projectID, nil
 }
 
-// newCtx returns a context with a 30-second timeout for SDK calls (TD-006).
+// newCtx returns a context whose timeout is governed by the global --timeout flag
+// (default 30s). Invalid or missing flag values fall back to 30 s (TD-006, #175).
 func newCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 30*time.Second)
+	d := 30 * time.Second
+	if rootCmd != nil {
+		if raw, err := rootCmd.PersistentFlags().GetString("timeout"); err == nil && raw != "" {
+			if parsed, err := time.ParseDuration(raw); err == nil && parsed > 0 {
+				d = parsed
+			}
+		}
+	}
+	return context.WithTimeout(context.Background(), d)
 }
 
 // fmtAPIError formats an SDK API error response into a Go error (TD-001/TD-003).

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -816,4 +817,56 @@ func TestPrintYAML_MarshalError(t *testing.T) {
 	if !strings.Contains(buf.String(), "error marshalling to JSON for YAML conversion") {
 		t.Errorf("expected marshal error message, got: %s", buf.String())
 	}
+}
+
+func TestNewCtx_DefaultTimeout(t *testing.T) {
+	resetCmdFlags(rootCmd)
+	ctx, cancel := newCtx()
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected deadline to be set")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > 31*time.Second {
+		t.Errorf("expected ~30s deadline, got %v remaining", remaining)
+	}
+}
+
+func TestNewCtx_CustomTimeout(t *testing.T) {
+	resetCmdFlags(rootCmd)
+	if err := rootCmd.PersistentFlags().Set("timeout", "2m"); err != nil {
+		t.Fatalf("set timeout flag: %v", err)
+	}
+	t.Cleanup(func() { resetCmdFlags(rootCmd) })
+
+	ctx, cancel := newCtx()
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected deadline to be set")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 100*time.Second || remaining > 121*time.Second {
+		t.Errorf("expected ~2m deadline, got %v remaining", remaining)
+	}
+}
+
+func TestNewCtx_InvalidTimeoutFallsBackTo30s(t *testing.T) {
+	resetCmdFlags(rootCmd)
+	if err := rootCmd.PersistentFlags().Set("timeout", "not-a-duration"); err == nil {
+		// cobra rejects invalid values at Set time; if accepted, test fallback
+		ctx, cancel := newCtx()
+		defer cancel()
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected deadline to be set")
+		}
+		remaining := time.Until(deadline)
+		if remaining > 31*time.Second {
+			t.Errorf("invalid duration should fall back to 30s, got %v", remaining)
+		}
+	}
+	// cobra rejects non-duration values for String flags at parse time; that's fine.
+	resetCmdFlags(rootCmd)
 }


### PR DESCRIPTION
## Summary

- Adds `--timeout` as a global persistent flag on `rootCmd` (default `30s`).
- `newCtx()` reads the flag and parses it as `time.Duration`; falls back to 30s on invalid input.
- Three unit tests cover: default, custom (2m), and invalid-value fallback.

## Test plan

- [x] `TestNewCtx_DefaultTimeout`
- [x] `TestNewCtx_CustomTimeout`
- [x] `TestNewCtx_InvalidTimeoutFallsBackTo30s`
- [x] `make test-skip-client` passes

Closes #175

 Generated with [Claude Code](https://claude.com/claude-code)