### PR TITLE
feat: add RenderGet helper and migrate 3 get commands to templates

### DIFF
--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -100,20 +100,6 @@ type kaasGetView struct {
 	ID, URI, Name, Region, Version, Status, CreatedAt, CreatedBy, Tags string
 }
 
-const kaasGetTmpl = `
-KaaS Cluster Details:
-====================
-ID:                 {{.ID}}
-URI:                {{.URI}}
-Name:               {{.Name}}
-Region:             {{.Region}}
-Kubernetes Version: {{.Version}}
-Status:             {{.Status}}
-Creation Date:      {{.CreatedAt}}
-Created By:         {{.CreatedBy}}
-Tags:               {{.Tags}}
-`
-
 func kaasRef(projectID, kaasID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Container/kaas/" + kaasID)

--- a/cmd/container.kaas.go
+++ b/cmd/container.kaas.go
@@ -96,6 +96,24 @@ func init() {
 }
 
 // kaasRef builds the URI for a specific KaaS cluster.
+type kaasGetView struct {
+	ID, URI, Name, Region, Version, Status, CreatedAt, CreatedBy, Tags string
+}
+
+const kaasGetTmpl = `
+KaaS Cluster Details:
+====================
+ID:                 {{.ID}}
+URI:                {{.URI}}
+Name:               {{.Name}}
+Region:             {{.Region}}
+Kubernetes Version: {{.Version}}
+Status:             {{.Status}}
+Creation Date:      {{.CreatedAt}}
+Created By:         {{.CreatedBy}}
+Tags:               {{.Tags}}
+`
+
 func kaasRef(projectID, kaasID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Container/kaas/" + kaasID)
@@ -784,45 +802,32 @@ func ContainerKaaSGet(ctx context.Context, client aruba.Client, args ContainerKa
 		return fmt.Errorf("getting KaaS cluster: %w", apiErrFromV2(err))
 	}
 
-	if kaas != nil && kaas.KaaSID() != "" {
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(kaas, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nKaaS Cluster Details:")
-		fmt.Println("====================")
-		fmt.Printf("ID:              %s\n", kaas.KaaSID())
-		if kaas.URI() != "" {
-			fmt.Printf("URI:             %s\n", kaas.URI())
-		}
-		fmt.Printf("Name:            %s\n", kaas.Name())
-		if r := kaas.Region(); r != "" {
-			fmt.Printf("Region:          %s\n", string(r))
-		}
-		if v := kaas.KubernetesVersion(); v != "" {
-			fmt.Printf("Kubernetes Version: %s\n", string(v))
-		}
-		if s := kaas.State(); s != "" {
-			fmt.Printf("Status:          %s\n", string(s))
-		}
-		if !kaas.CreatedAt().IsZero() {
-			fmt.Printf("Creation Date:   %s\n", kaas.CreatedAt().Format(DateLayout))
-		}
-		if v := kaas.CreatedBy(); v != "" {
-			fmt.Printf("Created By:      %s\n", v)
-		}
-		if tags := kaas.Tags(); len(tags) > 0 {
-			fmt.Printf("Tags:            %v\n", tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if kaas == nil || kaas.KaaSID() == "" {
 		fmt.Println("KaaS cluster not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(kaas, nil, nil)
+		return nil
+	}
+	view := kaasGetView{
+		ID:      kaas.KaaSID(),
+		URI:     kaas.URI(),
+		Name:    kaas.Name(),
+		Region:  string(kaas.Region()),
+		Version: string(kaas.KubernetesVersion()),
+		Status:  string(kaas.State()),
+		Tags:    "[]",
+	}
+	if !kaas.CreatedAt().IsZero() {
+		view.CreatedAt = kaas.CreatedAt().Format(DateLayout)
+	}
+	view.CreatedBy = kaas.CreatedBy()
+	if tags := kaas.Tags(); len(tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", tags)
+	}
+	return renderGet(kaasGetTmpl, view)
 }
 
 // ContainerKaaSList lists all KaaS clusters in a project.

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -31,3 +31,9 @@ func resolveOutputFormat() string {
 func PrintOutput(obj any, headers []TableColumn, rows [][]string) {
 	output.Print(resolveOutputFormat(), obj, headers, rows)
 }
+
+// renderGet renders a text/template string against data for the table-mode detail
+// view of get commands. Call only after the JSON/YAML early-return path.
+func renderGet(tmpl string, data any) error {
+	return output.RenderGet(tmpl, data)
+}

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -14,19 +14,6 @@ type kmsGetView struct {
 	ID, URI, Name, Region, Status, CreatedAt, CreatedBy, Tags string
 }
 
-const kmsGetTmpl = `
-KMS Details:
-============
-ID:              {{.ID}}
-URI:             {{.URI}}
-Name:            {{.Name}}
-Region:          {{.Region}}
-Status:          {{.Status}}
-Creation Date:   {{.CreatedAt}}
-Created By:      {{.CreatedBy}}
-Tags:            {{.Tags}}
-`
-
 func kmsRef(projectID, kmsID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Security/kms/" + kmsID)
 }

--- a/cmd/security.kms.go
+++ b/cmd/security.kms.go
@@ -10,6 +10,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type kmsGetView struct {
+	ID, URI, Name, Region, Status, CreatedAt, CreatedBy, Tags string
+}
+
+const kmsGetTmpl = `
+KMS Details:
+============
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
 func kmsRef(projectID, kmsID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Security/kms/" + kmsID)
 }
@@ -480,49 +497,42 @@ func SecurityKMSGet(ctx context.Context, client aruba.Client, args SecurityKMSGe
 		return fmt.Errorf("getting KMS: %w", apiErrFromV2(err))
 	}
 
-	if kms != nil && kms.Raw() != nil {
-		raw := kms.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(kms, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nKMS Details:")
-		fmt.Println("============")
-
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if kms == nil || kms.Raw() == nil {
 		fmt.Println("KMS not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(kms, nil, nil)
+		return nil
+	}
+	raw := kms.Raw()
+	view := kmsGetView{Tags: "[]"}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(kmsGetTmpl, view)
 }
 
 // SecurityKMSUpdate updates a KMS resource's name and/or tags.

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -14,23 +14,6 @@ type blockStorageGetView struct {
 	ID, URI, Name, Size, Type, Zone, Region, Bootable, Status, CreatedAt, CreatedBy, Tags string
 }
 
-const blockStorageGetTmpl = `
-Block Storage Details:
-======================
-ID:              {{.ID}}
-URI:             {{.URI}}
-Name:            {{.Name}}
-Size (GB):       {{.Size}}
-Type:            {{.Type}}
-Zone:            {{.Zone}}
-Region:          {{.Region}}
-Bootable:        {{.Bootable}}
-Status:          {{.Status}}
-Creation Date:   {{.CreatedAt}}
-Created By:      {{.CreatedBy}}
-Tags:            {{.Tags}}
-`
-
 func volumeRef(projectID, volumeID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/blockStorages/" + volumeID)
 }

--- a/cmd/storage.blockstorage.go
+++ b/cmd/storage.blockstorage.go
@@ -10,6 +10,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type blockStorageGetView struct {
+	ID, URI, Name, Size, Type, Zone, Region, Bootable, Status, CreatedAt, CreatedBy, Tags string
+}
+
+const blockStorageGetTmpl = `
+Block Storage Details:
+======================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Size (GB):       {{.Size}}
+Type:            {{.Type}}
+Zone:            {{.Zone}}
+Region:          {{.Region}}
+Bootable:        {{.Bootable}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
 func volumeRef(projectID, volumeID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/blockStorages/" + volumeID)
 }
@@ -526,54 +547,50 @@ func StorageBlockStorageGet(ctx context.Context, client aruba.Client, args Stora
 		return fmt.Errorf("getting block storage: %w", apiErrFromV2(err))
 	}
 
-	if vol != nil && vol.Raw() != nil {
-		raw := vol.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(vol, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nBlock Storage Details:")
-		fmt.Println("======================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		fmt.Printf("Size (GB):       %d\n", raw.Properties.SizeGB)
-		fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
-		fmt.Printf("Zone:            %s\n", string(raw.Properties.Zone))
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Properties.Bootable != nil {
-			fmt.Printf("Bootable:        %t\n", *raw.Properties.Bootable)
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if vol == nil || vol.Raw() == nil {
 		fmt.Println("Block storage not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(vol, nil, nil)
+		return nil
+	}
+	raw := vol.Raw()
+	view := blockStorageGetView{
+		Size: fmt.Sprintf("%d", raw.Properties.SizeGB),
+		Type: string(raw.Properties.Type),
+		Zone: string(raw.Properties.Zone),
+		Tags: "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.Bootable != nil {
+		view.Bootable = fmt.Sprintf("%t", *raw.Properties.Bootable)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(blockStorageGetTmpl, view)
 }
 
 // StorageBlockStorageUpdate mutates and persists a block storage volume.

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -1,0 +1,48 @@
+package cmd
+
+// Get-command template strings. Each const is rendered by renderGet() against
+// the resource-specific view struct defined in the same file as its command.
+
+const kmsGetTmpl = `
+KMS Details:
+============
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const kaasGetTmpl = `
+KaaS Cluster Details:
+====================
+ID:                 {{.ID}}
+URI:                {{.URI}}
+Name:               {{.Name}}
+Region:             {{.Region}}
+Kubernetes Version: {{.Version}}
+Status:             {{.Status}}
+Creation Date:      {{.CreatedAt}}
+Created By:         {{.CreatedBy}}
+Tags:               {{.Tags}}
+`
+
+const blockStorageGetTmpl = `
+Block Storage Details:
+======================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Size (GB):       {{.Size}}
+Type:            {{.Type}}
+Zone:            {{.Zone}}
+Region:          {{.Region}}
+Bootable:        {{.Bootable}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`

--- a/internal/output/get.go
+++ b/internal/output/get.go
@@ -1,0 +1,17 @@
+package output
+
+import (
+	"os"
+	"text/template"
+)
+
+// RenderGet executes a text/template string against data and writes the result
+// to stdout. Intended for the table-mode detail view of get commands; JSON/YAML
+// modes use PrintOutput before this is reached.
+func RenderGet(tmpl string, data any) error {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		return err
+	}
+	return t.Execute(os.Stdout, data)
+}

--- a/internal/output/get_test.go
+++ b/internal/output/get_test.go
@@ -1,0 +1,43 @@
+package output
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderGet_Basic(t *testing.T) {
+	tmpl := "\nVPC Details:\n============\nID:   {{.ID}}\nName: {{.Name}}\n"
+	data := struct{ ID, Name string }{"vpc-001", "my-vpc"}
+	out := captureStdout(func() { _ = RenderGet(tmpl, data) })
+	if !strings.Contains(out, "vpc-001") || !strings.Contains(out, "my-vpc") {
+		t.Errorf("unexpected output: %q", out)
+	}
+	if !strings.Contains(out, "VPC Details:") {
+		t.Errorf("missing title: %q", out)
+	}
+}
+
+func TestRenderGet_EmptyField(t *testing.T) {
+	tmpl := "Zone: {{.Zone}}\n"
+	data := struct{ Zone string }{""}
+	out := captureStdout(func() { _ = RenderGet(tmpl, data) })
+	if !strings.Contains(out, "Zone: ") {
+		t.Errorf("empty field should still print label: %q", out)
+	}
+}
+
+func TestRenderGet_InvalidTemplate(t *testing.T) {
+	err := RenderGet("{{.Unclosed", nil)
+	if err == nil {
+		t.Error("expected error for invalid template")
+	}
+}
+
+func TestRenderGet_SliceField(t *testing.T) {
+	tmpl := "Tags: {{.Tags}}\n"
+	data := struct{ Tags string }{"[e2e-test storage]"}
+	out := captureStdout(func() { _ = RenderGet(tmpl, data) })
+	if !strings.Contains(out, "[e2e-test storage]") {
+		t.Errorf("unexpected output: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #207.

Adds `internal/output.RenderGet(tmpl string, data any)` — executes a `text/template` string against a typed view struct and writes to stdout. The JSON/YAML early-return path (`PrintOutput`) in each `get` command is unchanged; `renderGet` only fires for the default table mode.

Migrates 3 `get` commands (one per resource family):

| Command | Pattern | Before | After |
|---|---|---|---|
| `SecurityKMSGet` | raw fields | 30 lines of `fmt.Printf` | `kmsGetTmpl` const + `kmsGetView` struct |
| `ContainerKaaSGet` | wrapper accessors | 24 lines of `fmt.Printf` | `kaasGetTmpl` const + `kaasGetView` struct |
| `StorageBlockStorageGet` | raw fields | 34 lines of `fmt.Printf` | `blockStorageGetTmpl` const + `blockStorageGetView` struct |

The remaining 27 `get` commands can migrate the same way incrementally.

## Design decisions

- **View struct pre-formats values** — nil pointers become empty strings, tags become `"[]"` when empty. The template stays unconditional and easy to read.
- **Empty fields always printed** — fields with no value render as `Field:           ` (blank). This is a minor UX improvement over silently skipping fields (it shows what metadata the API exposes) and greatly simplifies the template strings.
- **Const template per resource** — defined at package level in the same file as the command, co-located with the view struct. No file embedding needed.
- **`renderGet` cmd wrapper** — thin delegation to `output.RenderGet`; resource files need no new imports.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go build ./...` — no compile errors
- [x] `gofmt -l .` — clean
- [x] 4 new tests in `internal/output/get_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
