### PR TITLE
feat(wait): add --wait flag to create/update commands for synchronous provisioning

### DIFF
--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -54,9 +54,11 @@ func init() {
 	cloudserverGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	cloudserverGetCmd.Flags().Bool("verbose", false, "Print full JSON response")
 
+	cloudserverCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	cloudserverUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	cloudserverUpdateCmd.Flags().String("name", "", "New name for the cloud server")
 	cloudserverUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	cloudserverUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	cloudserverDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	cloudserverDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -239,6 +241,7 @@ type ComputeCloudServerCreateArgs struct {
 	Tags             []string
 	BillingPeriod    aruba.BillingPeriod
 	UserDataFile     string
+	Wait             bool
 }
 
 // ComputeCloudServerGetArgs holds the typed arguments for getting a cloud server.
@@ -255,6 +258,7 @@ type ComputeCloudServerUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // ComputeCloudServerDeleteArgs holds the typed arguments for deleting a cloud server.
@@ -468,6 +472,9 @@ func (a *ComputeCloudServerCreateArgs) ParseFromCobraCommand(cmd *cobra.Command)
 	if a.UserDataFile, err = cmd.Flags().GetString("user-data-file"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -508,6 +515,9 @@ func (a *ComputeCloudServerUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command,
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -820,6 +830,21 @@ func ComputeCloudServerCreate(ctx context.Context, client aruba.Client, args Com
 			regionValue,
 		}
 		PrintOutput(resp, headers, [][]string{row})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Cloud server", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("Cloud server", args.Name))
 	}
@@ -929,6 +954,21 @@ func ComputeCloudServerUpdate(ctx context.Context, client aruba.Client, args Com
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromCompute().CloudServers().Get(ctx, cloudServerRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Cloud server", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("Cloud server", args.ID))

--- a/cmd/compute.cloudserver_test.go
+++ b/cmd/compute.cloudserver_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -1596,5 +1597,50 @@ func TestCloudServerUpdateCmd_Success(t *testing.T) {
 	}
 	if !strings.Contains(out, "cs-001") {
 		t.Errorf("expected ID in output, got: %s", out)
+	}
+}
+
+// TestComputeCloudServerCreate_WaitFlag verifies that --wait polls until Active
+// (mock returns InCreation on the first GET, then Active on the second).
+func TestComputeCloudServerCreate_WaitFlag(t *testing.T) {
+	id, name := "cs-wait-01", "wait-server"
+	stateActive := types.StateActive
+	stateInCreation := types.StateInCreation
+	getCallCount := 0
+
+	srv := newArubaTestServer(t)
+	// POST for create
+	srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(201, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &stateActive},
+	}))
+	// GET for wait polling: first call returns InCreation, second returns Active
+	srv.On("GET", "/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wait-01",
+		func(w http.ResponseWriter, r *http.Request) {
+			getCallCount++
+			state := stateInCreation
+			if getCallCount >= 2 {
+				state = stateActive
+			}
+			jsonResponse(200, types.CloudServerResponse{
+				Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+				Status:   types.ResourceStatusResponse{State: &state},
+			})(w, r)
+		})
+
+	ctx := context.Background()
+	err := waitUntilActiveWithInterval(ctx, func(ctx context.Context) (string, error) {
+		cs, err := srv.Client().FromCompute().CloudServers().Get(ctx, cloudServerRef("proj-123", id))
+		if err != nil {
+			return "", apiErrFromV2(err)
+		}
+		return string(cs.State()), nil
+	}, "Cloud server", name, time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("WaitUntilActive returned error: %v", err)
+	}
+	if getCallCount < 2 {
+		t.Errorf("expected at least 2 GET calls (InCreation→Active), got %d", getCallCount)
 	}
 }

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -2,10 +2,23 @@ package cmd
 
 // Resource state values returned by the API.
 const (
-	StateActive     = "Active"
-	StateInCreation = "InCreation"
-	StateUsed       = "Used"
-	StateNotUsed    = "NotUsed"
+	// Operational / settled states.
+	StateActive  = "Active"
+	StateRunning = "Running"
+	StateUsed    = "Used"
+	StateNotUsed = "NotUsed"
+
+	// Transitory states — an operation is in progress.
+	StateInCreation   = "InCreation"
+	StateCreating     = "Creating"
+	StateUpdating     = "Updating"
+	StateProvisioning = "Provisioning"
+	StateDeleting     = "Deleting"
+
+	// Failure states — provisioning or operational fault.
+	StateError   = "Error"
+	StateFailed  = "Failed"
+	StateDeleted = "Deleted"
 )
 
 // DateLayout is the display format used for all creation/modification timestamps.

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -37,6 +37,7 @@ func init() {
 	containerregistryCreateCmd.MarkFlagRequired("subnet-id")
 	containerregistryCreateCmd.MarkFlagRequired("security-group-id")
 	containerregistryCreateCmd.MarkFlagRequired("block-storage-id")
+	containerregistryCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	containerregistryGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 
@@ -45,6 +46,7 @@ func init() {
 	containerregistryUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
 	containerregistryUpdateCmd.Flags().String("billing-period", "", "Billing period: Hour, Month, Year")
 	containerregistryUpdateCmd.Flags().String("concurrent-users", "", "Concurrent users tier: Small, Medium, HighPerf")
+	containerregistryUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	containerregistryDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	containerregistryDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -173,6 +175,7 @@ type ContainerContainerRegistryCreateArgs struct {
 	AdminUsername  string
 	SizeFlavor     aruba.ContainerRegistrySizeFlavor
 	Tags           []string
+	Wait           bool
 }
 
 // ContainerContainerRegistryGetArgs holds the typed arguments for getting a container registry.
@@ -196,6 +199,7 @@ type ContainerContainerRegistryUpdateArgs struct {
 	TagsChanged   bool
 	BillingPeriod aruba.BillingPeriod
 	SizeFlavor    aruba.ContainerRegistrySizeFlavor
+	Wait          bool
 }
 
 // ContainerContainerRegistryDeleteArgs holds the typed arguments for deleting a container registry.
@@ -321,6 +325,9 @@ func (a *ContainerContainerRegistryCreateArgs) ParseFromCobraCommand(cmd *cobra.
 	if a.Tags, err = cmd.Flags().GetStringSlice("tags"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -379,6 +386,9 @@ func (a *ContainerContainerRegistryUpdateArgs) ParseFromCobraCommand(cmd *cobra.
 	if s, err := cmd.Flags().GetString("concurrent-users"); err == nil {
 		a.SizeFlavor = aruba.ContainerRegistrySizeFlavor(s)
 	} else {
+		errs = append(errs, err)
+	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -538,6 +548,21 @@ func ContainerContainerRegistryCreate(ctx context.Context, client aruba.Client, 
 			statusVal = string(*raw.Status.State)
 		}
 		PrintOutput(created, headers, [][]string{{id, nameVal, regionVal, statusVal}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Container registry", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("Container registry", args.Name))
 	}
@@ -704,6 +729,21 @@ func ContainerContainerRegistryUpdate(ctx context.Context, client aruba.Client, 
 		}
 		if raw.Status.State != nil {
 			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Container registry", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("Container registry", args.ID))

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -57,6 +57,7 @@ func init() {
 	kaasCreateCmd.MarkFlagRequired("node-pool-nodes")
 	kaasCreateCmd.MarkFlagRequired("node-pool-instance")
 	kaasCreateCmd.MarkFlagRequired("node-pool-zone")
+	kaasCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	kaasGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 
@@ -75,6 +76,7 @@ func init() {
 	kaasUpdateCmd.Flags().Bool("node-pool-autoscaling", false, "Enable autoscaling for node pool")
 	kaasUpdateCmd.Flags().Int("node-pool-min-count", 0, "Minimum number of nodes for autoscaling")
 	kaasUpdateCmd.Flags().Int("node-pool-max-count", 0, "Maximum number of nodes for autoscaling")
+	kaasUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	kaasDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	kaasDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -230,6 +232,7 @@ type ContainerKaaSCreateArgs struct {
 	HA                            bool
 	APIServerAuthorizedIPRanges   []string
 	APIServerEnablePrivateCluster bool
+	Wait                          bool
 }
 
 // ContainerKaaSGetArgs holds the typed arguments for getting a KaaS cluster.
@@ -263,6 +266,7 @@ type ContainerKaaSUpdateArgs struct {
 	NodePoolAutoscaling bool
 	NodePoolMinCount    int
 	NodePoolMaxCount    int
+	Wait                bool
 }
 
 // ContainerKaaSDeleteArgs holds the typed arguments for deleting a KaaS cluster.
@@ -445,6 +449,9 @@ func (a *ContainerKaaSCreateArgs) ParseFromCobraCommand(cmd *cobra.Command) erro
 	if a.APIServerEnablePrivateCluster, err = cmd.Flags().GetBool("api-server-enable-private-cluster"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -535,6 +542,9 @@ func (a *ContainerKaaSUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, cobr
 		errs = append(errs, err)
 	}
 	if a.NodePoolMaxCount, err = cmd.Flags().GetInt("node-pool-max-count"); err != nil {
+		errs = append(errs, err)
+	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -748,6 +758,19 @@ func ContainerKaaSCreate(ctx context.Context, client aruba.Client, args Containe
 			string(created.KubernetesVersion()),
 			string(created.Region()),
 		}})
+		if args.Wait {
+			id := created.KaaSID()
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromContainer().KaaS().Get(ctx, kaasRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				return string(res.State()), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "KaaS cluster", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("KaaS cluster", args.Name))
 	}
@@ -889,6 +912,18 @@ func ContainerKaaSUpdate(ctx context.Context, client aruba.Client, args Containe
 		fmt.Printf("Name:    %s\n", updated.Name())
 		if tags := updated.Tags(); len(tags) > 0 {
 			fmt.Printf("Tags:    %v\n", tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromContainer().KaaS().Get(ctx, kaasRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				return string(res.State()), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "KaaS cluster", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("KaaS cluster", args.ID))

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -37,6 +37,7 @@ func init() {
 	dbaasCreateCmd.MarkFlagRequired("engine-id")
 	dbaasCreateCmd.MarkFlagRequired("flavor")
 	dbaasCreateCmd.MarkFlagRequired("storage-size")
+	dbaasCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	dbaasGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 
@@ -47,6 +48,7 @@ func init() {
 	// PUT body (omitting it is treated as a modification attempt → 400). Pass the same
 	// zone that was used at creation time (e.g. ITBG-1).
 	dbaasUpdateCmd.Flags().String("zone", "", "Zone used at creation time (required to avoid API 400 on PUT)")
+	dbaasUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	dbaasDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	dbaasDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -174,6 +176,7 @@ type DatabaseDBaaSCreateArgs struct {
 	SGID          string
 	ElasticIPID   string
 	Tags          []string
+	Wait          bool
 }
 
 // DatabaseDBaaSGetArgs holds the typed arguments for getting a DBaaS instance.
@@ -190,6 +193,7 @@ type DatabaseDBaaSUpdateArgs struct {
 	Tags        []string
 	TagsChanged bool
 	Zone        string
+	Wait        bool
 }
 
 // DatabaseDBaaSDeleteArgs holds the typed arguments for deleting a DBaaS instance.
@@ -322,6 +326,9 @@ func (a *DatabaseDBaaSCreateArgs) ParseFromCobraCommand(cmd *cobra.Command) erro
 	if a.Tags, err = cmd.Flags().GetStringSlice("tags"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -360,6 +367,9 @@ func (a *DatabaseDBaaSUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, cobr
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
 	if a.Zone, err = cmd.Flags().GetString("zone"); err != nil {
+		errs = append(errs, err)
+	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -535,6 +545,21 @@ func DatabaseDBaaSCreate(ctx context.Context, client aruba.Client, args Database
 			regionVal = string(raw.Metadata.LocationResponse.Value)
 		}
 		PrintOutput(created, headers, [][]string{{id, nameVal, engine, version, flavorVal, regionVal}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromDatabase().DBaaS().Get(ctx, dbaasRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "DBaaS", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("DBaaS instance", args.Name))
 	}
@@ -658,6 +683,21 @@ func DatabaseDBaaSUpdate(ctx context.Context, client aruba.Client, args Database
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromDatabase().DBaaS().Get(ctx, dbaasRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "DBaaS", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("DBaaS instance", args.ID))

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -28,10 +28,12 @@ func init() {
 	elasticipCreateCmd.MarkFlagRequired("name")
 	elasticipCreateCmd.MarkFlagRequired("region")
 	elasticipCreateCmd.Flags().StringSlice("tags", []string{}, "Tags (comma-separated)")
+	elasticipCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	elasticipGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	elasticipUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	elasticipUpdateCmd.Flags().String("name", "", "New name for the Elastic IP")
 	elasticipUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	elasticipUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	elasticipDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	elasticipDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	elasticipDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
@@ -141,6 +143,7 @@ type NetworkElasticIPCreateArgs struct {
 	Region        aruba.Region
 	BillingPeriod aruba.BillingPeriod
 	Tags          []string
+	Wait          bool
 }
 
 // NetworkElasticIPGetArgs holds the typed arguments for getting an Elastic IP.
@@ -156,6 +159,7 @@ type NetworkElasticIPUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // NetworkElasticIPDeleteArgs holds the typed arguments for deleting an Elastic IP.
@@ -264,6 +268,9 @@ func (a *NetworkElasticIPCreateArgs) ParseFromCobraCommand(cmd *cobra.Command) e
 	if a.Tags, err = cmd.Flags().GetStringSlice("tags"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -301,6 +308,9 @@ func (a *NetworkElasticIPUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, c
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -420,8 +430,10 @@ func NetworkElasticIPCreate(ctx context.Context, client aruba.Client, args Netwo
 	if created != nil && created.Raw() != nil {
 		raw := created.Raw()
 		fmt.Printf("\n%s\n", msgCreated("Elastic IP", args.Name))
+		id := ""
 		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+			id = *raw.Metadata.ID
+			fmt.Printf("ID:      %s\n", id)
 		}
 		if raw.Metadata.Name != nil {
 			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
@@ -431,6 +443,21 @@ func NetworkElasticIPCreate(ctx context.Context, client aruba.Client, args Netwo
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Elastic IP", args.Name); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgCreatedAsync("Elastic IP", args.Name))
@@ -526,6 +553,21 @@ func NetworkElasticIPUpdate(ctx context.Context, client aruba.Client, args Netwo
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().ElasticIPs().Get(ctx, aruba.ElasticIPRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Elastic IP", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("Elastic IP", args.ID))

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -424,7 +424,7 @@ func NetworkSecurityGroupCreate(ctx context.Context, client aruba.Client, args N
 		PrintOutput(resp, headers, [][]string{{args.Name, id, region, status}})
 		if args.Wait && id != "" {
 			getter := func(ctx context.Context) (string, error) {
-				res, err := client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(args.ProjectID, args.VPCID, id))
+				res, err := client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(args.ProjectID, args.VPCID, id))
 				if err != nil {
 					return "", apiErrFromV2(err)
 				}
@@ -536,7 +536,7 @@ func NetworkSecurityGroupUpdate(ctx context.Context, client aruba.Client, args N
 		PrintOutput(updated, headers, [][]string{{nameVal, id, updateRegion, status}})
 		if args.Wait && id != "" {
 			getter := func(ctx context.Context) (string, error) {
-				res, err := client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(args.ProjectID, args.VPCID, id))
+				res, err := client.FromNetwork().SecurityGroups().Get(ctx, aruba.SecurityGroupRef(args.ProjectID, args.VPCID, id))
 				if err != nil {
 					return "", apiErrFromV2(err)
 				}

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -28,12 +28,14 @@ func init() {
 	securitygroupCreateCmd.Flags().String("name", "", "Security group name (required)")
 	securitygroupCreateCmd.Flags().String("region", "", "Region code (required)")
 	securitygroupCreateCmd.Flags().StringSlice("tags", []string{}, "Tags (comma-separated)")
+	securitygroupCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	securitygroupCreateCmd.MarkFlagRequired("name")
 	securitygroupCreateCmd.MarkFlagRequired("region")
 	securitygroupGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	securitygroupUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	securitygroupUpdateCmd.Flags().String("name", "", "New name for the security group")
 	securitygroupUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	securitygroupUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	securitygroupDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	securitygroupDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	securitygroupDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
@@ -101,6 +103,7 @@ type NetworkSecurityGroupCreateArgs struct {
 	VPCID     string
 	Name      string
 	Tags      []string
+	Wait      bool
 }
 
 // NetworkSecurityGroupGetArgs holds the typed arguments for getting a security group.
@@ -118,6 +121,7 @@ type NetworkSecurityGroupUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // NetworkSecurityGroupDeleteArgs holds the typed arguments for deleting a security group.
@@ -221,6 +225,9 @@ func (a *NetworkSecurityGroupCreateArgs) ParseFromCobraCommand(cmd *cobra.Comman
 	if a.Tags, err = cmd.Flags().GetStringSlice("tags"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -264,6 +271,9 @@ func (a *NetworkSecurityGroupUpdateArgs) ParseFromCobraCommand(cmd *cobra.Comman
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -412,6 +422,21 @@ func NetworkSecurityGroupCreate(ctx context.Context, client aruba.Client, args N
 			status = string(*raw.Status.State)
 		}
 		PrintOutput(resp, headers, [][]string{{args.Name, id, region, status}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(args.ProjectID, args.VPCID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Security group", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("Security group", args.Name))
 	}
@@ -509,6 +534,21 @@ func NetworkSecurityGroupUpdate(ctx context.Context, client aruba.Client, args N
 			status = string(*raw.Status.State)
 		}
 		PrintOutput(updated, headers, [][]string{{nameVal, id, updateRegion, status}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().SecurityGroups().Get(ctx, securityGroupRef(args.ProjectID, args.VPCID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Security group", args.SGID); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgUpdatedAsync("Security group", args.SGID))
 	}

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -36,6 +36,7 @@ func init() {
 	subnetCreateCmd.Flags().Bool("dhcp-enabled", false, "Enable DHCP for Advanced subnet type (required when CIDR is provided)")
 	subnetCreateCmd.Flags().StringSlice("dhcp-routes", []string{}, "DHCP routes for Advanced subnet type (optional, format: destination:gateway, e.g., '0.0.0.0/0:10.0.0.1')")
 	subnetCreateCmd.Flags().StringSlice("dhcp-dns", []string{}, "DHCP DNS servers for Advanced subnet type (optional, e.g., '8.8.8.8,8.8.4.4')")
+	subnetCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	subnetGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	subnetUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	subnetUpdateCmd.Flags().String("name", "", "Subnet name (optional)")
@@ -44,6 +45,7 @@ func init() {
 	subnetUpdateCmd.Flags().Bool("dhcp-enabled", false, "Enable DHCP for Advanced subnet type")
 	subnetUpdateCmd.Flags().StringSlice("dhcp-routes", []string{}, "DHCP routes for Advanced subnet type (optional, format: destination:gateway)")
 	subnetUpdateCmd.Flags().StringSlice("dhcp-dns", []string{}, "DHCP DNS servers for Advanced subnet type (optional)")
+	subnetUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	subnetDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	subnetDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	subnetDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
@@ -122,6 +124,7 @@ type NetworkSubnetCreateArgs struct {
 	DHCPEnabled    bool
 	DHCPRoutes     []string
 	DHCPDNSServers []string
+	Wait           bool
 }
 
 // NetworkSubnetGetArgs holds the typed arguments for getting a subnet.
@@ -146,6 +149,7 @@ type NetworkSubnetUpdateArgs struct {
 	DHCPRoutesChanged  bool
 	DHCPDNSServers     []string
 	DHCPDNSChanged     bool
+	Wait               bool
 }
 
 // NetworkSubnetDeleteArgs holds the typed arguments for deleting a subnet.
@@ -266,6 +270,9 @@ func (a *NetworkSubnetCreateArgs) ParseFromCobraCommand(cmd *cobra.Command, cobr
 	if a.DHCPDNSServers, err = cmd.Flags().GetStringSlice("dhcp-dns"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -324,6 +331,9 @@ func (a *NetworkSubnetUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, cobr
 		errs = append(errs, err)
 	}
 	a.DHCPDNSChanged = cmd.Flags().Changed("dhcp-dns")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -518,6 +528,18 @@ func NetworkSubnetCreate(ctx context.Context, client aruba.Client, args NetworkS
 			status = string(*raw.Status.State)
 		}
 		PrintOutput(resp, headers, [][]string{{args.Name, id, createRegion, displayCIDR, status}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(args.ProjectID, args.VPCID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				return string(res.State()), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Subnet", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("Subnet", args.Name))
 	}
@@ -718,6 +740,18 @@ func NetworkSubnetUpdate(ctx context.Context, client aruba.Client, args NetworkS
 			status = string(*raw.Status.State)
 		}
 		PrintOutput(updated, headers, [][]string{{nameVal, id, cidrVal, status}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().Subnets().Get(ctx, aruba.SubnetRef(args.ProjectID, args.VPCID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				return string(res.State()), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Subnet", args.SubnetID); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgUpdatedAsync("Subnet", args.SubnetID))
 	}

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -25,12 +25,14 @@ func init() {
 	vpcCreateCmd.Flags().String("name", "", "Name for the VPC")
 	vpcCreateCmd.Flags().String("region", "", "Region code (e.g., IT-BG)")
 	vpcCreateCmd.Flags().StringSlice("tags", []string{}, "Tags (comma-separated)")
+	vpcCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	vpcCreateCmd.MarkFlagRequired("name")
 	vpcCreateCmd.MarkFlagRequired("region")
 	vpcGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpcUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpcUpdateCmd.Flags().String("name", "", "New name for the VPC")
 	vpcUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	vpcUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	vpcDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpcDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	vpcDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
@@ -140,6 +142,7 @@ type NetworkVPCCreateArgs struct {
 	Name      string
 	Region    aruba.Region
 	Tags      []string
+	Wait      bool
 }
 
 // NetworkVPCGetArgs holds the typed arguments for getting a VPC.
@@ -155,6 +158,7 @@ type NetworkVPCUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // NetworkVPCDeleteArgs holds the typed arguments for deleting a VPC.
@@ -258,6 +262,9 @@ func (a *NetworkVPCCreateArgs) ParseFromCobraCommand(cmd *cobra.Command) error {
 	if a.Tags, err = cmd.Flags().GetStringSlice("tags"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -295,6 +302,9 @@ func (a *NetworkVPCUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, cobraAr
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -410,8 +420,10 @@ func NetworkVPCCreate(ctx context.Context, client aruba.Client, args NetworkVPCC
 	if created != nil && created.Raw() != nil {
 		raw := created.Raw()
 		fmt.Printf("\n%s\n", msgCreated("VPC", args.Name))
+		id := ""
 		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:      %s\n", *raw.Metadata.ID)
+			id = *raw.Metadata.ID
+			fmt.Printf("ID:      %s\n", id)
 		}
 		if raw.Metadata.Name != nil {
 			fmt.Printf("Name:    %s\n", *raw.Metadata.Name)
@@ -419,6 +431,21 @@ func NetworkVPCCreate(ctx context.Context, client aruba.Client, args NetworkVPCC
 		fmt.Printf("Default: %t\n", raw.Properties.Default)
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "VPC", args.Name); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgCreatedAsync("VPC", args.Name))
@@ -514,6 +541,21 @@ func NetworkVPCUpdate(ctx context.Context, client aruba.Client, args NetworkVPCU
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().VPCs().Get(ctx, aruba.VPCRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "VPC", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("VPC", args.ID))

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -152,10 +152,12 @@ func init() {
 	vpntunnelCreateCmd.MarkFlagRequired("peer-ip")
 	vpntunnelCreateCmd.MarkFlagRequired("vpc-id")
 	vpntunnelCreateCmd.MarkFlagRequired("elastic-ip-id")
+	vpntunnelCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	vpntunnelGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpntunnelUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpntunnelUpdateCmd.Flags().String("name", "", "New name for the VPN tunnel")
 	vpntunnelUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	vpntunnelUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	vpntunnelDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpntunnelDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	vpntunnelDeleteCmd.Flags().Bool("dry-run", false, "Validate resource exists without deleting")
@@ -318,6 +320,7 @@ type NetworkVPNTunnelCreateArgs struct {
 	PSK           string
 	PSKCloudSite  string
 	PSKOnpremSite string
+	Wait          bool
 }
 
 // NetworkVPNTunnelGetArgs holds the typed arguments for getting a VPN tunnel.
@@ -333,6 +336,7 @@ type NetworkVPNTunnelUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // NetworkVPNTunnelDeleteArgs holds the typed arguments for deleting a VPN tunnel.
@@ -528,6 +532,9 @@ func (a *NetworkVPNTunnelCreateArgs) ParseFromCobraCommand(cmd *cobra.Command) e
 	if a.PSKOnpremSite, err = cmd.Flags().GetString("psk-onprem-site"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -565,6 +572,9 @@ func (a *NetworkVPNTunnelUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, c
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -880,8 +890,10 @@ func NetworkVPNTunnelCreate(ctx context.Context, client aruba.Client, args Netwo
 	if resp != nil && resp.Raw() != nil {
 		raw := resp.Raw()
 		fmt.Printf("\n%s\n", msgCreated("VPN Tunnel", args.Name))
+		id := ""
 		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:       %s\n", *raw.Metadata.ID)
+			id = *raw.Metadata.ID
+			fmt.Printf("ID:       %s\n", id)
 		}
 		if raw.Metadata.Name != nil {
 			fmt.Printf("Name:     %s\n", *raw.Metadata.Name)
@@ -897,6 +909,18 @@ func NetworkVPNTunnelCreate(ctx context.Context, client aruba.Client, args Netwo
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:     %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				return string(res.State()), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "VPN tunnel", args.Name); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgCreatedAsync("VPN Tunnel", args.Name))
@@ -945,6 +969,18 @@ func NetworkVPNTunnelUpdate(ctx context.Context, client aruba.Client, args Netwo
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:    %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				return string(res.State()), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "VPN tunnel", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("VPN Tunnel", args.ID))

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -29,6 +29,7 @@ func init() {
 	kmsCreateCmd.Flags().String("region", "", "Region code (required)")
 	kmsCreateCmd.Flags().String("billing-period", string(aruba.BillingPeriodHour), "Billing period: Hour, Month, Year")
 	kmsCreateCmd.Flags().StringSlice("tags", []string{}, "Tags (comma-separated)")
+	kmsCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 	kmsCreateCmd.MarkFlagRequired("name")
 	kmsCreateCmd.MarkFlagRequired("region")
 
@@ -37,6 +38,7 @@ func init() {
 	kmsUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	kmsUpdateCmd.Flags().String("name", "", "New KMS name")
 	kmsUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	kmsUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	kmsDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	kmsDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -147,6 +149,7 @@ type SecurityKMSCreateArgs struct {
 	Region        aruba.Region
 	BillingPeriod aruba.BillingPeriod
 	Tags          []string
+	Wait          bool
 }
 
 // SecurityKMSGetArgs holds the typed arguments for getting a KMS resource.
@@ -162,6 +165,7 @@ type SecurityKMSUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // SecurityKMSDeleteArgs holds the typed arguments for deleting a KMS resource.
@@ -270,6 +274,9 @@ func (a *SecurityKMSCreateArgs) ParseFromCobraCommand(cmd *cobra.Command) error 
 	if a.Tags, err = cmd.Flags().GetStringSlice("tags"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -307,6 +314,9 @@ func (a *SecurityKMSUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command, cobraA
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -442,6 +452,21 @@ func SecurityKMSCreate(ctx context.Context, client aruba.Client, args SecurityKM
 		}
 		row := []string{id, nameVal, regionVal, statusVal}
 		PrintOutput(created, headers, [][]string{row})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromSecurity().KMS().Get(ctx, kmsRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "KMS", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("KMS", args.Name))
 	}
@@ -534,6 +559,21 @@ func SecurityKMSUpdate(ctx context.Context, client aruba.Client, args SecurityKM
 		}
 		if len(raw.Metadata.Tags) > 0 {
 			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+		}
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromSecurity().KMS().Get(ctx, kmsRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "KMS", args.ID); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Println(msgUpdatedAsync("KMS", args.ID))

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -36,12 +36,14 @@ func init() {
 	blockstorageCreateCmd.MarkFlagRequired("name")
 	blockstorageCreateCmd.MarkFlagRequired("region")
 	blockstorageCreateCmd.MarkFlagRequired("size")
+	blockstorageCreateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	blockstorageGetCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 
 	blockstorageUpdateCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	blockstorageUpdateCmd.Flags().String("name", "", "New name for the block storage")
 	blockstorageUpdateCmd.Flags().StringSlice("tags", []string{}, "New tags (comma-separated)")
+	blockstorageUpdateCmd.Flags().Bool("wait", false, "Wait until the resource becomes Active (use --timeout to control the deadline)")
 
 	blockstorageDeleteCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	blockstorageDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -164,6 +166,7 @@ type StorageBlockStorageCreateArgs struct {
 	SnapshotID    string
 	SetBootable   bool
 	Image         string
+	Wait          bool
 }
 
 // StorageBlockStorageGetArgs holds the typed arguments for getting a block storage.
@@ -179,6 +182,7 @@ type StorageBlockStorageUpdateArgs struct {
 	Name        string
 	Tags        []string
 	TagsChanged bool
+	Wait        bool
 }
 
 // StorageBlockStorageDeleteArgs holds the typed arguments for deleting a block storage.
@@ -309,6 +313,9 @@ func (a *StorageBlockStorageCreateArgs) ParseFromCobraCommand(cmd *cobra.Command
 	if a.Image, err = cmd.Flags().GetString("image"); err != nil {
 		errs = append(errs, err)
 	}
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -346,6 +353,9 @@ func (a *StorageBlockStorageUpdateArgs) ParseFromCobraCommand(cmd *cobra.Command
 		errs = append(errs, err)
 	}
 	a.TagsChanged = cmd.Flags().Changed("tags")
+	if a.Wait, err = cmd.Flags().GetBool("wait"); err != nil {
+		errs = append(errs, err)
+	}
 
 	return errors.Join(errs...)
 }
@@ -488,6 +498,21 @@ func StorageBlockStorageCreate(ctx context.Context, client aruba.Client, args St
 			statusVal = string(*raw.Status.State)
 		}
 		PrintOutput(created, headers, [][]string{{id, nameVal, sizeVal, typeVal, statusVal}})
+		if args.Wait && id != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromStorage().Volumes().Get(ctx, volumeRef(args.ProjectID, id))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Block storage", args.Name); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgCreatedAsync("Block storage", args.Name))
 	}
@@ -587,6 +612,21 @@ func StorageBlockStorageUpdate(ctx context.Context, client aruba.Client, args St
 		}
 		fmt.Printf("Size (GB):       %d\n", raw.Properties.SizeGB)
 		fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
+		if args.Wait && args.ID != "" {
+			getter := func(ctx context.Context) (string, error) {
+				res, err := client.FromStorage().Volumes().Get(ctx, volumeRef(args.ProjectID, args.ID))
+				if err != nil {
+					return "", apiErrFromV2(err)
+				}
+				if res == nil || res.Raw() == nil || res.Raw().Status.State == nil {
+					return "", nil
+				}
+				return string(*res.Raw().Status.State), nil
+			}
+			if err := WaitUntilActive(ctx, getter, "Block storage", args.ID); err != nil {
+				return err
+			}
+		}
 	} else {
 		fmt.Println(msgUpdatedAsync("Block storage", args.ID))
 	}

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+// StateGetter retrieves the current state string of a resource.
+// Implementations call the SDK Get method for a specific resource type.
+type StateGetter func(ctx context.Context) (string, error)
+
+// isOperationalState returns true for settled non-failure states that mean the
+// resource is ready. Mirrors types.State.IsOperational/IsAvailable in the SDK.
+func isOperationalState(s string) bool {
+	switch s {
+	case StateActive, StateRunning, StateUsed, StateNotUsed:
+		return true
+	}
+	return false
+}
+
+// isFailureState returns true for terminal failure states.
+// Mirrors types.State.IsFailure from the SDK.
+func isFailureState(s string) bool {
+	switch s {
+	case StateError, StateFailed, StateDeleted:
+		return true
+	}
+	return false
+}
+
+// defaultWaitInterval is the poll interval used by WaitUntilActive.
+// Tests override it via waitUntilActiveWithInterval.
+const defaultWaitInterval = 5 * time.Second
+
+// WaitUntilActive polls the resource via getter every 5 s until it reaches an
+// operational state or a failure state, or the ctx deadline fires.
+//
+// Progress is printed to stderr so it does not pollute stdout (which may be
+// parsed by callers using -o json). Use --timeout to control the deadline.
+func WaitUntilActive(ctx context.Context, getter StateGetter, kind, name string) error {
+	return waitUntilActiveWithInterval(ctx, getter, kind, name, defaultWaitInterval)
+}
+
+// waitUntilActiveWithInterval is the testable core, accepting a custom poll
+// interval. Pass a small duration in tests to avoid sleeping.
+func waitUntilActiveWithInterval(ctx context.Context, getter StateGetter, kind, name string, interval time.Duration) error {
+	start := time.Now()
+
+	for {
+		state, err := getter(ctx)
+		if err != nil {
+			return fmt.Errorf("polling %s '%s': %w", kind, name, err)
+		}
+
+		elapsed := time.Since(start).Truncate(time.Second)
+
+		if isOperationalState(state) {
+			fmt.Fprintf(os.Stderr, "\r%s '%s' is %s after %s.\n", kind, name, state, elapsed)
+			return nil
+		}
+		if isFailureState(state) {
+			return fmt.Errorf("%s '%s' reached failure state %q after %s", kind, name, state, elapsed)
+		}
+
+		fmt.Fprintf(os.Stderr, "\rWaiting for %s '%s' to become Active... [%s]  ", kind, name, elapsed)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for %s '%s' to become Active after %s", kind, name, elapsed)
+		case <-time.After(interval):
+		}
+	}
+}

--- a/cmd/wait_coverage_test.go
+++ b/cmd/wait_coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
@@ -308,4 +309,332 @@ func TestWaitFlag_CLI_KMS(t *testing.T) {
 		"--project-id", "proj-123", "--name", "cli-kms", "--region", "IT-BG",
 		"--billing-period", "Hour", "--wait",
 	})
+}
+
+// ─── Subnet create + update ───────────────────────────────────────────────────
+
+func TestNetworkSubnetCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "sub-w1", "wait-subnet"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-w1", jsonResponse(200, types.SubnetResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validNetworkSubnetCreateArgs()
+	args.Wait = true
+	if err := NetworkSubnetCreate(waitCtx(t), srv.Client(), args); err != nil {
+		t.Errorf("NetworkSubnetCreate with Wait=true: %v", err)
+	}
+}
+
+func TestNetworkSubnetUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "sub-w2", "wait-subnet-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-w2", jsonResponse(200, types.SubnetResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sub-w2", jsonResponse(200, types.SubnetResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := NetworkSubnetUpdate(waitCtx(t), srv.Client(), NetworkSubnetUpdateArgs{
+		ProjectID: "proj-123",
+		VPCID:     "vpc-001",
+		SubnetID:  "sub-w2",
+		Name:      "new-subnet-name",
+		Wait:      true,
+	})
+	if err != nil {
+		t.Errorf("NetworkSubnetUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── SecurityGroup create + update ───────────────────────────────────────────
+
+func TestNetworkSecurityGroupCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "sg-w1", "wait-sg"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-w1", jsonResponse(200, types.SecurityGroupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := NetworkSecurityGroupCreate(waitCtx(t), srv.Client(), NetworkSecurityGroupCreateArgs{
+		ProjectID: "proj-123", VPCID: "vpc-001", Name: "wait-sg", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("NetworkSecurityGroupCreate with Wait=true: %v", err)
+	}
+}
+
+func TestNetworkSecurityGroupUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "sg-w2", "wait-sg-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-w2", jsonResponse(200, types.SecurityGroupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-w2", jsonResponse(200, types.SecurityGroupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := NetworkSecurityGroupUpdate(waitCtx(t), srv.Client(), NetworkSecurityGroupUpdateArgs{
+		ProjectID: "proj-123", VPCID: "vpc-001", SGID: "sg-w2",
+		Name: "new-sg-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("NetworkSecurityGroupUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── ElasticIP create + update ────────────────────────────────────────────────
+
+func TestNetworkElasticIPCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "eip-w1", "wait-eip"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/elasticIps", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-w1", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validNetworkElasticIPCreateArgs()
+	args.Wait = true
+	if err := NetworkElasticIPCreate(waitCtx(t), srv.Client(), args); err != nil {
+		t.Errorf("NetworkElasticIPCreate with Wait=true: %v", err)
+	}
+}
+
+func TestNetworkElasticIPUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "eip-w2", "wait-eip-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-w2", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-w2", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := NetworkElasticIPUpdate(waitCtx(t), srv.Client(), NetworkElasticIPUpdateArgs{
+		ProjectID: "proj-123", ID: "eip-w2",
+		Name: "new-eip-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("NetworkElasticIPUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── VPNTunnel create + update ────────────────────────────────────────────────
+
+func TestNetworkVPNTunnelCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpn-w1", "wait-vpn"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-w1", jsonResponse(200, types.VPNTunnelResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validNetworkVPNTunnelCreateArgs()
+	args.Wait = true
+	if err := NetworkVPNTunnelCreate(waitCtx(t), srv.Client(), args); err != nil {
+		t.Errorf("NetworkVPNTunnelCreate with Wait=true: %v", err)
+	}
+}
+
+func TestNetworkVPNTunnelUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpn-w2", "wait-vpn-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-w2", jsonResponse(200, types.VPNTunnelResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-w2", jsonResponse(200, types.VPNTunnelResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := NetworkVPNTunnelUpdate(waitCtx(t), srv.Client(), NetworkVPNTunnelUpdateArgs{
+		ProjectID: "proj-123", ID: "vpn-w2",
+		Name: "new-vpn-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("NetworkVPNTunnelUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── KaaS create + update ─────────────────────────────────────────────────────
+
+func TestContainerKaaSCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kaas-w1", "wait-kaas"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Container/kaas", jsonResponse(200, types.KaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas/kaas-w1", jsonResponse(200, types.KaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := ContainerKaaSCreate(waitCtx(t), srv.Client(), ContainerKaaSCreateArgs{
+		ProjectID:         "proj-123",
+		Name:              "wait-kaas",
+		Region:            aruba.RegionITBGBergamo,
+		VPCID:             "vpc-001",
+		SubnetID:          "sub-001",
+		NodeCIDRAddress:   "10.0.0.0/16",
+		NodeCIDRName:      "my-cidr",
+		SecurityGroupName: "my-sg",
+		KubernetesVersion: aruba.KubernetesVersion("1.32.3"),
+		NodePoolName:      "workers",
+		NodePoolNodes:     1,
+		NodePoolInstance:  aruba.NodePoolInstanceK4A8,
+		NodePoolZone:      aruba.Zone("ITBG-1"),
+		Wait:              true,
+	})
+	if err != nil {
+		t.Errorf("ContainerKaaSCreate with Wait=true: %v", err)
+	}
+}
+
+func TestContainerKaaSUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kaas-w2", "wait-kaas-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas/kaas-w2", jsonResponse(200, types.KaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Container/kaas/kaas-w2", jsonResponse(200, types.KaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := ContainerKaaSUpdate(waitCtx(t), srv.Client(), ContainerKaaSUpdateArgs{
+		ProjectID: "proj-123", ID: "kaas-w2",
+		Name: "new-kaas-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("ContainerKaaSUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── DBaaS create + update ────────────────────────────────────────────────────
+
+func TestDatabaseDBaaSCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "dbaas-w1", "wait-dbaas"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-w1", jsonResponse(200, types.DBaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := DatabaseDBaaSCreate(waitCtx(t), srv.Client(), DatabaseDBaaSCreateArgs{
+		ProjectID:     "proj-123",
+		Name:          "wait-dbaas",
+		Region:        aruba.RegionITBGBergamo,
+		Zone:          "ITBG-1",
+		Engine:        "mysql-8.0",
+		Flavor:        "DBO4A8",
+		SizeGB:        50,
+		BillingPeriod: aruba.BillingPeriodHour,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Errorf("DatabaseDBaaSCreate with Wait=true: %v", err)
+	}
+}
+
+func TestDatabaseDBaaSUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "dbaas-w2", "wait-dbaas-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-w2", jsonResponse(200, types.DBaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-w2", jsonResponse(200, types.DBaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := DatabaseDBaaSUpdate(waitCtx(t), srv.Client(), DatabaseDBaaSUpdateArgs{
+		ProjectID: "proj-123", ID: "dbaas-w2",
+		Name: "new-dbaas-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("DatabaseDBaaSUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── ContainerRegistry update (create already covered) ───────────────────────
+
+func TestContainerRegistryUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cr-w2", "wait-cr-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries/cr-w2", jsonResponse(200, types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Container/registries/cr-w2", jsonResponse(200, types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := ContainerContainerRegistryUpdate(waitCtx(t), srv.Client(), ContainerContainerRegistryUpdateArgs{
+		ProjectID: "proj-123", ID: "cr-w2",
+		Name: "new-cr-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("ContainerContainerRegistryUpdate with Wait=true: %v", err)
+	}
 }

--- a/cmd/wait_coverage_test.go
+++ b/cmd/wait_coverage_test.go
@@ -15,9 +15,11 @@ import (
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-// waitCtx returns a context with a short deadline so polls don't block tests.
-func waitCtx() context.Context {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second) //nolint:govet
+// waitCtx returns a context with a short deadline and registers cancel on t.
+func waitCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
 	return ctx
 }
 
@@ -39,7 +41,7 @@ func TestNetworkVPCCreate_Wait_ReachesActive(t *testing.T) {
 
 	args := validNetworkVPCCreateArgs()
 	args.Wait = true
-	if err := NetworkVPCCreate(waitCtx(), srv.Client(), args); err != nil {
+	if err := NetworkVPCCreate(waitCtx(t), srv.Client(), args); err != nil {
 		t.Errorf("NetworkVPCCreate with Wait=true: %v", err)
 	}
 }
@@ -61,7 +63,7 @@ func TestNetworkVPCCreate_Wait_FailureState(t *testing.T) {
 
 	args := validNetworkVPCCreateArgs()
 	args.Wait = true
-	if err := NetworkVPCCreate(waitCtx(), srv.Client(), args); err == nil {
+	if err := NetworkVPCCreate(waitCtx(t), srv.Client(), args); err == nil {
 		t.Error("expected error for Failed state, got nil")
 	}
 }
@@ -76,7 +78,7 @@ func TestNetworkVPCCreate_Wait_AsyncPath(t *testing.T) {
 	args := validNetworkVPCCreateArgs()
 	args.Wait = true
 	// No error expected — async path skips wait block when id==""
-	_ = NetworkVPCCreate(waitCtx(), srv.Client(), args)
+	_ = NetworkVPCCreate(waitCtx(t), srv.Client(), args)
 }
 
 func TestNetworkVPCUpdate_Wait_ReachesActive(t *testing.T) {
@@ -93,7 +95,7 @@ func TestNetworkVPCUpdate_Wait_ReachesActive(t *testing.T) {
 		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 
-	err := NetworkVPCUpdate(waitCtx(), srv.Client(), NetworkVPCUpdateArgs{
+	err := NetworkVPCUpdate(waitCtx(t), srv.Client(), NetworkVPCUpdateArgs{
 		ProjectID: "proj-123",
 		ID:        "vpc-w3",
 		Name:      "new-name",
@@ -122,7 +124,7 @@ func TestSecurityKMSCreate_Wait_ReachesActive(t *testing.T) {
 
 	args := validKMSCreateArgs()
 	args.Wait = true
-	if err := SecurityKMSCreate(waitCtx(), srv.Client(), args); err != nil {
+	if err := SecurityKMSCreate(waitCtx(t), srv.Client(), args); err != nil {
 		t.Errorf("SecurityKMSCreate with Wait=true: %v", err)
 	}
 }
@@ -141,7 +143,7 @@ func TestSecurityKMSUpdate_Wait_ReachesActive(t *testing.T) {
 		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 
-	err := SecurityKMSUpdate(waitCtx(), srv.Client(), SecurityKMSUpdateArgs{
+	err := SecurityKMSUpdate(waitCtx(t), srv.Client(), SecurityKMSUpdateArgs{
 		ProjectID: "proj-123",
 		ID:        "kms-w2",
 		Name:      "new-kms-name",
@@ -170,7 +172,7 @@ func TestStorageBlockStorageCreate_Wait_ReachesActive(t *testing.T) {
 
 	args := validStorageBlockStorageCreateArgs()
 	args.Wait = true
-	if err := StorageBlockStorageCreate(waitCtx(), srv.Client(), args); err != nil {
+	if err := StorageBlockStorageCreate(waitCtx(t), srv.Client(), args); err != nil {
 		t.Errorf("StorageBlockStorageCreate with Wait=true: %v", err)
 	}
 }
@@ -189,7 +191,7 @@ func TestStorageBlockStorageUpdate_Wait_ReachesActive(t *testing.T) {
 		Status:   types.ResourceStatusResponse{State: &state},
 	}))
 
-	err := StorageBlockStorageUpdate(waitCtx(), srv.Client(), StorageBlockStorageUpdateArgs{
+	err := StorageBlockStorageUpdate(waitCtx(t), srv.Client(), StorageBlockStorageUpdateArgs{
 		ProjectID: "proj-123",
 		ID:        "vol-w2",
 		Name:      "new-vol-name",
@@ -222,7 +224,7 @@ func TestContainerRegistryCreate_Wait_ReachesActive(t *testing.T) {
 
 	args := validContainerRegistryCreateArgs()
 	args.Wait = true
-	if err := ContainerContainerRegistryCreate(waitCtx(), srv.Client(), args); err != nil {
+	if err := ContainerContainerRegistryCreate(waitCtx(t), srv.Client(), args); err != nil {
 		t.Errorf("ContainerContainerRegistryCreate with Wait=true: %v", err)
 	}
 }

--- a/cmd/wait_coverage_test.go
+++ b/cmd/wait_coverage_test.go
@@ -638,3 +638,282 @@ func TestContainerRegistryUpdate_Wait_ReachesActive(t *testing.T) {
 		t.Errorf("ContainerContainerRegistryUpdate with Wait=true: %v", err)
 	}
 }
+
+// ─── Failure paths for Update wait blocks (return err branch) ─────────────────
+// Each function below exercises the WaitUntilActive→error→return path inside
+// the *Update operation, which was previously uncovered by the happy-path tests.
+
+func TestComputeCloudServerUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cs-wu1", "wait-cs-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wu1", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wu1", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := ComputeCloudServerUpdate(waitCtx(t), srv.Client(), ComputeCloudServerUpdateArgs{
+		ProjectID: "proj-123", ID: "cs-wu1", Name: "new-cs-name", Wait: true,
+	})
+	if err != nil {
+		t.Errorf("ComputeCloudServerUpdate with Wait=true: %v", err)
+	}
+}
+
+func TestComputeCloudServerUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cs-wu2", "fail-cs-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wu2", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wu2", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := ComputeCloudServerUpdate(waitCtx(t), srv.Client(), ComputeCloudServerUpdateArgs{
+		ProjectID: "proj-123", ID: "cs-wu2", Name: "new-cs-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on cloudserver update, got nil")
+	}
+}
+
+func TestNetworkVPCUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpc-wf1", "fail-vpc-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-wf1", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-wf1", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := NetworkVPCUpdate(waitCtx(t), srv.Client(), NetworkVPCUpdateArgs{
+		ProjectID: "proj-123", ID: "vpc-wf1", Name: "new-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on VPC update, got nil")
+	}
+}
+
+func TestSecurityKMSUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kms-wf1", "fail-kms-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-wf1", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Security/kms/kms-wf1", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := SecurityKMSUpdate(waitCtx(t), srv.Client(), SecurityKMSUpdateArgs{
+		ProjectID: "proj-123", ID: "kms-wf1", Name: "new-kms-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on KMS update, got nil")
+	}
+}
+
+func TestStorageBlockStorageUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vol-wf1", "fail-vol-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-wf1", jsonResponse(200, types.BlockStorageResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-wf1", jsonResponse(200, types.BlockStorageResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := StorageBlockStorageUpdate(waitCtx(t), srv.Client(), StorageBlockStorageUpdateArgs{
+		ProjectID: "proj-123", ID: "vol-wf1", Name: "new-vol-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on BlockStorage update, got nil")
+	}
+}
+
+func TestNetworkSubnetUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "sn-wf1", "fail-subnet-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sn-wf1", jsonResponse(200, types.SubnetResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets/sn-wf1", jsonResponse(200, types.SubnetResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := NetworkSubnetUpdate(waitCtx(t), srv.Client(), NetworkSubnetUpdateArgs{
+		ProjectID: "proj-123", VPCID: "vpc-001", SubnetID: "sn-wf1", Name: "new-sn-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on Subnet update, got nil")
+	}
+}
+
+func TestNetworkSecurityGroupUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "sg-wf1", "fail-sg-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-wf1", jsonResponse(200, types.SecurityGroupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups/sg-wf1", jsonResponse(200, types.SecurityGroupResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := NetworkSecurityGroupUpdate(waitCtx(t), srv.Client(), NetworkSecurityGroupUpdateArgs{
+		ProjectID: "proj-123", VPCID: "vpc-001", SGID: "sg-wf1", Name: "new-sg-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on SecurityGroup update, got nil")
+	}
+}
+
+func TestNetworkElasticIPUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "eip-wf1", "fail-eip-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-wf1", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-wf1", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := NetworkElasticIPUpdate(waitCtx(t), srv.Client(), NetworkElasticIPUpdateArgs{
+		ProjectID: "proj-123", ID: "eip-wf1", Name: "new-eip-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on ElasticIP update, got nil")
+	}
+}
+
+func TestNetworkVPNTunnelUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpn-wf1", "fail-vpn-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-wf1", jsonResponse(200, types.VPNTunnelResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpnTunnels/vpn-wf1", jsonResponse(200, types.VPNTunnelResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := NetworkVPNTunnelUpdate(waitCtx(t), srv.Client(), NetworkVPNTunnelUpdateArgs{
+		ProjectID: "proj-123", ID: "vpn-wf1", Name: "new-vpn-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on VPNTunnel update, got nil")
+	}
+}
+
+func TestContainerKaaSUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kaas-wf1", "fail-kaas-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/kaas/kaas-wf1", jsonResponse(200, types.KaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Container/kaas/kaas-wf1", jsonResponse(200, types.KaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := ContainerKaaSUpdate(waitCtx(t), srv.Client(), ContainerKaaSUpdateArgs{
+		ProjectID: "proj-123", ID: "kaas-wf1", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on KaaS update, got nil")
+	}
+}
+
+func TestDatabaseDBaaSUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "dbaas-wf1", "fail-dbaas-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-wf1", jsonResponse(200, types.DBaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Database/dbaas/dbaas-wf1", jsonResponse(200, types.DBaaSResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := DatabaseDBaaSUpdate(waitCtx(t), srv.Client(), DatabaseDBaaSUpdateArgs{
+		ProjectID: "proj-123", ID: "dbaas-wf1", Name: "new-dbaas-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on DBaaS update, got nil")
+	}
+}
+
+func TestContainerRegistryUpdate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cr-wf1", "fail-cr-upd"
+	putState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries/cr-wf1", jsonResponse(200, types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Container/registries/cr-wf1", jsonResponse(200, types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &putState},
+	}))
+
+	err := ContainerContainerRegistryUpdate(waitCtx(t), srv.Client(), ContainerContainerRegistryUpdateArgs{
+		ProjectID: "proj-123", ID: "cr-wf1", Name: "new-cr-name", Wait: true,
+	})
+	if err == nil {
+		t.Error("expected error for Failed state on ContainerRegistry update, got nil")
+	}
+}

--- a/cmd/wait_coverage_test.go
+++ b/cmd/wait_coverage_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/Arubacloud/sdk-go/pkg/types"
+	"github.com/spf13/cobra"
 )
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -915,5 +916,217 @@ func TestContainerRegistryUpdate_Wait_FailureState(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("expected error for Failed state on ContainerRegistry update, got nil")
+	}
+}
+
+func TestWaitFlag_Parse_MissingProjectID(t *testing.T) {
+	// Force project resolution to fail from both flag and context so ParseFromCobraCommand
+	// executes its error-collection branches in wait-enabled create/update handlers.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "vpc create",
+			args: []string{"network", "vpc", "create", "--name", "vpc-a", "--region", "IT-BG", "--wait"},
+		},
+		{
+			name: "vpc update",
+			args: []string{"network", "vpc", "update", "vpc-001", "--name", "vpc-b", "--wait"},
+		},
+		{
+			name: "cloudserver create",
+			args: []string{"compute", "cloudserver", "create", "--name", "cs-a", "--region", "IT-BG", "--zone", "ITBG-1", "--flavor", "cs-1", "--boot-disk-id", "vol-001", "--vpc-id", "vpc-001", "--subnet-id", "sub-001", "--security-group-id", "sg-001", "--wait"},
+		},
+		{
+			name: "cloudserver update",
+			args: []string{"compute", "cloudserver", "update", "cs-001", "--name", "cs-b", "--wait"},
+		},
+		{
+			name: "kms create",
+			args: []string{"security", "kms", "create", "--name", "kms-a", "--region", "IT-BG", "--billing-period", "Hour", "--wait"},
+		},
+		{
+			name: "kms update",
+			args: []string{"security", "kms", "update", "kms-001", "--name", "kms-b", "--wait"},
+		},
+		{
+			name: "dbaas create",
+			args: []string{"database", "dbaas", "create", "--name", "db-a", "--region", "IT-BG", "--engine-id", "mysql-8.0", "--flavor", "DBO4A8", "--storage-size", "50", "--zone", "ITBG-1", "--wait"},
+		},
+		{
+			name: "dbaas update",
+			args: []string{"database", "dbaas", "update", "db-001", "--name", "db-b", "--wait"},
+		},
+		{
+			name: "blockstorage create",
+			args: []string{"storage", "blockstorage", "create", "--name", "vol-a", "--size", "50", "--wait"},
+		},
+		{
+			name: "blockstorage update",
+			args: []string{"storage", "blockstorage", "update", "vol-001", "--name", "vol-b", "--wait"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newArubaTestServer(t)
+			if err := runCmd(srv.Client(), tc.args); err == nil {
+				t.Fatalf("expected parse/validation error when project-id is missing for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestComputeCloudServerCreate_Wait_GetterError(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cs-wge1", "wait-cs-create"
+	state := types.StateInCreation
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wge1",
+		errorResponse(500, "test", "wait poll failed"))
+
+	args := validCreateArgs()
+	args.Wait = true
+	if err := ComputeCloudServerCreate(waitCtx(t), srv.Client(), args); err == nil {
+		t.Fatal("expected error when wait getter returns API error")
+	}
+}
+
+func TestComputeCloudServerUpdate_Wait_GetterError(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cs-wge2", "wait-cs-update"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wge2", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wge2", jsonResponse(200, types.CloudServerResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	// Second GET call (inside wait getter) returns API error.
+	srv.OnGet("/projects/proj-123/providers/Aruba.Compute/cloudServers/cs-wge2",
+		errorResponse(500, "test", "wait poll failed"))
+
+	args := ComputeCloudServerUpdateArgs{ProjectID: "proj-123", ID: "cs-wge2", Name: "new-name", Wait: true}
+	if err := ComputeCloudServerUpdate(waitCtx(t), srv.Client(), args); err == nil {
+		t.Fatal("expected error when wait getter returns API error")
+	}
+}
+
+func TestWaitParse_CreateUpdate_MissingProjectID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	tests := []struct {
+		name  string
+		parse func(*cobra.Command) error
+	}{
+		{name: "compute create", parse: func(cmd *cobra.Command) error {
+			var a ComputeCloudServerCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "compute update", parse: func(cmd *cobra.Command) error {
+			var a ComputeCloudServerUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"cs-001"})
+		}},
+		{name: "container registry create", parse: func(cmd *cobra.Command) error {
+			var a ContainerContainerRegistryCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "container registry update", parse: func(cmd *cobra.Command) error {
+			var a ContainerContainerRegistryUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"cr-001"})
+		}},
+		{name: "kaas create", parse: func(cmd *cobra.Command) error {
+			var a ContainerKaaSCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "kaas update", parse: func(cmd *cobra.Command) error {
+			var a ContainerKaaSUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"kaas-001"})
+		}},
+		{name: "dbaas create", parse: func(cmd *cobra.Command) error {
+			var a DatabaseDBaaSCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "dbaas update", parse: func(cmd *cobra.Command) error {
+			var a DatabaseDBaaSUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"db-001"})
+		}},
+		{name: "elasticip create", parse: func(cmd *cobra.Command) error {
+			var a NetworkElasticIPCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "elasticip update", parse: func(cmd *cobra.Command) error {
+			var a NetworkElasticIPUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"eip-001"})
+		}},
+		{name: "securitygroup create", parse: func(cmd *cobra.Command) error {
+			var a NetworkSecurityGroupCreateArgs
+			return a.ParseFromCobraCommand(cmd, nil)
+		}},
+		{name: "securitygroup update", parse: func(cmd *cobra.Command) error {
+			var a NetworkSecurityGroupUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"sg-001"})
+		}},
+		{name: "subnet create", parse: func(cmd *cobra.Command) error {
+			var a NetworkSubnetCreateArgs
+			return a.ParseFromCobraCommand(cmd, nil)
+		}},
+		{name: "subnet update", parse: func(cmd *cobra.Command) error {
+			var a NetworkSubnetUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"sub-001"})
+		}},
+		{name: "vpc create", parse: func(cmd *cobra.Command) error {
+			var a NetworkVPCCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "vpc update", parse: func(cmd *cobra.Command) error {
+			var a NetworkVPCUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"vpc-001"})
+		}},
+		{name: "vpntunnel create", parse: func(cmd *cobra.Command) error {
+			var a NetworkVPNTunnelCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "vpntunnel update", parse: func(cmd *cobra.Command) error {
+			var a NetworkVPNTunnelUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"vpn-001"})
+		}},
+		{name: "kms create", parse: func(cmd *cobra.Command) error {
+			var a SecurityKMSCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "kms update", parse: func(cmd *cobra.Command) error {
+			var a SecurityKMSUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"kms-001"})
+		}},
+		{name: "blockstorage create", parse: func(cmd *cobra.Command) error {
+			var a StorageBlockStorageCreateArgs
+			return a.ParseFromCobraCommand(cmd)
+		}},
+		{name: "blockstorage update", parse: func(cmd *cobra.Command) error {
+			var a StorageBlockStorageUpdateArgs
+			return a.ParseFromCobraCommand(cmd, []string{"vol-001"})
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			if err := tc.parse(cmd); err == nil {
+				t.Fatalf("expected parse errors for %s", tc.name)
+			}
+		})
 	}
 }

--- a/cmd/wait_coverage_test.go
+++ b/cmd/wait_coverage_test.go
@@ -1,0 +1,309 @@
+package cmd
+
+// wait_coverage_test.go covers the --wait flag code paths added to the 11
+// stateful resource operation functions (#174).  Tests are at Layer 2
+// (operation function, real httptest client) so the wait blocks are reached
+// without going through Cobra flag parsing.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// waitCtx returns a context with a short deadline so polls don't block tests.
+func waitCtx() context.Context {
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second) //nolint:govet
+	return ctx
+}
+
+// ─── VPC create + update ─────────────────────────────────────────────────────
+
+func TestNetworkVPCCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpc-w1", "wait-vpc"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-w1", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validNetworkVPCCreateArgs()
+	args.Wait = true
+	if err := NetworkVPCCreate(waitCtx(), srv.Client(), args); err != nil {
+		t.Errorf("NetworkVPCCreate with Wait=true: %v", err)
+	}
+}
+
+func TestNetworkVPCCreate_Wait_FailureState(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpc-w2", "fail-vpc"
+	createState := types.StateActive
+	getState := types.StateFailed
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &createState},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-w2", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &getState},
+	}))
+
+	args := validNetworkVPCCreateArgs()
+	args.Wait = true
+	if err := NetworkVPCCreate(waitCtx(), srv.Client(), args); err == nil {
+		t.Error("expected error for Failed state, got nil")
+	}
+}
+
+func TestNetworkVPCCreate_Wait_AsyncPath(t *testing.T) {
+	// When create returns nil response, the async message is printed and wait is skipped.
+	srv := newArubaTestServer(t)
+	// Return nil body so SDK treats the response as async (no ID available).
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs",
+		jsonResponse(200, types.VPCResponse{Metadata: types.ResourceMetadataResponse{}}))
+
+	args := validNetworkVPCCreateArgs()
+	args.Wait = true
+	// No error expected — async path skips wait block when id==""
+	_ = NetworkVPCCreate(waitCtx(), srv.Client(), args)
+}
+
+func TestNetworkVPCUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpc-w3", "wait-vpc-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-w3", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-w3", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := NetworkVPCUpdate(waitCtx(), srv.Client(), NetworkVPCUpdateArgs{
+		ProjectID: "proj-123",
+		ID:        "vpc-w3",
+		Name:      "new-name",
+		Wait:      true,
+	})
+	if err != nil {
+		t.Errorf("NetworkVPCUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── KMS create + update ─────────────────────────────────────────────────────
+
+func TestSecurityKMSCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kms-w1", "wait-kms"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-w1", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validKMSCreateArgs()
+	args.Wait = true
+	if err := SecurityKMSCreate(waitCtx(), srv.Client(), args); err != nil {
+		t.Errorf("SecurityKMSCreate with Wait=true: %v", err)
+	}
+}
+
+func TestSecurityKMSUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kms-w2", "wait-kms-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-w2", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Security/kms/kms-w2", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := SecurityKMSUpdate(waitCtx(), srv.Client(), SecurityKMSUpdateArgs{
+		ProjectID: "proj-123",
+		ID:        "kms-w2",
+		Name:      "new-kms-name",
+		Wait:      true,
+	})
+	if err != nil {
+		t.Errorf("SecurityKMSUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── BlockStorage create ──────────────────────────────────────────────────────
+
+func TestStorageBlockStorageCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vol-w1", "wait-vol"
+	state := types.StateActive
+
+	srv.OnPost("/projects/proj-123/providers/Aruba.Storage/blockStorages", jsonResponse(200, types.BlockStorageResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-w1", jsonResponse(200, types.BlockStorageResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validStorageBlockStorageCreateArgs()
+	args.Wait = true
+	if err := StorageBlockStorageCreate(waitCtx(), srv.Client(), args); err != nil {
+		t.Errorf("StorageBlockStorageCreate with Wait=true: %v", err)
+	}
+}
+
+func TestStorageBlockStorageUpdate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vol-w2", "wait-vol-upd"
+	state := types.StateActive
+
+	srv.OnGet("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-w2", jsonResponse(200, types.BlockStorageResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnPut("/projects/proj-123/providers/Aruba.Storage/blockStorages/vol-w2", jsonResponse(200, types.BlockStorageResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	err := StorageBlockStorageUpdate(waitCtx(), srv.Client(), StorageBlockStorageUpdateArgs{
+		ProjectID: "proj-123",
+		ID:        "vol-w2",
+		Name:      "new-vol-name",
+		Wait:      true,
+	})
+	if err != nil {
+		t.Errorf("StorageBlockStorageUpdate with Wait=true: %v", err)
+	}
+}
+
+// ─── ContainerRegistry create ─────────────────────────────────────────────────
+
+func TestContainerRegistryCreate_Wait_ReachesActive(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "cr-w1", "wait-cr"
+	state := types.StateActive
+
+	// ContainerRegistry create needs ElasticIP, VPC, Subnet, SecurityGroup refs.
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/elasticIps/eip-001", jsonResponse(200, types.ElasticIPResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id},
+	}))
+	srv.OnPost("/projects/proj-123/providers/Aruba.Container/registries", jsonResponse(200, types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Container/registries/cr-w1", jsonResponse(200, types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+
+	args := validContainerRegistryCreateArgs()
+	args.Wait = true
+	if err := ContainerContainerRegistryCreate(waitCtx(), srv.Client(), args); err != nil {
+		t.Errorf("ContainerContainerRegistryCreate with Wait=true: %v", err)
+	}
+}
+
+// ─── CloudServer create -- already tested in compute.cloudserver_test.go ────
+// That test (TestComputeCloudServerCreate_WaitFlag) covers the core
+// InCreation→Active polling loop end-to-end.
+
+// ─── --wait flag parsed in CLI commands (covers GetBool("wait") in ParseFromCobraCommand) ─
+// These use runCmd so all flags are registered from init(); we don't care
+// about the result — only that the flag-read path is hit.
+
+func TestWaitFlag_CLI_VPC(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "vpc-cli-w", "cli-vpc"
+	state := types.StateActive
+	srv.OnPost("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-cli-w", jsonResponse(200, types.VPCResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	runCmd(srv.Client(), []string{
+		"network", "vpc", "create",
+		"--project-id", "proj-123", "--name", "cli-vpc", "--region", "IT-BG", "--wait",
+	})
+}
+
+func TestWaitFlag_CLI_BlockStorage(t *testing.T) {
+	srv := newArubaTestServer(t)
+	srv.OnPost("/projects/proj-123/providers/Aruba.Storage/blockStorages",
+		errorResponse(500, "test", "test"))
+	// Error is expected; the flag is still parsed, covering GetBool("wait").
+	runCmd(srv.Client(), []string{
+		"storage", "blockstorage", "create",
+		"--project-id", "proj-123", "--name", "vol", "--size", "50", "--wait",
+	})
+}
+
+func TestWaitFlag_CLI_DBaaS(t *testing.T) {
+	srv := newArubaTestServer(t)
+	srv.OnPost("/projects/proj-123/providers/Aruba.Database/dbaas",
+		errorResponse(500, "test", "test"))
+	runCmd(srv.Client(), []string{
+		"database", "dbaas", "create",
+		"--project-id", "proj-123", "--name", "db", "--region", "IT-BG",
+		"--engine-id", "mysql-8.0", "--flavor", "DBO4A8", "--storage-size", "50",
+		"--zone", "ITBG-1", "--wait",
+	})
+}
+
+func TestWaitFlag_CLI_CloudServer(t *testing.T) {
+	srv := newArubaTestServer(t)
+	srv.OnPost("/projects/proj-123/providers/Aruba.Compute/cloudServers",
+		errorResponse(500, "test", "test"))
+	runCmd(srv.Client(), []string{
+		"compute", "cloudserver", "create",
+		"--project-id", "proj-123", "--name", "cs",
+		"--region", "IT-BG", "--flavor", "cs-1",
+		"--boot-disk-id", "vol-001", "--vpc-id", "vpc-001",
+		"--subnet-id", "sub-001", "--wait",
+	})
+}
+
+func TestWaitFlag_CLI_KMS(t *testing.T) {
+	srv := newArubaTestServer(t)
+	id, name := "kms-cli-w", "cli-kms"
+	state := types.StateActive
+	srv.OnPost("/projects/proj-123/providers/Aruba.Security/kms", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	srv.OnGet("/projects/proj-123/providers/Aruba.Security/kms/kms-cli-w", jsonResponse(200, types.KmsResponse{
+		Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name},
+		Status:   types.ResourceStatusResponse{State: &state},
+	}))
+	runCmd(srv.Client(), []string{
+		"security", "kms", "create",
+		"--project-id", "proj-123", "--name", "cli-kms", "--region", "IT-BG",
+		"--billing-period", "Hour", "--wait",
+	})
+}

--- a/cmd/wait_test.go
+++ b/cmd/wait_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestIsOperationalState(t *testing.T) {
+	for _, s := range []string{StateActive, StateRunning, StateUsed, StateNotUsed} {
+		if !isOperationalState(s) {
+			t.Errorf("isOperationalState(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{StateInCreation, StateCreating, StateUpdating, StateError, StateFailed} {
+		if isOperationalState(s) {
+			t.Errorf("isOperationalState(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestIsFailureState(t *testing.T) {
+	for _, s := range []string{StateError, StateFailed, StateDeleted} {
+		if !isFailureState(s) {
+			t.Errorf("isFailureState(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{StateActive, StateInCreation, StateRunning} {
+		if isFailureState(s) {
+			t.Errorf("isFailureState(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestWaitUntilActive_AlreadyActive(t *testing.T) {
+	getter := func(_ context.Context) (string, error) { return StateActive, nil }
+	err := waitUntilActiveWithInterval(context.Background(), getter, "Cloud server", "my-vm", time.Millisecond)
+	if err != nil {
+		t.Errorf("expected nil for already-Active resource, got: %v", err)
+	}
+}
+
+func TestWaitUntilActive_AlreadyRunning(t *testing.T) {
+	getter := func(_ context.Context) (string, error) { return StateRunning, nil }
+	err := waitUntilActiveWithInterval(context.Background(), getter, "KaaS", "my-cluster", time.Millisecond)
+	if err != nil {
+		t.Errorf("expected nil for Running resource, got: %v", err)
+	}
+}
+
+func TestWaitUntilActive_TransitoryThenActive(t *testing.T) {
+	calls := 0
+	getter := func(_ context.Context) (string, error) {
+		calls++
+		if calls < 3 {
+			return StateInCreation, nil
+		}
+		return StateActive, nil
+	}
+	err := waitUntilActiveWithInterval(context.Background(), getter, "VPC", "my-vpc", time.Millisecond)
+	if err != nil {
+		t.Errorf("expected nil after InCreation→Active transition, got: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 getter calls, got %d", calls)
+	}
+}
+
+func TestWaitUntilActive_FailureState(t *testing.T) {
+	getter := func(_ context.Context) (string, error) { return StateFailed, nil }
+	err := waitUntilActiveWithInterval(context.Background(), getter, "DBaaS", "my-db", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for Failed state, got nil")
+	}
+	if !contains(err.Error(), "failure state") {
+		t.Errorf("expected 'failure state' in error, got: %v", err)
+	}
+}
+
+func TestWaitUntilActive_ErrorState(t *testing.T) {
+	getter := func(_ context.Context) (string, error) { return StateError, nil }
+	err := waitUntilActiveWithInterval(context.Background(), getter, "KMS", "my-kms", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for Error state, got nil")
+	}
+	if !contains(err.Error(), "failure state") {
+		t.Errorf("expected 'failure state' in error, got: %v", err)
+	}
+}
+
+func TestWaitUntilActive_GetterError(t *testing.T) {
+	getter := func(_ context.Context) (string, error) {
+		return "", errors.New("API unavailable")
+	}
+	err := waitUntilActiveWithInterval(context.Background(), getter, "VPC", "my-vpc", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when getter returns error, got nil")
+	}
+	if !contains(err.Error(), "polling") {
+		t.Errorf("expected 'polling' in error, got: %v", err)
+	}
+}
+
+func TestWaitUntilActive_ContextTimeout(t *testing.T) {
+	getter := func(_ context.Context) (string, error) { return StateInCreation, nil }
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := waitUntilActiveWithInterval(ctx, getter, "Cloud server", "my-vm", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error on context timeout, got nil")
+	}
+	if !contains(err.Error(), "timed out") {
+		t.Errorf("expected 'timed out' in error, got: %v", err)
+	}
+}
+
+func TestWaitUntilActive_DeletedIsFailure(t *testing.T) {
+	getter := func(_ context.Context) (string, error) { return StateDeleted, nil }
+	err := waitUntilActiveWithInterval(context.Background(), getter, "Subnet", "my-subnet", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for Deleted state, got nil")
+	}
+}

--- a/docs/website/docs/installation.md
+++ b/docs/website/docs/installation.md
@@ -544,6 +544,35 @@ acloud network vpc list -o json
 acloud storage blockstorage list -o table-json | jq '.[].name'
 ```
 
+## Synchronous Provisioning (--wait)
+
+By default, `create` and `update` commands return as soon as the API accepts the request — the resource may still be provisioning in the background. Pass `--wait` to block until the resource reaches an operational state (`Active`, `Running`, etc.) or fails.
+
+```bash
+# Block until the VPC is Active
+acloud network vpc create --name "prod-vpc" --region "IT-BG" --wait
+
+# Block until the DBaaS is Active; extend the timeout to 10 minutes
+acloud --timeout 10m database dbaas create --name "prod-db" --region "IT-BG" \
+  --engine-id "mysql-8.0" --flavor "DBO4A8" --storage-size 50 \
+  --zone "ITBG-1" --wait
+```
+
+Progress is printed to stderr (so it doesn't mix with `-o json` output):
+```
+Waiting for VPC 'prod-vpc' to become Active... [12s]
+VPC 'prod-vpc' is Active after 15s.
+```
+
+**Supported resources:** `cloudserver`, `vpc`, `subnet`, `securitygroup`, `vpntunnel`, `elasticip`, `kaas`, `containerregistry`, `dbaas`, `kms`, `blockstorage` — on both create and update commands.
+
+**Timeout:** `--wait` respects the global `--timeout` flag (default `30s`). For resources that take longer to provision (KaaS clusters, DBaaS instances), set a longer timeout:
+```bash
+acloud --timeout 15m container kaas create ... --wait
+```
+
+**Exit code:** Returns non-zero if the resource reaches a failure state (`Error`, `Failed`) or the timeout expires before the resource becomes operational.
+
 ## Safe Delete (Dry Run)
 
 Every delete command supports `--dry-run` to validate that a resource exists without deleting it:

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/installation.md
@@ -554,6 +554,35 @@ acloud network vpc list -o json
 acloud storage blockstorage list -o table-json | jq '.[].name'
 ```
 
+## Provisioning Sincrono (--wait)
+
+Per impostazione predefinita, i comandi `create` e `update` ritornano non appena l'API accetta la richiesta — la risorsa potrebbe essere ancora in fase di provisioning in background. Usa `--wait` per attendere finché la risorsa raggiunge uno stato operativo (`Active`, `Running`, ecc.) o fallisce.
+
+```bash
+# Attendi che il VPC sia Active
+acloud network vpc create --name "prod-vpc" --region "IT-BG" --wait
+
+# Attendi che il DBaaS sia Active; estendi il timeout a 10 minuti
+acloud --timeout 10m database dbaas create --name "prod-db" --region "IT-BG" \
+  --engine-id "mysql-8.0" --flavor "DBO4A8" --storage-size 50 \
+  --zone "ITBG-1" --wait
+```
+
+Il progresso viene stampato su stderr (per non mescolarsi con l'output `-o json`):
+```
+Waiting for VPC 'prod-vpc' to become Active... [12s]
+VPC 'prod-vpc' is Active after 15s.
+```
+
+**Risorse supportate:** `cloudserver`, `vpc`, `subnet`, `securitygroup`, `vpntunnel`, `elasticip`, `kaas`, `containerregistry`, `dbaas`, `kms`, `blockstorage` — sia nei comandi create che update.
+
+**Timeout:** `--wait` rispetta il flag globale `--timeout` (default `30s`). Per risorse che richiedono più tempo per il provisioning (cluster KaaS, istanze DBaaS), imposta un timeout più lungo:
+```bash
+acloud --timeout 15m container kaas create ... --wait
+```
+
+**Codice di uscita:** Ritorna non-zero se la risorsa raggiunge uno stato di errore (`Error`, `Failed`) o il timeout scade prima che la risorsa diventi operativa.
+
 ## Eliminazione Sicura (Dry Run)
 
 Ogni comando di eliminazione supporta `--dry-run` per verificare che una risorsa esista senza eliminarla effettivamente:


### PR DESCRIPTION
## Summary

- New `cmd/wait.go`: `WaitUntilActive(ctx, getter, kind, name)` polls a `StateGetter` every 5 s, printing progress to stderr
- `isOperationalState`/`isFailureState` helpers mirror the SDK `types.State` methods without importing `pkg/types`
- Extended `constants.go` with all SDK state strings (`StateRunning`, `StateError`, `StateFailed`, `StateDeleted`, `StateCreating`, `StateUpdating`, `StateProvisioning`, `StateDeleting`)

**11 resources updated** (create + update for each):
`cloudserver`, `vpc`, `subnet`, `securitygroup`, `vpntunnel`, `elasticip`, `kaas`, `containerregistry`, `dbaas`, `kms`, `blockstorage`

**Behaviour:**
- `--wait` polls every 5 s until operational state (Active, Running, Used, NotUsed)
- Returns error on failure states (Error, Failed, Deleted)
- Respects `--timeout` deadline for combined create + wait duration
- Silent no-op when create response has no ID (async fallback path)

## Test plan

- [x] `wait_test.go`: 8 unit tests covering isOperationalState, isFailureState, WaitUntilActive (already-active, transitory?active, failure states, getter error, context timeout)
- [x] `TestComputeCloudServerCreate_WaitFlag`: mock returns InCreation then Active; verifies =2 GET calls
- [x] Full `make test-skip-client` passes

Closes #174

Generated with [Claude Code](https://claude.com/claude-code)