### PR TITLE
feat(config): follow XDG Base Directory Specification for config file location

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -77,13 +77,63 @@ func init() {
 	configSetCmd.Flags().String("token-issuer-url", "", "Token issuer URL for authentication (optional, default: https://login.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token)")
 }
 
-// GetConfigPath returns the path to the config file
-func GetConfigPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
+// xdgConfigDir returns the XDG config home directory (#176).
+// Uses $XDG_CONFIG_HOME if set, otherwise falls back to $HOME/.config.
+func xdgConfigDir() (string, error) {
+	if d := os.Getenv("XDG_CONFIG_HOME"); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(homeDir, ".acloud.yaml"), nil
+	return filepath.Join(home, ".config"), nil
+}
+
+// GetConfigPath returns the XDG-compliant path to the config file (#176).
+// New path: $XDG_CONFIG_HOME/acloud/config.yaml (default: ~/.config/acloud/config.yaml).
+func GetConfigPath() (string, error) {
+	dir, err := xdgConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "acloud", "config.yaml"), nil
+}
+
+// legacyConfigPath returns the pre-XDG config path (~/.acloud.yaml).
+func legacyConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".acloud.yaml"), nil
+}
+
+// migrateLegacyConfig copies ~/.acloud.yaml → XDG path when the new file is
+// absent. Prints a one-time notice to stderr so the user is informed (#176).
+func migrateLegacyConfig() {
+	newPath, err := GetConfigPath()
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return // new file already exists; nothing to do
+	}
+	oldPath, err := legacyConfigPath()
+	if err != nil {
+		return
+	}
+	data, err := os.ReadFile(oldPath)
+	if err != nil {
+		return // old file absent; normal first-run case
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), FilePermDirAll); err != nil {
+		return
+	}
+	if err := os.WriteFile(newPath, data, FilePermConfig); err != nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "notice: config migrated from %s to %s\n", oldPath, newPath)
 }
 
 // LoadConfig loads the configuration from the config file, with env var overrides.
@@ -91,7 +141,9 @@ func GetConfigPath() (string, error) {
 // ACLOUD_TOKEN_ISSUER_URL take precedence over the config file when set.
 // If the config file is missing but credentials are supplied via env vars,
 // the file is not required and no error is returned.
+// Migrates legacy ~/.acloud.yaml to the XDG path on first load (#176).
 func LoadConfig() (*Config, error) {
+	migrateLegacyConfig()
 	configPath, err := GetConfigPath()
 	if err != nil {
 		return nil, err
@@ -140,11 +192,16 @@ func LoadConfig() (*Config, error) {
 	return config, nil
 }
 
-// SaveConfig saves the configuration to the config file
+// SaveConfig saves the configuration to the XDG config file, creating
+// the parent directory if it does not exist (#176).
 func SaveConfig(config *Config) error {
 	configPath, err := GetConfigPath()
 	if err != nil {
 		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), FilePermDirAll); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
 	}
 
 	data, err := yaml.Marshal(fileFromConfig(config))

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -14,17 +14,10 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	originalHome := os.Getenv("HOME")
-	originalUserProfile := os.Getenv("USERPROFILE")
-
 	tmpDir := t.TempDir()
-
-	os.Setenv("HOME", tmpDir)
-	os.Setenv("USERPROFILE", tmpDir)
-	defer func() {
-		os.Setenv("HOME", originalHome)
-		os.Setenv("USERPROFILE", originalUserProfile)
-	}()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "") // use HOME/.config, not CI's XDG dir
 
 	// Test with non-existent config
 	config, err := LoadConfig()
@@ -318,6 +311,7 @@ func TestConfigSetCmd_MissingClientID(t *testing.T) {
 	tmpDir := t.TempDir()
 	os.Setenv("HOME", tmpDir)
 	os.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "") // use HOME/.config, not CI's XDG dir
 	os.Unsetenv("ACLOUD_CLIENT_ID")
 	os.Setenv("ACLOUD_CLIENT_SECRET", "env-secret")
 	defer func() {
@@ -456,6 +450,7 @@ func TestConfigShowCmd_NoConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	os.Setenv("HOME", tmpDir)
 	os.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "") // use HOME/.config, not CI's XDG dir
 	defer func() {
 		os.Setenv("HOME", origHome)
 		os.Setenv("USERPROFILE", origUserProfile)
@@ -514,12 +509,19 @@ func withTempHome(t *testing.T) func() {
 	t.Helper()
 	origHome := os.Getenv("HOME")
 	origUserProfile := os.Getenv("USERPROFILE")
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
 	tmpDir := t.TempDir()
 	os.Setenv("HOME", tmpDir)
 	os.Setenv("USERPROFILE", tmpDir)
+	os.Unsetenv("XDG_CONFIG_HOME") // ensure HOME/.config is used, not CI's XDG dir
 	return func() {
 		os.Setenv("HOME", origHome)
 		os.Setenv("USERPROFILE", origUserProfile)
+		if origXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
 	}
 }
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -38,17 +37,8 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestSaveConfig(t *testing.T) {
-	originalHome := os.Getenv("HOME")
-	originalUserProfile := os.Getenv("USERPROFILE")
-
 	tmpDir := t.TempDir()
-
-	os.Setenv("HOME", tmpDir)
-	os.Setenv("USERPROFILE", tmpDir)
-	defer func() {
-		os.Setenv("HOME", originalHome)
-		os.Setenv("USERPROFILE", originalUserProfile)
-	}()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Create test config
 	testConfig := &Config{
@@ -62,10 +52,10 @@ func TestSaveConfig(t *testing.T) {
 		t.Fatalf("SaveConfig() error = %v", err)
 	}
 
-	// Verify file exists
-	configPath := filepath.Join(tmpDir, ".acloud.yaml")
+	// Verify file exists at XDG path
+	configPath := filepath.Join(tmpDir, "acloud", "config.yaml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		t.Fatal("SaveConfig() did not create config file")
+		t.Fatal("SaveConfig() did not create config file at XDG path")
 	}
 
 	// Load and verify
@@ -84,17 +74,8 @@ func TestSaveConfig(t *testing.T) {
 }
 
 func TestConfigPath(t *testing.T) {
-	originalHome := os.Getenv("HOME")
-	originalUserProfile := os.Getenv("USERPROFILE")
-
 	tmpDir := t.TempDir()
-
-	os.Setenv("HOME", tmpDir)
-	os.Setenv("USERPROFILE", tmpDir)
-	defer func() {
-		os.Setenv("HOME", originalHome)
-		os.Setenv("USERPROFILE", originalUserProfile)
-	}()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Get config path
 	configPath, err := GetConfigPath()
@@ -102,31 +83,24 @@ func TestConfigPath(t *testing.T) {
 		t.Fatalf("GetConfigPath() error = %v", err)
 	}
 
-	expectedPath := filepath.Join(tmpDir, ".acloud.yaml")
+	// XDG path: $XDG_CONFIG_HOME/acloud/config.yaml
+	expectedPath := filepath.Join(tmpDir, "acloud", "config.yaml")
 	if configPath != expectedPath {
 		t.Errorf("GetConfigPath() = %v, want %v", configPath, expectedPath)
 	}
 }
 
 func TestLoadConfig_InvalidYAML(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("os.UserHomeDir() on Windows uses Win32 API, not HOME env var")
-	}
-	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE")
-	}
-
 	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
-
-	configPath := filepath.Join(tmpDir, ".acloud.yaml")
-	invalidYAML := "this is not valid yaml: ["
-	err := os.WriteFile(configPath, []byte(invalidYAML), 0600)
-	if err != nil {
-		t.Fatalf("Failed to write invalid YAML: %v", err)
+	// Write invalid YAML to the XDG path, creating the directory first.
+	xdgPath := filepath.Join(tmpDir, "acloud", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(xdgPath, []byte("this is not valid yaml: ["), 0600); err != nil {
+		t.Fatalf("write: %v", err)
 	}
 
 	config, err := LoadConfig()
@@ -205,25 +179,15 @@ func TestSaveConfig_PartialConfig(t *testing.T) {
 }
 
 func TestGetConfigPath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("os.UserHomeDir() on Windows uses Win32 API, not HOME env var")
-	}
-	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE")
-	}
-
 	tmpDir := t.TempDir()
-
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	configPath, err := GetConfigPath()
 	if err != nil {
 		t.Fatalf("GetConfigPath() error = %v", err)
 	}
 
-	expectedPath := filepath.Join(tmpDir, ".acloud.yaml")
+	expectedPath := filepath.Join(tmpDir, "acloud", "config.yaml")
 	if configPath != expectedPath {
 		t.Errorf("GetConfigPath() = %v, want %v", configPath, expectedPath)
 	}
@@ -715,5 +679,51 @@ func TestConfigShow_Operation_NoConfig(t *testing.T) {
 
 	if !strings.Contains(out, "No configuration found") {
 		t.Errorf("expected no-config message, got: %s", out)
+	}
+}
+
+func TestMigrateLegacyConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping migration test in short mode")
+	}
+	tmpHome := t.TempDir()
+	tmpXDG := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", tmpXDG)
+
+	// Write a legacy config at ~/.acloud.yaml
+	legacyPath := filepath.Join(tmpHome, ".acloud.yaml")
+	legacyYAML := "clientId: migrated-id\nclientSecret: migrated-secret\n"
+	if err := os.WriteFile(legacyPath, []byte(legacyYAML), 0600); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	// Calling LoadConfig should trigger migration to XDG path
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() after migration: %v", err)
+	}
+	if cfg.ClientID != "migrated-id" {
+		t.Errorf("ClientID = %q, want migrated-id", cfg.ClientID)
+	}
+
+	// New XDG file must exist
+	newPath := filepath.Join(tmpXDG, "acloud", "config.yaml")
+	if _, err := os.Stat(newPath); os.IsNotExist(err) {
+		t.Error("migrateLegacyConfig() did not create XDG config file")
+	}
+}
+
+func TestGetConfigPath_XDGEnvVar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	got, err := GetConfigPath()
+	if err != nil {
+		t.Fatalf("GetConfigPath(): %v", err)
+	}
+	want := filepath.Join(tmpDir, "acloud", "config.yaml")
+	if got != want {
+		t.Errorf("GetConfigPath() = %q, want %q", got, want)
 	}
 }

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -63,8 +63,10 @@ var contextDeleteCmd = &cobra.Command{
 	RunE:  ContextDeleteRun,
 }
 
-// LoadContext loads the context configuration
+// LoadContext loads the context configuration.
+// Migrates legacy ~/.acloud-context.yaml to the XDG path on first load (#176).
 func LoadContext() (*Context, error) {
+	migrateLegacyContext()
 	contextFile, err := getContextFilePath()
 	if err != nil {
 		return nil, err
@@ -122,13 +124,49 @@ func GetCurrentProjectID() (string, error) {
 	return info.ProjectID, nil
 }
 
-// getContextFilePath returns the path to the context file (TD-007).
+// getContextFilePath returns the XDG-compliant path to the context file (#176, TD-007).
+// New path: $XDG_CONFIG_HOME/acloud/context.yaml (default: ~/.config/acloud/context.yaml).
 func getContextFilePath() (string, error) {
+	dir, err := xdgConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine XDG config directory: %w", err)
+	}
+	return filepath.Join(dir, "acloud", "context.yaml"), nil
+}
+
+// legacyContextPath returns the pre-XDG context path (~/.acloud-context.yaml).
+func legacyContextPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("cannot determine home directory: %w", err)
+		return "", err
 	}
 	return filepath.Join(home, ".acloud-context.yaml"), nil
+}
+
+// migrateLegacyContext copies ~/.acloud-context.yaml → XDG path when absent (#176).
+func migrateLegacyContext() {
+	newPath, err := getContextFilePath()
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return
+	}
+	oldPath, err := legacyContextPath()
+	if err != nil {
+		return
+	}
+	data, err := os.ReadFile(oldPath)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), FilePermDirAll); err != nil {
+		return
+	}
+	if err := os.WriteFile(newPath, data, FilePermConfig); err != nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "notice: context migrated from %s to %s\n", oldPath, newPath)
 }
 
 func init() {

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -285,12 +285,19 @@ func withTempHomeDir(t *testing.T) (cleanup func()) {
 	t.Helper()
 	origHome := os.Getenv("HOME")
 	origUserProfile := os.Getenv("USERPROFILE")
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
 	tmpDir := t.TempDir()
 	os.Setenv("HOME", tmpDir)
 	os.Setenv("USERPROFILE", tmpDir)
+	os.Unsetenv("XDG_CONFIG_HOME") // ensure $HOME/.config is used, not a pre-set XDG dir
 	return func() {
 		os.Setenv("HOME", origHome)
 		os.Setenv("USERPROFILE", origUserProfile)
+		if origXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
 	}
 }
 

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -36,17 +35,8 @@ func TestLoadContext(t *testing.T) {
 }
 
 func TestSaveContext(t *testing.T) {
-	originalHome := os.Getenv("HOME")
-	originalUserProfile := os.Getenv("USERPROFILE")
-
 	tmpDir := t.TempDir()
-
-	os.Setenv("HOME", tmpDir)
-	os.Setenv("USERPROFILE", tmpDir)
-	defer func() {
-		os.Setenv("HOME", originalHome)
-		os.Setenv("USERPROFILE", originalUserProfile)
-	}()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	// Create test context
 	testContext := &Context{
@@ -64,10 +54,10 @@ func TestSaveContext(t *testing.T) {
 		t.Fatalf("SaveContext() error = %v", err)
 	}
 
-	// Verify file exists
-	contextPath := filepath.Join(tmpDir, ".acloud-context.yaml")
+	// Verify file exists at XDG path
+	contextPath := filepath.Join(tmpDir, "acloud", "context.yaml")
 	if _, err := os.Stat(contextPath); os.IsNotExist(err) {
-		t.Fatal("SaveContext() did not create context file")
+		t.Fatal("SaveContext() did not create context file at XDG path")
 	}
 
 	// Load and verify
@@ -134,24 +124,16 @@ func TestGetCurrentProjectID(t *testing.T) {
 }
 
 func TestLoadContext_InvalidYAML(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("os.UserHomeDir() on Windows uses Win32 API, not HOME env var")
-	}
-	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE")
-	}
-
 	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
-
-	contextPath := filepath.Join(tmpDir, ".acloud-context.yaml")
-	invalidYAML := "this is not valid yaml: ["
-	err := os.WriteFile(contextPath, []byte(invalidYAML), 0600)
-	if err != nil {
-		t.Fatalf("Failed to write invalid YAML: %v", err)
+	// Write invalid YAML to the XDG path, creating the directory first.
+	xdgPath := filepath.Join(tmpDir, "acloud", "context.yaml")
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(xdgPath, []byte("this is not valid yaml: ["), 0600); err != nil {
+		t.Fatalf("write: %v", err)
 	}
 
 	ctx, err := LoadContext()

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// TestMain clears XDG_CONFIG_HOME before any test in this package runs.
+// Tests that need a specific XDG directory set it explicitly via t.Setenv.
+// Without this, CI runners that have XDG_CONFIG_HOME pointing at a real config
+// dir cause _NoProjectID tests to find an actual context file, making them pass
+// the GetProjectID call when they expect it to fail.
+func TestMain(m *testing.M) {
+	os.Unsetenv("XDG_CONFIG_HOME")
+	os.Exit(m.Run())
+}
+
 // ─── httptest harness ─────────────────────────────────────────────────────────
 
 // arubaTestServer is an httptest-backed fake Aruba API. Tests register routes

--- a/cmd/root_getprojectid_test.go
+++ b/cmd/root_getprojectid_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -115,46 +114,17 @@ func TestGetProjectID_FlagTakesPrecedence(t *testing.T) {
 }
 
 func TestGetProjectID_NoFlagNoContext(t *testing.T) {
-	// Save original home dir
-	originalHome := os.Getenv("HOME")
-	originalUserProfile := os.Getenv("USERPROFILE")
-	if originalHome == "" {
-		originalHome = originalUserProfile // Windows
-	}
-
-	// Create temporary directory for test
 	tmpDir := t.TempDir()
-
-	// Set both HOME and USERPROFILE to temp directory (for cross-platform compatibility)
-	os.Setenv("HOME", tmpDir)
-	os.Setenv("USERPROFILE", tmpDir)
-	defer func() {
-		if originalHome != "" {
-			os.Setenv("HOME", originalHome)
-		}
-		if originalUserProfile != "" {
-			os.Setenv("USERPROFILE", originalUserProfile)
-		}
-		// Clear client cache to avoid interference
-		resetClientState()
-	}()
-
-	// Ensure no context file exists in temp dir
-	contextPath := filepath.Join(tmpDir, ".acloud-context.yaml")
-	_ = os.Remove(contextPath) // Ignore error if file doesn't exist
-
-	// Also ensure no context file exists in actual home (in case of test pollution)
-	actualHome, _ := os.UserHomeDir()
-	if actualHome != "" && actualHome != tmpDir {
-		actualContextPath := filepath.Join(actualHome, ".acloud-context.yaml")
-		_ = os.Remove(actualContextPath) // Ignore error
-	}
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "") // clear so HOME/.config is used, not CI's XDG dir
+	t.Cleanup(resetClientState)
 
 	// Create command without project-id flag set
 	cmd := &cobra.Command{}
 	cmd.Flags().String("project-id", "", "Project ID")
 
-	// Should return error
+	// Should return error: no --project-id and no context file in empty tmpDir
 	projectID, err := GetProjectID(cmd)
 	if err == nil {
 		t.Error("GetProjectID() should return error when no flag and no context")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -35,36 +34,36 @@ func contains(s, substr string) bool {
 // setupMockConfig creates a temporary config file for testing
 func setupMockConfig(t *testing.T) (string, func()) {
 	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, ".acloud.yaml")
 
-	// Save original HOME
+	// Save originals and redirect HOME + XDG for full config isolation.
 	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE")
-	}
+	originalUserProfile := os.Getenv("USERPROFILE")
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
 
-	// Set HOME to temp directory
 	os.Setenv("HOME", tmpDir)
-	if os.Getenv("USERPROFILE") != "" {
-		os.Setenv("USERPROFILE", tmpDir)
-	}
+	os.Setenv("USERPROFILE", tmpDir)
+	os.Unsetenv("XDG_CONFIG_HOME") // ensure HOME/.config is used, not CI's XDG dir
 
-	// Create mock config
+	// Create mock config (written to the now-XDG-resolved path).
 	config := &Config{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
 	}
-	err := SaveConfig(config)
-	if err != nil {
+	if err := SaveConfig(config); err != nil {
 		t.Fatalf("Failed to create mock config: %v", err)
 	}
 
-	// Cleanup function
+	// configPath is the XDG path; callers that care should use GetConfigPath().
+	configPath, _ := GetConfigPath()
+
 	cleanup := func() {
-		if originalHome != "" {
-			os.Setenv("HOME", originalHome)
+		os.Setenv("HOME", originalHome)
+		os.Setenv("USERPROFILE", originalUserProfile)
+		if originalXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
 		}
-		// Clear client cache
 		resetClientState()
 	}
 
@@ -113,25 +112,11 @@ func TestGetArubaClient_Caching(t *testing.T) {
 }
 
 func TestGetArubaClient_NoConfig(t *testing.T) {
-	// Save original HOME
-	originalHome := os.Getenv("HOME")
-	if originalHome == "" {
-		originalHome = os.Getenv("USERPROFILE")
-	}
-
-	// Create temporary directory without config
 	tmpDir := t.TempDir()
-	os.Setenv("HOME", tmpDir)
-	if os.Getenv("USERPROFILE") != "" {
-		os.Setenv("USERPROFILE", tmpDir)
-	}
-	defer func() {
-		if originalHome != "" {
-			os.Setenv("HOME", originalHome)
-		}
-		// Clear client cache
-		resetClientState()
-	}()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "") // clear so HOME/.config is used
+	t.Cleanup(resetClientState)
 
 	client, err := GetArubaClient()
 	if err == nil {
@@ -141,9 +126,7 @@ func TestGetArubaClient_NoConfig(t *testing.T) {
 		t.Error("GetArubaClient() should return nil client when config doesn't exist")
 	}
 
-	// Verify error message
-	errMsg := err.Error()
-	if !contains(errMsg, "failed to load configuration") {
+	if !contains(err.Error(), "failed to load configuration") {
 		t.Errorf("Expected error about failed to load configuration, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `GetConfigPath()` now returns `$XDG_CONFIG_HOME/acloud/config.yaml` (fallback: `~/.config/acloud/config.yaml`)
- `getContextFilePath()` now returns `$XDG_CONFIG_HOME/acloud/context.yaml`
- `SaveConfig`/`SaveContext` auto-create the parent directory on write
- `migrateLegacyConfig`/`migrateLegacyContext` silently copy `~/.acloud.yaml` and `~/.acloud-context.yaml` to the XDG paths on first load, printing a one-line notice to stderr
- All tests updated to use `t.Setenv("XDG_CONFIG_HOME", ...)` for isolation

## Test plan

- [x] `TestMigrateLegacyConfig` - verifies legacy file is copied to XDG path
- [x] `TestGetConfigPath_XDGEnvVar` - verifies env var is respected
- [x] `TestSaveConfig`, `TestSaveContext` - file at XDG path
- [x] Full `make test-skip-client` passes

Closes #176

 Generated with [Claude Code](https://claude.com/claude-code)