### PR TITLE
fix(e2e): add Cleanup completed guard to network and storage suites

### DIFF
--- a/e2e/network/test.sh
+++ b/e2e/network/test.sh
@@ -346,6 +346,8 @@ cleanup() {
             del_elapsed=$((del_elapsed + 10))
         done
     fi
+
+    echo -e "${GREEN}Cleanup completed!${NC}"
 }
 
 trap cleanup EXIT

--- a/e2e/storage/test.sh
+++ b/e2e/storage/test.sh
@@ -119,6 +119,8 @@ cleanup() {
             del_elapsed=$((del_elapsed + 10))
         done
     fi
+
+    echo -e "${GREEN}Cleanup completed!${NC}"
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
When BOOTSTRAP_PROJECT_ID is empty (CI with ACLOUD_PROJECT_ID pre-set), the trailing if block exits with 1 (bash if-with-false-condition-and-no-else), propagating through the EXIT trap and making the suite exit 1 even when FAILURES=0. All other 6 suites already end cleanup() with "echo Cleanup completed" which guarantees exit 0. Add the same guard to network and storage to match.

