### PR TITLE
test(output): add yaml/table-json/table-yaml parity tests for all resource list commands

### DIFF
--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -80,6 +80,61 @@ func TestCloudServerListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
+					Values: []types.CloudServerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
+					Values: []types.CloudServerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cs-001", "my-server"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerListResponse{
+					Values: []types.CloudServerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"compute", "cloudserver", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/compute.keypair_test.go
+++ b/cmd/compute.keypair_test.go
@@ -77,6 +77,61 @@ func TestKeyPairListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				kpID, kpName := "kp-001", "my-kp"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keyPairs", jsonResponse(200, types.KeyPairListResponse{
+					Values: []types.KeyPairResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				kpID, kpName := "kp-001", "my-kp"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keyPairs", jsonResponse(200, types.KeyPairListResponse{
+					Values: []types.KeyPairResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"compute", "keypair", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				kpID, kpName := "kp-001", "my-kp"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Compute/keyPairs", jsonResponse(200, types.KeyPairListResponse{
+					Values: []types.KeyPairResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &kpID, Name: &kpName}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"compute", "keypair", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/container.containerregistry_test.go
+++ b/cmd/container.containerregistry_test.go
@@ -65,6 +65,61 @@ func TestContainerRegistryListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cr-001", "my-registry"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
+					Values: []types.ContainerRegistryResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cr-001", "my-registry"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
+					Values: []types.ContainerRegistryResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "cr-001", "my-registry"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryListResponse{
+					Values: []types.ContainerRegistryResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"container", "containerregistry", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/container.kaas_test.go
+++ b/cmd/container.kaas_test.go
@@ -66,6 +66,61 @@ func TestKaaSListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"container", "kaas", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kaas-001", "my-cluster"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
+					Values: []types.KaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"container", "kaas", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kaas-001", "my-cluster"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
+					Values: []types.KaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"container", "kaas", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kaas-001", "my-cluster"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSListResponse{
+					Values: []types.KaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"container", "kaas", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/database.backup_test.go
+++ b/cmd/database.backup_test.go
@@ -65,6 +65,61 @@ func TestDBBackupListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"database", "backup", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
+					Values: []types.BackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"database", "backup", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
+					Values: []types.BackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"database", "backup", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/backups", jsonResponse(200, types.DBaaSBackupListResponse{
+					Values: []types.BackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"database", "backup", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/database.dbaas.database_test.go
+++ b/cmd/database.dbaas.database_test.go
@@ -60,6 +60,58 @@ func TestDBaaSDatabaseListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
+					Values: []types.DatabaseResponse{
+						{Name: "my-db"},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
+					Values: []types.DatabaseResponse{
+						{Name: "my-db"},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/databases", jsonResponse(200, types.DatabaseListResponse{
+					Values: []types.DatabaseResponse{
+						{Name: "my-db"},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"database", "dbaas", "database", "list", "dbaas-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/database.dbaas.grant_test.go
+++ b/cmd/database.dbaas.grant_test.go
@@ -61,6 +61,67 @@ func TestDBaaSGrantListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output json emits valid JSON",
+			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123", "--output", "json"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet(grantListPath, jsonResponse(200, types.GrantListResponse{
+					Values: []types.GrantResponse{makeGrantResp()},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+					t.Errorf("output is not valid JSON: %v\noutput: %s", err, out)
+				}
+			},
+		},
+		{
+			name: "--output yaml emits non-empty YAML",
+			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet(grantListPath, jsonResponse(200, types.GrantListResponse{
+					Values: []types.GrantResponse{makeGrantResp()},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet(grantListPath, jsonResponse(200, types.GrantListResponse{
+					Values: []types.GrantResponse{makeGrantResp()},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet(grantListPath, jsonResponse(200, types.GrantListResponse{
+					Values: []types.GrantResponse{makeGrantResp()},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"database", "dbaas", "grant", "list", "dbaas-001", "mydb", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/database.dbaas.user_test.go
+++ b/cmd/database.dbaas.user_test.go
@@ -60,6 +60,58 @@ func TestDBaaSUserListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
+					Values: []types.UserResponse{
+						{Username: "admin"},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
+					Values: []types.UserResponse{
+						{Username: "admin"},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-001/users", jsonResponse(200, types.DatabaseUserListResponse{
+					Values: []types.UserResponse{
+						{Username: "admin"},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"database", "dbaas", "user", "list", "dbaas-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/database.dbaas_test.go
+++ b/cmd/database.dbaas_test.go
@@ -64,6 +64,61 @@ func TestDBaaSListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "dbaas-001", "my-dbaas"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
+					Values: []types.DBaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "dbaas-001", "my-dbaas"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
+					Values: []types.DBaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"database", "dbaas", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "dbaas-001", "my-dbaas"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
+					Values: []types.DBaaSResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "list items with all optional fields covers nil-guards",
 			args: []string{"database", "dbaas", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/management.project_test.go
+++ b/cmd/management.project_test.go
@@ -63,6 +63,61 @@ func TestProjectListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits non-empty YAML",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "proj-001", "my-project"
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
+					Values: []types.ProjectResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"management", "project", "list", "--output", "yaml"},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "proj-001", "my-project"
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
+					Values: []types.ProjectResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"management", "project", "list", "--output", "table-json"},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML sequence",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "proj-001", "my-project"
+				srv.OnGet("/projects", jsonResponse(200, types.ProjectListResponse{
+					Values: []types.ProjectResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"management", "project", "list", "--output", "table-yaml"},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects", errorResponse(500, "Internal Server Error", "boom"))

--- a/cmd/network.elasticip_test.go
+++ b/cmd/network.elasticip_test.go
@@ -64,6 +64,61 @@ func TestElasticIPListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
+					Values: []types.ElasticIPResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
+					Values: []types.ElasticIPResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "elasticip", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "eip-001", "my-eip"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPListResponse{
+					Values: []types.ElasticIPResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "elasticip", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.loadbalancer_test.go
+++ b/cmd/network.loadbalancer_test.go
@@ -63,6 +63,61 @@ func TestLoadBalancerListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "lb-001", "my-lb"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
+					Values: []types.LoadBalancerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "lb-001", "my-lb"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
+					Values: []types.LoadBalancerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "lb-001", "my-lb"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/loadBalancers", jsonResponse(200, types.LoadBalancerListResponse{
+					Values: []types.LoadBalancerResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "loadbalancer", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.securitygroup_test.go
+++ b/cmd/network.securitygroup_test.go
@@ -65,6 +65,61 @@ func TestSecurityGroupListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
+					Values: []types.SecurityGroupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
+					Values: []types.SecurityGroupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sg-001", "my-sg"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
+					Values: []types.SecurityGroupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "securitygroup", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.securityrule_test.go
+++ b/cmd/network.securityrule_test.go
@@ -68,6 +68,64 @@ func TestSecurityRuleListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
+					jsonResponse(200, types.SecurityRuleListResponse{
+						Values: []types.SecurityRuleResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
+					jsonResponse(200, types.SecurityRuleListResponse{
+						Values: []types.SecurityRuleResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rule-001", "my-rule"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-001/securityRules",
+					jsonResponse(200, types.SecurityRuleListResponse{
+						Values: []types.SecurityRuleResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "securityrule", "list", "vpc-001", "sg-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.subnet_test.go
+++ b/cmd/network.subnet_test.go
@@ -64,6 +64,61 @@ func TestSubnetListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
+					Values: []types.SubnetResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
+					Values: []types.SubnetResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "sub-001", "my-subnet"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
+					Values: []types.SubnetResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "subnet", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.vpc_test.go
+++ b/cmd/network.vpc_test.go
@@ -64,6 +64,61 @@ func TestVPCListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+					Values: []types.VPCResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+					Values: []types.VPCResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "vpc", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpc-001", "my-vpc"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+					Values: []types.VPCResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "vpc", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.vpcpeering_test.go
+++ b/cmd/network.vpcpeering_test.go
@@ -67,6 +67,64 @@ func TestVPCPeeringListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "peer-001", "my-peering"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringListResponse{
+						Values: []types.VPCPeeringResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "peer-001", "my-peering"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringListResponse{
+						Values: []types.VPCPeeringResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "peer-001", "my-peering"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings",
+					jsonResponse(200, types.VPCPeeringListResponse{
+						Values: []types.VPCPeeringResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "vpcpeering", "list", "vpc-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.vpcpeeringroute_test.go
+++ b/cmd/network.vpcpeeringroute_test.go
@@ -67,6 +67,64 @@ func TestVPCPeeringRouteListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteListResponse{
+						Values: []types.VPCPeeringRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteListResponse{
+						Values: []types.VPCPeeringRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings/peer-001/vpcPeeringRoutes",
+					jsonResponse(200, types.VPCPeeringRouteListResponse{
+						Values: []types.VPCPeeringRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "vpcpeeringroute", "list", "vpc-001", "peer-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.vpnroute_test.go
+++ b/cmd/network.vpnroute_test.go
@@ -67,6 +67,64 @@ func TestVPNRouteListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteListResponse{
+						Values: []types.VPNRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteListResponse{
+						Values: []types.VPNRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "route-001", "my-route"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-001/vpnRoutes",
+					jsonResponse(200, types.VPNRouteListResponse{
+						Values: []types.VPNRouteResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "vpnroute", "list", "vpn-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/network.vpntunnel_test.go
+++ b/cmd/network.vpntunnel_test.go
@@ -68,6 +68,64 @@ func TestVPNTunnelListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelListResponse{
+						Values: []types.VPNTunnelResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelListResponse{
+						Values: []types.VPNTunnelResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vpn-001", "my-tunnel"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels",
+					jsonResponse(200, types.VPNTunnelListResponse{
+						Values: []types.VPNTunnelResponse{
+							{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+						},
+					}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"network", "vpntunnel", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/schedule.job_test.go
+++ b/cmd/schedule.job_test.go
@@ -67,6 +67,61 @@ func TestJobListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"schedule", "job", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "job-001", "my-job"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
+					Values: []types.JobResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"schedule", "job", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "job-001", "my-job"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
+					Values: []types.JobResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"schedule", "job", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "job-001", "my-job"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Schedule/jobs", jsonResponse(200, types.JobListResponse{
+					Values: []types.JobResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"schedule", "job", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/security.kms_test.go
+++ b/cmd/security.kms_test.go
@@ -64,6 +64,61 @@ func TestKMSListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
+					Values: []types.KmsResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"security", "kms", "list", "--project-id", "proj-123", "--output", "yaml"},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
+					Values: []types.KmsResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"security", "kms", "list", "--project-id", "proj-123", "--output", "table-json"},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "kms-001", "my-kms"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsListResponse{
+					Values: []types.KmsResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			args: []string{"security", "kms", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			setupSrv: func(srv *arubaTestServer) {
 				srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms", errorResponse(500, "Internal Server Error", "boom"))

--- a/cmd/storage.backup_test.go
+++ b/cmd/storage.backup_test.go
@@ -146,6 +146,61 @@ func TestStorageBackupListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
+					Values: []types.StorageBackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
+					Values: []types.StorageBackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"storage", "backup", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "bkp-001", "my-backup"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups", jsonResponse(200, types.StorageBackupListResponse{
+					Values: []types.StorageBackupResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"storage", "backup", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/storage.blockstorage_test.go
+++ b/cmd/storage.blockstorage_test.go
@@ -63,6 +63,61 @@ func TestBlockStorageListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vol-001", "my-volume"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
+					Values: []types.BlockStorageResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vol-001", "my-volume"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
+					Values: []types.BlockStorageResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "vol-001", "my-volume"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageListResponse{
+					Values: []types.BlockStorageResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"storage", "blockstorage", "list", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/storage.restore_test.go
+++ b/cmd/storage.restore_test.go
@@ -178,6 +178,61 @@ func TestStorageRestoreListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123", "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
+					Values: []types.StorageRestoreResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123", "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
+					Values: []types.StorageRestoreResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123", "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "rst-001", "my-restore"
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/backups/bkp-001/restores", jsonResponse(200, types.StorageRestoreListResponse{
+					Values: []types.StorageRestoreResponse{
+						{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"storage", "restore", "list", "bkp-001", "--project-id", "proj-123"},
 			setupSrv: func(srv *arubaTestServer) {

--- a/cmd/storage.snapshot_test.go
+++ b/cmd/storage.snapshot_test.go
@@ -73,6 +73,73 @@ func TestSnapshotListCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "--output yaml emits valid YAML",
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-id", snapshotVolID, "--output", "yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "snap-001", "my-snapshot"
+				volURI := snapshotVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
+					Values: []types.SnapshotResponse{
+						{
+							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfoResponse{URI: &volURI}},
+						},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "{}" || strings.TrimSpace(out) == "" {
+					t.Errorf("yaml output is empty or {}, got: %s", out)
+				}
+			},
+		},
+		{
+			name: "--output table-json emits valid JSON array",
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-id", snapshotVolID, "--output", "table-json"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "snap-001", "my-snapshot"
+				volURI := snapshotVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
+					Values: []types.SnapshotResponse{
+						{
+							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfoResponse{URI: &volURI}},
+						},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+					t.Errorf("table-json output is not a valid JSON array: %v\noutput: %s", err, out)
+				}
+				if len(rows) == 0 {
+					t.Errorf("expected at least one row in table-json output, got none")
+				}
+			},
+		},
+		{
+			name: "--output table-yaml emits non-empty YAML",
+			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-id", snapshotVolID, "--output", "table-yaml"},
+			setupSrv: func(srv *arubaTestServer) {
+				id, name := "snap-001", "my-snapshot"
+				volURI := snapshotVolURI
+				srv.OnGet("/projects/proj-123/providers/Aruba.Storage/snapshots", jsonResponse(200, types.SnapshotListResponse{
+					Values: []types.SnapshotResponse{
+						{
+							Metadata:   types.ResourceMetadataResponse{ID: &id, Name: &name},
+							Properties: types.SnapshotPropertiesResponse{Volume: &types.VolumeInfoResponse{URI: &volURI}},
+						},
+					},
+				}))
+			},
+			assertOut: func(t *testing.T, out string) {
+				if strings.TrimSpace(out) == "" {
+					t.Errorf("table-yaml output is empty, got: %s", out)
+				}
+			},
+		},
+		{
 			name: "server error propagates",
 			args: []string{"storage", "snapshot", "list", "--project-id", "proj-123", "--volume-id", snapshotVolID},
 			setupSrv: func(srv *arubaTestServer) {


### PR DESCRIPTION
Closes #178. Adds yaml, table-json, table-yaml output-format tests to all 26 resource list commands. Generated with Claude Code.