### PR TITLE
feat: add PersistentPreRunE for early client initialization

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -5,7 +5,31 @@ import (
 
 	"github.com/Arubacloud/acloud-cli/internal/client"
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/spf13/cobra"
 )
+
+func init() {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if skipClientInit(cmd) {
+			return nil
+		}
+		_, err := GetArubaClient()
+		return err
+	}
+}
+
+// skipClientInit returns true for commands that work without an SDK client:
+// config/context management, shell completion helpers, and built-in help.
+func skipClientInit(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case "config", "context", "completion",
+			"__complete", "__completeNoDesc", "help":
+			return true
+		}
+	}
+	return false
+}
 
 // GetArubaClient returns a cached aruba.Client built from the active profile config.
 // The client is re-created whenever credentials, URLs, or the --debug flag change.

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestSkipClientInit(t *testing.T) {
+	cases := []struct {
+		name string
+		path []string // command path from root to leaf (root first)
+		want bool
+	}{
+		// Commands that MUST skip client init
+		{"config root", []string{"acloud", "config"}, true},
+		{"config set", []string{"acloud", "config", "set"}, true},
+		{"config show", []string{"acloud", "config", "show"}, true},
+		{"config profile list", []string{"acloud", "config", "profile", "list"}, true},
+		{"context root", []string{"acloud", "context"}, true},
+		{"context use", []string{"acloud", "context", "use"}, true},
+		{"context list", []string{"acloud", "context", "list"}, true},
+		{"completion", []string{"acloud", "completion"}, true},
+		{"__complete", []string{"acloud", "__complete"}, true},
+		{"__completeNoDesc", []string{"acloud", "__completeNoDesc"}, true},
+		{"help", []string{"acloud", "help"}, true},
+		// Resource commands that MUST NOT skip
+		{"network vpc list", []string{"acloud", "network", "vpc", "list"}, false},
+		{"compute cloudserver get", []string{"acloud", "compute", "cloudserver", "get"}, false},
+		{"storage blockstorage list", []string{"acloud", "storage", "blockstorage", "list"}, false},
+		{"security kms create", []string{"acloud", "security", "kms", "create"}, false},
+		{"management project list", []string{"acloud", "management", "project", "list"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build a chain of commands matching the path.
+			var leaf *cobra.Command
+			for i, name := range tc.path {
+				cmd := &cobra.Command{Use: name}
+				if i > 0 {
+					leaf.AddCommand(cmd)
+				}
+				leaf = cmd
+			}
+			if got := skipClientInit(leaf); got != tc.want {
+				t.Errorf("skipClientInit(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPersistentPreRunE_SkipsForConfig(t *testing.T) {
+	// config show must work without a valid credentials file.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Cleanup(resetClientState)
+
+	// Running config show without credentials should not return a credential error.
+	err := runCmd(nil, []string{"config", "show"})
+	if err != nil {
+		t.Errorf("config show should not require credentials, got: %v", err)
+	}
+}
+
+func TestPersistentPreRunE_SkipsForContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Cleanup(resetClientState)
+
+	err := runCmd(nil, []string{"context", "list"})
+	if err != nil {
+		t.Errorf("context list should not require credentials, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #208.

Wires `GetArubaClient()` into `rootCmd.PersistentPreRunE` so credentials are validated **once** before any resource command's `RunE` fires. Subsequent `GetArubaClient()` calls within the same invocation hit the `internal/client` cache at zero I/O cost. All 60+ existing call sites in `RunE` handlers are **unchanged** — they now always get a cache hit.

## How it works

```
CLI invocation
  └─ PersistentPreRunE            ← NEW: validates credentials once
       ├─ skipClientInit? → skip  ← config / context / completion / help
       └─ GetArubaClient()        ← warms cache; returns error early if no creds
  └─ RunE
       └─ GetArubaClient()        ← cache hit, no I/O
```

`skipClientInit()` walks the Cobra parent chain and returns `true` for:
`config`, `context`, `completion`, `__complete`, `__completeNoDesc`, `help`

## Acceptance criteria

- [x] `PersistentPreRunE` warms the client cache before any SDK-using command runs
- [x] `acloud config show` and `acloud context list` work with no `~/.acloud.yaml`
- [x] All existing `GetArubaClient()` call sites unchanged
- [x] `go test ./...` — all packages green
- [x] 17 new tests: `TestSkipClientInit` (15 cases) + `TestPersistentPreRunE_SkipsForConfig/Context`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
