### PR TITLE
perf(completion): cache shell completion API responses with TTL

### DIFF
--- a/cmd/completion_cache.go
+++ b/cmd/completion_cache.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// completionCacheOverride is an in-memory override used in tests to prevent
+// cross-test cache pollution. When non-nil, disk I/O is bypassed entirely.
+var completionCacheOverride map[string][]string
+var completionCacheOverrideMu sync.Mutex
+
+// completionCacheReset clears the in-memory cache override, forcing the next
+// call to completionCacheGet to miss. Called from resetClientState during tests.
+func completionCacheReset() {
+	completionCacheOverrideMu.Lock()
+	defer completionCacheOverrideMu.Unlock()
+	completionCacheOverride = make(map[string][]string)
+}
+
+// completionCacheEntry is the on-disk shape of a completion cache file.
+type completionCacheEntry struct {
+	Entries  []string `json:"entries"`
+	CachedAt string   `json:"cachedAt"`
+}
+
+// xdgCacheDir returns $XDG_CACHE_HOME, falling back to ~/.cache (#179).
+func xdgCacheDir() (string, error) {
+	if d := os.Getenv("XDG_CACHE_HOME"); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache"), nil
+}
+
+// completionCachePath returns the cache file path for a given resource key.
+// The key should be stable and safe for use in a filename (no slashes).
+func completionCachePath(key string) (string, error) {
+	dir, err := xdgCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "acloud", "completion", key+".json"), nil
+}
+
+// completionTTL returns the configured TTL from ACLOUD_COMPLETION_CACHE_TTL
+// (default 60 s) (#179).
+func completionTTL() time.Duration {
+	if raw := os.Getenv("ACLOUD_COMPLETION_CACHE_TTL"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 60 * time.Second
+}
+
+// completionCacheGet returns cached entries for key if they are within the TTL.
+// Returns nil, nil on any miss (file absent, expired, or unreadable).
+// When the in-memory override is active (set by completionCacheReset in tests),
+// disk I/O is bypassed.
+func completionCacheGet(key string) ([]string, error) {
+	completionCacheOverrideMu.Lock()
+	override := completionCacheOverride
+	completionCacheOverrideMu.Unlock()
+	if override != nil {
+		if entries, ok := override[key]; ok {
+			return entries, nil
+		}
+		return nil, nil
+	}
+
+	path, err := completionCachePath(key)
+	if err != nil {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil
+	}
+	var entry completionCacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, nil
+	}
+	cachedAt, err := time.Parse(time.RFC3339, entry.CachedAt)
+	if err != nil || time.Since(cachedAt) > completionTTL() {
+		return nil, nil
+	}
+	return entry.Entries, nil
+}
+
+// completionCachePut writes entries to the cache for key. Errors are silently
+// discarded — a failed write degrades to no-cache, not a hard failure.
+// When the in-memory override is active (set by completionCacheReset in tests),
+// disk I/O is bypassed.
+func completionCachePut(key string, entries []string) {
+	completionCacheOverrideMu.Lock()
+	override := completionCacheOverride
+	completionCacheOverrideMu.Unlock()
+	if override != nil {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride[key] = entries
+		completionCacheOverrideMu.Unlock()
+		return
+	}
+
+	path, err := completionCachePath(key)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return
+	}
+	entry := completionCacheEntry{
+		Entries:  entries,
+		CachedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0600)
+}
+
+// cacheKey builds a canonical cache key from a resource name and additional
+// identifiers (project ID, parent resource IDs). Segments are joined with "-"
+// after stripping any path-unsafe characters.
+func cacheKey(parts ...string) string {
+	safe := make([]string, 0, len(parts))
+	for _, p := range parts {
+		// Replace non-alphanumeric runs with "_" to keep filenames safe.
+		var b strings.Builder
+		prevSafe := false
+		for _, r := range p {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+				b.WriteRune(r)
+				prevSafe = true
+			} else if prevSafe {
+				b.WriteRune('_')
+				prevSafe = false
+			}
+		}
+		s := strings.Trim(b.String(), "_-")
+		if s != "" {
+			safe = append(safe, s)
+		}
+	}
+	return strings.Join(safe, "-")
+}
+
+// filterCompletions returns entries whose ID portion starts with prefix.
+// If prefix is empty all entries are returned. The ID portion is the text
+// before the first tab (the description separator used by Cobra).
+func filterCompletions(entries []string, prefix string) []string {
+	if prefix == "" {
+		return entries
+	}
+	out := entries[:0:0] // nil-safe empty slice
+	for _, e := range entries {
+		id := e
+		if idx := strings.IndexByte(e, '\t'); idx >= 0 {
+			id = e[:idx]
+		}
+		if strings.HasPrefix(id, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/cmd/completion_cache_test.go
+++ b/cmd/completion_cache_test.go
@@ -1,0 +1,328 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── xdgCacheDir ─────────────────────────────────────────────────────────────
+
+func TestXDGCacheDir_EnvVar(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	got, err := xdgCacheDir()
+	if err != nil {
+		t.Fatalf("xdgCacheDir() error: %v", err)
+	}
+	if got != tmp {
+		t.Errorf("xdgCacheDir() = %q, want %q", got, tmp)
+	}
+}
+
+func TestXDGCacheDir_FallbackToHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", tmp)
+
+	got, err := xdgCacheDir()
+	if err != nil {
+		t.Fatalf("xdgCacheDir() error: %v", err)
+	}
+	want := filepath.Join(tmp, ".cache")
+	if got != want {
+		t.Errorf("xdgCacheDir() = %q, want %q", got, want)
+	}
+}
+
+// ─── completionCachePath ─────────────────────────────────────────────────────
+
+func TestCompletionCachePath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	got, err := completionCachePath("vpc-proj-123")
+	if err != nil {
+		t.Fatalf("completionCachePath() error: %v", err)
+	}
+	want := filepath.Join(tmp, "acloud", "completion", "vpc-proj-123.json")
+	if got != want {
+		t.Errorf("completionCachePath() = %q, want %q", got, want)
+	}
+}
+
+// ─── completionTTL ───────────────────────────────────────────────────────────
+
+func TestCompletionTTL_Default(t *testing.T) {
+	t.Setenv("ACLOUD_COMPLETION_CACHE_TTL", "")
+	if got := completionTTL(); got != 60*time.Second {
+		t.Errorf("completionTTL() = %v, want 60s", got)
+	}
+}
+
+func TestCompletionTTL_EnvVar(t *testing.T) {
+	t.Setenv("ACLOUD_COMPLETION_CACHE_TTL", "5m")
+	if got := completionTTL(); got != 5*time.Minute {
+		t.Errorf("completionTTL() = %v, want 5m", got)
+	}
+}
+
+func TestCompletionTTL_InvalidFallsBack(t *testing.T) {
+	t.Setenv("ACLOUD_COMPLETION_CACHE_TTL", "not-a-duration")
+	if got := completionTTL(); got != 60*time.Second {
+		t.Errorf("completionTTL() with invalid env = %v, want 60s fallback", got)
+	}
+}
+
+func TestCompletionTTL_ZeroFallsBack(t *testing.T) {
+	t.Setenv("ACLOUD_COMPLETION_CACHE_TTL", "0s")
+	if got := completionTTL(); got != 60*time.Second {
+		t.Errorf("completionTTL() with 0s env = %v, want 60s fallback", got)
+	}
+}
+
+// ─── completionCacheGet / completionCachePut (disk path) ─────────────────────
+
+func TestCompletionCache_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	// Disable the in-memory override so we exercise disk I/O.
+	completionCacheOverrideMu.Lock()
+	prev := completionCacheOverride
+	completionCacheOverride = nil
+	completionCacheOverrideMu.Unlock()
+	t.Cleanup(func() {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride = prev
+		completionCacheOverrideMu.Unlock()
+	})
+
+	entries := []string{"vol-001\tmy-volume", "vol-002\tother-volume"}
+	completionCachePut("blockstorage-proj-123", entries)
+
+	got, err := completionCacheGet("blockstorage-proj-123")
+	if err != nil {
+		t.Fatalf("completionCacheGet() error: %v", err)
+	}
+	if len(got) != 2 || got[0] != entries[0] || got[1] != entries[1] {
+		t.Errorf("round-trip mismatch: got %v, want %v", got, entries)
+	}
+}
+
+func TestCompletionCacheGet_Miss(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	completionCacheOverrideMu.Lock()
+	prev := completionCacheOverride
+	completionCacheOverride = nil
+	completionCacheOverrideMu.Unlock()
+	t.Cleanup(func() {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride = prev
+		completionCacheOverrideMu.Unlock()
+	})
+
+	got, err := completionCacheGet("nonexistent-key")
+	if err != nil || got != nil {
+		t.Errorf("expected nil, nil on cache miss; got %v, %v", got, err)
+	}
+}
+
+func TestCompletionCacheGet_Expired(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	t.Setenv("ACLOUD_COMPLETION_CACHE_TTL", "1ms")
+	completionCacheOverrideMu.Lock()
+	prev := completionCacheOverride
+	completionCacheOverride = nil
+	completionCacheOverrideMu.Unlock()
+	t.Cleanup(func() {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride = prev
+		completionCacheOverrideMu.Unlock()
+	})
+
+	// Write a cache file with an old timestamp.
+	path := filepath.Join(tmp, "acloud", "completion", "stale-key.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	stale := completionCacheEntry{
+		Entries:  []string{"id-001\tname"},
+		CachedAt: time.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(stale)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := completionCacheGet("stale-key")
+	if err != nil || got != nil {
+		t.Errorf("expected nil on expired entry; got %v, %v", got, err)
+	}
+}
+
+func TestCompletionCacheGet_CorruptJSON(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	completionCacheOverrideMu.Lock()
+	prev := completionCacheOverride
+	completionCacheOverride = nil
+	completionCacheOverrideMu.Unlock()
+	t.Cleanup(func() {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride = prev
+		completionCacheOverrideMu.Unlock()
+	})
+
+	path := filepath.Join(tmp, "acloud", "completion", "bad-key.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not json {{{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := completionCacheGet("bad-key")
+	if err != nil || got != nil {
+		t.Errorf("expected nil on corrupt JSON; got %v, %v", got, err)
+	}
+}
+
+func TestCompletionCacheGet_BadTimestamp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	completionCacheOverrideMu.Lock()
+	prev := completionCacheOverride
+	completionCacheOverride = nil
+	completionCacheOverrideMu.Unlock()
+	t.Cleanup(func() {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride = prev
+		completionCacheOverrideMu.Unlock()
+	})
+
+	path := filepath.Join(tmp, "acloud", "completion", "badts-key.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	bad := completionCacheEntry{Entries: []string{"id\tname"}, CachedAt: "not-a-time"}
+	data, _ := json.Marshal(bad)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := completionCacheGet("badts-key")
+	if got != nil {
+		t.Errorf("expected nil on bad timestamp, got %v", got)
+	}
+}
+
+// ─── cacheKey ────────────────────────────────────────────────────────────────
+
+func TestCacheKey(t *testing.T) {
+	cases := []struct {
+		parts []string
+		want  string
+	}{
+		{[]string{"vpc", "proj-123"}, "vpc-proj-123"},
+		{[]string{"blockstorage", "p1"}, "blockstorage-p1"},
+		{[]string{"database", "proj/abc", "dbaas-01"}, "database-proj_abc-dbaas-01"},
+		{[]string{"grant", "p1", "d1", "db name"}, "grant-p1-d1-db_name"},
+		{[]string{"", "p1"}, "p1"},
+		{[]string{"project"}, "project"},
+	}
+	for _, c := range cases {
+		got := cacheKey(c.parts...)
+		if got != c.want {
+			t.Errorf("cacheKey(%v) = %q, want %q", c.parts, got, c.want)
+		}
+	}
+}
+
+// ─── filterCompletions ───────────────────────────────────────────────────────
+
+func TestFilterCompletions(t *testing.T) {
+	entries := []string{"aaa-001\tname-a", "bbb-002\tname-b", "aaa-003\tname-c"}
+
+	t.Run("empty prefix returns all", func(t *testing.T) {
+		got := filterCompletions(entries, "")
+		if len(got) != 3 {
+			t.Errorf("expected 3, got %d", len(got))
+		}
+	})
+
+	t.Run("prefix match", func(t *testing.T) {
+		got := filterCompletions(entries, "aaa")
+		if len(got) != 2 {
+			t.Errorf("expected 2 for prefix 'aaa', got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		got := filterCompletions(entries, "zzz")
+		if len(got) != 0 {
+			t.Errorf("expected 0 for prefix 'zzz', got %d", len(got))
+		}
+	})
+
+	t.Run("entry without tab uses full string", func(t *testing.T) {
+		got := filterCompletions([]string{"bare-id"}, "bare")
+		if len(got) != 1 || got[0] != "bare-id" {
+			t.Errorf("unexpected result: %v", got)
+		}
+	})
+
+	t.Run("nil entries returns nil-safe empty", func(t *testing.T) {
+		got := filterCompletions(nil, "x")
+		if got == nil {
+			// filterCompletions uses entries[:0:0] — result for nil input with non-empty prefix
+			// is an empty non-nil slice or nil; either is acceptable.
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 results for nil entries, got %d", len(got))
+		}
+	})
+}
+
+// ─── in-memory override path ─────────────────────────────────────────────────
+
+func TestCompletionCacheOverride_HitAndMiss(t *testing.T) {
+	// Activate the in-memory override (mimics what resetClientState does in tests).
+	completionCacheReset()
+	t.Cleanup(func() {
+		completionCacheOverrideMu.Lock()
+		completionCacheOverride = nil
+		completionCacheOverrideMu.Unlock()
+	})
+
+	// Miss before any Put.
+	got, _ := completionCacheGet("k1")
+	if got != nil {
+		t.Errorf("expected miss before Put, got %v", got)
+	}
+
+	// Put then Get.
+	completionCachePut("k1", []string{"id-1\tname-1"})
+	got, _ = completionCacheGet("k1")
+	if len(got) != 1 || got[0] != "id-1\tname-1" {
+		t.Errorf("in-memory round-trip failed: %v", got)
+	}
+}
+
+// ─── cacheKey special characters ─────────────────────────────────────────────
+
+func TestCacheKey_SpecialChars(t *testing.T) {
+	// Slashes, spaces, and other unsafe chars are stripped/replaced.
+	got := cacheKey("res", "proj/with spaces!")
+	if strings.Contains(got, "/") || strings.Contains(got, " ") || strings.Contains(got, "!") {
+		t.Errorf("cacheKey produced unsafe filename: %q", got)
+	}
+	if got == "" {
+		t.Errorf("cacheKey returned empty string for non-empty input")
+	}
+}

--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -99,6 +99,11 @@ func completeCloudServerID(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("cloudserver", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -122,13 +127,12 @@ func completeCloudServerID(cmd *cobra.Command, args []string, toComplete string)
 			if raw.Metadata.Name != nil {
 				name = *raw.Metadata.Name
 			}
-			if toComplete == "" || strings.HasPrefix(id, toComplete) {
-				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
-			}
+			completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // CloudServer subcommands

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -62,6 +61,11 @@ func completeKeyPairID(cmd *cobra.Command, args []string, toComplete string) ([]
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("keypair", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -77,13 +81,14 @@ func completeKeyPairID(cmd *cobra.Command, args []string, toComplete string) ([]
 	if list != nil {
 		for _, kp := range list.Items() {
 			name := kp.Name()
-			if toComplete == "" || strings.HasPrefix(name, toComplete) {
+			if name != "" {
 				completions = append(completions, fmt.Sprintf("%s\tKeypair", name))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // KeyPair subcommands

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -72,6 +71,11 @@ func completeContainerRegistryID(cmd *cobra.Command, args []string, toComplete s
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("container-registry", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -87,13 +91,14 @@ func completeContainerRegistryID(cmd *cobra.Command, args []string, toComplete s
 	if list != nil {
 		for _, cr := range list.Items() {
 			id := cr.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, cr.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var containerregistryCmd = &cobra.Command{

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -106,6 +105,11 @@ func completeKaaSID(cmd *cobra.Command, args []string, toComplete string) ([]str
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("kaas", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -121,13 +125,14 @@ func completeKaaSID(cmd *cobra.Command, args []string, toComplete string) ([]str
 	if list != nil {
 		for _, k := range list.Items() {
 			id := k.KaaSID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, k.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var kaasCmd = &cobra.Command{

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -56,6 +55,11 @@ func completeDatabaseBackupID(cmd *cobra.Command, args []string, toComplete stri
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("database-backup", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -71,13 +75,14 @@ func completeDatabaseBackupID(cmd *cobra.Command, args []string, toComplete stri
 	if list != nil {
 		for _, backup := range list.Items() {
 			id := backup.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, backup.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var backupCmd = &cobra.Command{

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -50,12 +49,17 @@ func completeDBaaSDatabaseID(cmd *cobra.Command, args []string, toComplete strin
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	dbaasID := args[0]
+
+	key := cacheKey("database", projectID, dbaasID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
-	dbaasID := args[0]
 
 	ctx := context.Background()
 	list, err := client.FromDatabase().Databases().List(ctx, dbaasRef(projectID, dbaasID))
@@ -68,14 +72,13 @@ func completeDBaaSDatabaseID(cmd *cobra.Command, args []string, toComplete strin
 		for _, db := range list.Items() {
 			raw := db.Raw()
 			if raw != nil && raw.Name != "" {
-				if toComplete == "" || strings.HasPrefix(raw.Name, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", raw.Name, raw.Name))
-				}
+				completions = append(completions, fmt.Sprintf("%s\t%s", raw.Name, raw.Name))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var dbaasDatabaseCmd = &cobra.Command{

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -74,6 +73,11 @@ func completeDBaaSID(cmd *cobra.Command, args []string, toComplete string) ([]st
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("dbaas", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -89,13 +93,14 @@ func completeDBaaSID(cmd *cobra.Command, args []string, toComplete string) ([]st
 	if list != nil {
 		for _, d := range list.Items() {
 			id := d.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, d.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var dbaasCmd = &cobra.Command{

--- a/cmd/database.dbaas.grant.go
+++ b/cmd/database.dbaas.grant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -54,11 +53,17 @@ func completeGrantID(cmd *cobra.Command, args []string, toComplete string) ([]st
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+	dbaasID, dbName := args[0], args[1]
+
+	key := cacheKey("grant", projectID, dbaasID, dbName)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	dbaasID, dbName := args[0], args[1]
 	ctx := context.Background()
 	list, err := client.FromDatabase().Grants().List(ctx, databaseRef(projectID, dbaasID, dbName))
 	if err != nil {
@@ -68,12 +73,11 @@ func completeGrantID(cmd *cobra.Command, args []string, toComplete string) ([]st
 	if list != nil {
 		for _, g := range list.Items() {
 			id := g.ID()
-			if toComplete == "" || strings.HasPrefix(id, toComplete) {
-				completions = append(completions, fmt.Sprintf("%s\t%s→%s", id, g.Username(), g.RoleName()))
-			}
+			completions = append(completions, fmt.Sprintf("%s\t%s→%s", id, g.Username(), g.RoleName()))
 		}
 	}
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var dbaasGrantCmd = &cobra.Command{

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -59,12 +58,17 @@ func completeDBaaSUserID(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	dbaasID := args[0]
+
+	key := cacheKey("dbaas-user", projectID, dbaasID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
-	dbaasID := args[0]
 
 	ctx := context.Background()
 	list, err := client.FromDatabase().Users().List(ctx, dbaasRef(projectID, dbaasID))
@@ -77,14 +81,13 @@ func completeDBaaSUserID(cmd *cobra.Command, args []string, toComplete string) (
 		for _, user := range list.Items() {
 			raw := user.Raw()
 			if raw != nil && raw.Username != "" {
-				if toComplete == "" || strings.HasPrefix(raw.Username, toComplete) {
-					completions = append(completions, fmt.Sprintf("%s\t%s", raw.Username, raw.Username))
-				}
+				completions = append(completions, fmt.Sprintf("%s\t%s", raw.Username, raw.Username))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var dbaasUserCmd = &cobra.Command{

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -48,6 +47,11 @@ func init() {
 func completeProjectID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Allow completion even if args exist - user might be completing a partial ID
 
+	key := cacheKey("project")
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	// Get SDK client
 	client, err := GetArubaClient()
 	if err != nil {
@@ -66,15 +70,15 @@ func completeProjectID(cmd *cobra.Command, args []string, toComplete string) ([]
 		for _, p := range list.Items() {
 			id := p.ID()
 			name := p.Name()
-			// Filter by partial input - use HasPrefix for more reliable matching
-			if toComplete == "" || strings.HasPrefix(id, toComplete) {
+			if id != "" {
 				// Format: "id\tname" - the tab separates the completion from the description
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, name))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var projectCmd = &cobra.Command{

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -52,6 +51,11 @@ func completeElasticIPID(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("elasticip", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -67,13 +71,14 @@ func completeElasticIPID(cmd *cobra.Command, args []string, toComplete string) (
 	if list != nil {
 		for _, eip := range list.Items() {
 			id := eip.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, eip.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // ElasticIP subcommands

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -39,6 +38,11 @@ func completeLoadBalancerID(cmd *cobra.Command, args []string, toComplete string
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("loadbalancer", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -54,13 +58,14 @@ func completeLoadBalancerID(cmd *cobra.Command, args []string, toComplete string
 	if list != nil {
 		for _, lb := range list.Items() {
 			id := lb.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, lb.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // LoadBalancer subcommands

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -71,13 +70,18 @@ func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	vpcID := args[0]
+	securityGroupID := args[1]
+
+	key := cacheKey("security-rule", projectID, vpcID, securityGroupID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
-	vpcID := args[0]
-	securityGroupID := args[1]
 
 	ctx := context.Background()
 	list, err := client.FromNetwork().SecurityGroupRules().List(ctx, aruba.SecurityGroupRef(projectID, vpcID, securityGroupID))
@@ -89,13 +93,14 @@ func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string
 	if list != nil {
 		for _, rule := range list.Items() {
 			id := rule.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, rule.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // SecurityRule subcommands

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -53,6 +52,11 @@ func completeVPCID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("vpc", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -68,13 +72,14 @@ func completeVPCID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	if list != nil {
 		for _, vpc := range list.Items() {
 			id := vpc.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, vpc.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // VPC subcommands

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -68,13 +67,18 @@ func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete str
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	vpcID := args[0]
+	vpcPeeringID := args[1]
+
+	key := cacheKey("vpc-peering-route", projectID, vpcID, vpcPeeringID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
-	vpcID := args[0]
-	vpcPeeringID := args[1]
 
 	ctx := context.Background()
 	list, err := client.FromNetwork().VPCPeeringRoutes().List(ctx, aruba.VPCPeeringRef(projectID, vpcID, vpcPeeringID))
@@ -86,13 +90,14 @@ func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete str
 	if list != nil {
 		for _, route := range list.Items() {
 			id := route.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, route.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var vpcpeeringrouteCmd = &cobra.Command{

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -62,11 +61,17 @@ func completeVPNRouteID(cmd *cobra.Command, args []string, toComplete string) ([
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+	vpnTunnelID := args[0]
+
+	key := cacheKey("vpn-route", projectID, vpnTunnelID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	vpnTunnelID := args[0]
 
 	ctx := context.Background()
 	list, err := client.FromNetwork().VPNRoutes().List(ctx, aruba.VPNTunnelRef(projectID, vpnTunnelID))
@@ -77,12 +82,13 @@ func completeVPNRouteID(cmd *cobra.Command, args []string, toComplete string) ([
 	if list != nil {
 		for _, route := range list.Items() {
 			id := route.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, route.Name()))
 			}
 		}
 	}
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var vpnrouteCmd = &cobra.Command{

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -193,6 +192,11 @@ func completeVPNTunnelID(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("vpntunnel", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -208,13 +212,14 @@ func completeVPNTunnelID(cmd *cobra.Command, args []string, toComplete string) (
 	if list != nil {
 		for _, vpn := range list.Items() {
 			id := vpn.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, vpn.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // VPNTunnel subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var state = &clientState{}
 // Intended for use in tests to prevent state leaking between test cases.
 func resetClientState() {
 	state = &clientState{}
+	completionCacheReset()
 }
 
 // setClientForTesting injects a mock client that GetArubaClient returns directly,

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -68,6 +67,11 @@ func completeJobID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("job", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -83,13 +87,14 @@ func completeJobID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	if list != nil {
 		for _, job := range list.Items() {
 			id := job.JobID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, job.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var jobCmd = &cobra.Command{

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -60,6 +59,11 @@ func completeKMSID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("kms", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -75,13 +79,14 @@ func completeKMSID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 	if list != nil {
 		for _, kms := range list.Items() {
 			id := kms.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, kms.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // KMS subcommands

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -56,6 +55,11 @@ func completeBackupID(cmd *cobra.Command, args []string, toComplete string) ([]s
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("backup", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -71,13 +75,14 @@ func completeBackupID(cmd *cobra.Command, args []string, toComplete string) ([]s
 	if list != nil {
 		for _, bkp := range list.Items() {
 			id := bkp.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, bkp.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var storageBackupCmd = &cobra.Command{

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -63,6 +62,11 @@ func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("blockstorage", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -78,13 +82,14 @@ func completeBlockStorageID(cmd *cobra.Command, args []string, toComplete string
 	if list != nil {
 		for _, vol := range list.Items() {
 			id := vol.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, vol.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var blockstorageCmd = &cobra.Command{

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -63,6 +62,11 @@ func completeRestoreID(cmd *cobra.Command, args []string, toComplete string) ([]
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("restore", projectID, backupID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -78,13 +82,14 @@ func completeRestoreID(cmd *cobra.Command, args []string, toComplete string) ([]
 	if list != nil {
 		for _, r := range list.Items() {
 			id := r.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, r.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var storageRestoreCmd = &cobra.Command{

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
@@ -60,6 +59,11 @@ func completeSnapshotID(cmd *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	key := cacheKey("snapshot", projectID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, err := GetArubaClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -75,13 +79,14 @@ func completeSnapshotID(cmd *cobra.Command, args []string, toComplete string) ([
 	if list != nil {
 		for _, snap := range list.Items() {
 			id := snap.ID()
-			if id != "" && (toComplete == "" || strings.HasPrefix(id, toComplete)) {
+			if id != "" {
 				completions = append(completions, fmt.Sprintf("%s\t%s", id, snap.Name()))
 			}
 		}
 	}
 
-	return completions, cobra.ShellCompDirectiveNoFileComp
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 var snapshotCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

- New `cmd/completion_cache.go`: file-backed TTL cache stored at `$XDG_CACHE_HOME/acloud/completion/<key>.json`
- TTL defaults to 60 s, configurable via `ACLOUD_COMPLETION_CACHE_TTL` (e.g. `ACLOUD_COMPLETION_CACHE_TTL=5m`)
- Cache key = resource type + project ID; nested resources include parent IDs (dbaas-id, vpc-id, etc.)
- All 23 `completeXxxID` functions updated: hit cache before calling `GetArubaClient`, populate after API call
- `filterCompletions()` centralises prefix filtering so loops now collect **all** entries regardless of `toComplete`
- In-memory override (`completionCacheReset`) wired to `resetClientState()` keeps tests deterministic without disk I/O

## Test plan

- [x] `make test-skip-client` passes
- [x] `TestCompleteBlockStorageID_APIError`, `_PrefixFilter`, `_PrefixNoMatch` all still pass (cache is bypassed in tests via in-memory override)
- [x] Manual verification: second `<Tab>` for `acloud storage blockstorage get <Tab>` produces no new API call within 60 s

Closes #179

Generated with [Claude Code](https://claude.com/claude-code)