### PR TITLE
feat: migrate all remaining list and get commands to RenderList/RenderGet

### DIFF
--- a/cmd/compute.cloudserver.go
+++ b/cmd/compute.cloudserver.go
@@ -89,6 +89,10 @@ func init() {
 }
 
 // cloudServerRef builds the combined project+server Ref that Get/Delete need.
+type cloudServerGetView struct {
+	ID, Name, Region, Flavor, CPU, RAM, HD, BootVolumeURI, KeypairURI, Status, Tags string
+}
+
 func cloudServerRef(projectID, serverID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Compute/cloudServers/" + serverID)
@@ -862,48 +866,39 @@ func ComputeCloudServerGet(ctx context.Context, client aruba.Client, args Comput
 		fmt.Println("Cloud server not found or no data returned.")
 		return nil
 	}
-
-	raw := server.Raw()
-
 	format := resolveOutputFormat()
 	if format == OutputFormatJSON || format == OutputFormatYAML {
 		PrintOutput(server, nil, nil)
 		return nil
 	}
-
-	fmt.Println("\nCloud Server Details:")
-	fmt.Println("====================")
-
+	raw := server.Raw()
+	view := cloudServerGetView{
+		CPU:  fmt.Sprintf("%d", raw.Properties.Flavor.CPU),
+		RAM:  fmt.Sprintf("%d GB", raw.Properties.Flavor.RAM),
+		HD:   fmt.Sprintf("%d GB", raw.Properties.Flavor.HD),
+		Tags: "[]",
+	}
 	if raw.Metadata.ID != nil {
-		fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+		view.ID = *raw.Metadata.ID
 	}
 	if raw.Metadata.Name != nil {
-		fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
+		view.Name = *raw.Metadata.Name
 	}
-	if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-		fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
 	}
-	if raw.Properties.Flavor.Name != "" {
-		fmt.Printf("Flavor:          %s\n", raw.Properties.Flavor.Name)
-	}
-	fmt.Printf("CPU:             %d\n", raw.Properties.Flavor.CPU)
-	fmt.Printf("RAM:             %d GB\n", raw.Properties.Flavor.RAM)
-	fmt.Printf("HD:              %d GB\n", raw.Properties.Flavor.HD)
-	if raw.Properties.BootVolume.URI != "" {
-		fmt.Printf("Boot Volume URI: %s\n", raw.Properties.BootVolume.URI)
-	}
-	if raw.Properties.KeyPair.URI != "" {
-		fmt.Printf("Keypair URI:     %s\n", raw.Properties.KeyPair.URI)
-	}
+	view.Flavor = string(raw.Properties.Flavor.Name)
+	view.BootVolumeURI = raw.Properties.BootVolume.URI
+	view.KeypairURI = raw.Properties.KeyPair.URI
 	if raw.Status.State != nil {
-		fmt.Printf("Status:          %s\n", *raw.Status.State)
+		view.Status = string(*raw.Status.State)
 	}
 	if len(raw.Metadata.Tags) > 0 {
-		fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-	} else {
-		fmt.Printf("Tags:            []\n")
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
 	}
-
+	if err := renderGet(cloudServerGetTmpl, view); err != nil {
+		return err
+	}
 	if args.Verbose {
 		jsonData, _ := json.MarshalIndent(raw, "", "  ")
 		fmt.Println("\nFull JSON Response:")
@@ -993,52 +988,45 @@ func ComputeCloudServerList(ctx context.Context, client aruba.Client, args Compu
 		return fmt.Errorf("listing cloud servers: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 25},
-			{Header: "ID", Width: 30},
-			{Header: "LOCATION", Width: 15},
-			{Header: "FLAVOR", Width: 15},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, server := range list.Items() {
-			raw := server.Raw()
-			if raw == nil || raw.Metadata.ID == nil || *raw.Metadata.ID == "" {
-				continue
-			}
-			id := *raw.Metadata.ID
-			var name string
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			var location string
-			if raw.Metadata.LocationResponse != nil {
-				location = string(raw.Metadata.LocationResponse.Value)
-			}
-			flavor := raw.Properties.Flavor.Name
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{
-				name,
-				id,
-				location,
-				string(flavor),
-				status,
-			})
-		}
-
-		if len(rows) == 0 {
-			fmt.Println("No cloud servers found")
-			return nil
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No cloud servers found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.CloudServer]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 25}, Value: func(s *aruba.CloudServer) string {
+			if r := s.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 30}, Value: func(s *aruba.CloudServer) string {
+			if r := s.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "LOCATION", Width: 15}, Value: func(s *aruba.CloudServer) string {
+			if r := s.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "FLAVOR", Width: 15}, Value: func(s *aruba.CloudServer) string {
+			if r := s.Raw(); r != nil {
+				return string(r.Properties.Flavor.Name)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(s *aruba.CloudServer) string {
+			if r := s.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(s *aruba.CloudServer) bool {
+		r := s.Raw()
+		return r != nil && r.Metadata.ID != nil && *r.Metadata.ID != ""
+	})
 	return nil
 }
 

--- a/cmd/compute.keypair.go
+++ b/cmd/compute.keypair.go
@@ -49,6 +49,10 @@ func init() {
 }
 
 // keypairRef builds the combined project+keypair Ref that v0.2.0 Get/Delete need.
+type keypairGetView struct {
+	Name, URI, PublicKey, CreatedAt, CreatedBy string
+}
+
 func keypairRef(projectID, name string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Compute/keyPairs/" + name)
@@ -447,38 +451,30 @@ func ComputeKeyPairGet(ctx context.Context, client aruba.Client, args ComputeKey
 		return fmt.Errorf("getting keypair: %w", apiErrFromV2(err))
 	}
 
-	if kp != nil && kp.Raw() != nil {
-		raw := kp.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(kp, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nKeypair Details:")
-		fmt.Println("===============")
-
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Properties.Value != "" {
-			fmt.Printf("Public Key:      %s\n", raw.Properties.Value)
-		}
-		fmt.Printf("Status:          Active\n")
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-	} else {
+	if kp == nil || kp.Raw() == nil {
 		fmt.Println("Keypair not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(kp, nil, nil)
+		return nil
+	}
+	raw := kp.Raw()
+	view := keypairGetView{PublicKey: raw.Properties.Value}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	return renderGet(keypairGetTmpl, view)
 }
 
 // ComputeKeyPairUpdate prints a "not supported" message (the API does not support keypair updates).
@@ -509,49 +505,39 @@ func ComputeKeyPairList(ctx context.Context, client aruba.Client, args ComputeKe
 		return fmt.Errorf("listing keypairs: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 40},
-			{Header: "ID", Width: 30},
-			{Header: "PUBLIC_KEY", Width: 60},
-			{Header: "STATUS", Width: 10},
-		}
-
-		var rows [][]string
-		for _, kp := range list.Items() {
-			raw := kp.Raw()
-			if raw == nil {
-				continue
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			if id == "" {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			publicKey := ""
-			if raw.Properties.Value != "" {
-				publicKey = raw.Properties.Value
-				if len(publicKey) > 50 {
-					publicKey = publicKey[:50] + "..."
-				}
-			}
-			rows = append(rows, []string{name, id, publicKey, "Active"})
-		}
-
-		if len(rows) == 0 {
-			fmt.Println("No keypairs found")
-			return nil
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No keypairs found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.KeyPair]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 40}, Value: func(kp *aruba.KeyPair) string {
+			if r := kp.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 30}, Value: func(kp *aruba.KeyPair) string {
+			if r := kp.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "PUBLIC_KEY", Width: 60}, Value: func(kp *aruba.KeyPair) string {
+			r := kp.Raw()
+			if r == nil || r.Properties.Value == "" {
+				return ""
+			}
+			v := r.Properties.Value
+			if len(v) > 50 {
+				return v[:50] + "..."
+			}
+			return v
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 10}, Value: func(kp *aruba.KeyPair) string { return "Active" }},
+	}, list.Items(), func(kp *aruba.KeyPair) bool {
+		r := kp.Raw()
+		return r != nil && r.Metadata.ID != nil && *r.Metadata.ID != ""
+	})
 	return nil
 }
 

--- a/cmd/container.containerregistry.go
+++ b/cmd/container.containerregistry.go
@@ -62,6 +62,11 @@ func init() {
 }
 
 // containerRegistryRef builds the URI for a specific container registry.
+type containerRegistryGetView struct {
+	ID, URI, Name, Region, PublicIP, VPC, Subnet, SecurityGroup, BlockStorage     string
+	BillingPeriod, AdminUser, ConcurrentUsers, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func containerRegistryRef(projectID, registryID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Container/registries/" + registryID)
@@ -576,72 +581,58 @@ func ContainerContainerRegistryGet(ctx context.Context, client aruba.Client, arg
 		return fmt.Errorf("getting container registry: %w", apiErrFromV2(err))
 	}
 
-	if registry != nil && registry.Raw() != nil {
-		raw := registry.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(registry, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nContainer Registry Details:")
-		fmt.Println("==========================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Properties.PublicIp.URI != "" {
-			fmt.Printf("Public IP:       %s\n", raw.Properties.PublicIp.URI)
-		}
-		if raw.Properties.VPC.URI != "" {
-			fmt.Printf("VPC:             %s\n", raw.Properties.VPC.URI)
-		}
-		if raw.Properties.Subnet.URI != "" {
-			fmt.Printf("Subnet:          %s\n", raw.Properties.Subnet.URI)
-		}
-		if raw.Properties.SecurityGroup.URI != "" {
-			fmt.Printf("Security Group:  %s\n", raw.Properties.SecurityGroup.URI)
-		}
-		if raw.Properties.BlockStorage.URI != "" {
-			fmt.Printf("Block Storage:   %s\n", raw.Properties.BlockStorage.URI)
-		}
-		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-			fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPlanCommon.BillingPeriod))
-		}
-		if raw.Properties.AdminUser != nil {
-			fmt.Printf("Admin User:      %s\n", raw.Properties.AdminUser.Username)
-		}
-		if raw.Properties.ConcurrentUsers != nil {
-			fmt.Printf("Concurrent Users: %s\n", *raw.Properties.ConcurrentUsers)
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if registry == nil || registry.Raw() == nil {
 		fmt.Println("Container registry not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(registry, nil, nil)
+		return nil
+	}
+	raw := registry.Raw()
+	view := containerRegistryGetView{
+		PublicIP:      raw.Properties.PublicIp.URI,
+		VPC:           raw.Properties.VPC.URI,
+		Subnet:        raw.Properties.Subnet.URI,
+		SecurityGroup: raw.Properties.SecurityGroup.URI,
+		BlockStorage:  raw.Properties.BlockStorage.URI,
+		Tags:          "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+		view.BillingPeriod = string(*raw.Properties.BillingPlanCommon.BillingPeriod)
+	}
+	if raw.Properties.AdminUser != nil {
+		view.AdminUser = raw.Properties.AdminUser.Username
+	}
+	if raw.Properties.ConcurrentUsers != nil {
+		view.ConcurrentUsers = *raw.Properties.ConcurrentUsers
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(containerRegistryGetTmpl, view)
 }
 
 // ContainerContainerRegistryList lists all container registries in a project.
@@ -651,42 +642,36 @@ func ContainerContainerRegistryList(ctx context.Context, client aruba.Client, ar
 		return fmt.Errorf("listing container registries: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 40},
-			{Header: "ID", Width: 30},
-			{Header: "REGION", Width: 20},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, cr := range list.Items() {
-			raw := cr.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No container registries found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.ContainerRegistry]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 40}, Value: func(cr *aruba.ContainerRegistry) string {
+			if r := cr.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 30}, Value: func(cr *aruba.ContainerRegistry) string {
+			if r := cr.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 20}, Value: func(cr *aruba.ContainerRegistry) string {
+			if r := cr.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(cr *aruba.ContainerRegistry) string {
+			if r := cr.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(cr *aruba.ContainerRegistry) bool { return cr.Raw() != nil })
 	return nil
 }
 

--- a/cmd/database.backup.go
+++ b/cmd/database.backup.go
@@ -45,6 +45,10 @@ func init() {
 }
 
 // databaseBackupRef returns a Ref for a specific database backup.
+type databaseBackupGetView struct {
+	ID, URI, Name, Region, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func databaseBackupRef(projectID, backupID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Database/backups/" + backupID)
 }
@@ -423,48 +427,42 @@ func DatabaseDBaaSBackupGet(ctx context.Context, client aruba.Client, args Datab
 		return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
 	}
 
-	if backup != nil && backup.Raw() != nil {
-		raw := backup.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(backup, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nBackup Details:")
-		fmt.Println("==============")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if backup == nil || backup.Raw() == nil {
 		fmt.Println("Backup not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(backup, nil, nil)
+		return nil
+	}
+	raw := backup.Raw()
+	view := databaseBackupGetView{Tags: "[]"}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(databaseBackupGetTmpl, view)
 }
 
 // DatabaseDBaaSBackupList lists all database backups in a project.
@@ -474,42 +472,36 @@ func DatabaseDBaaSBackupList(ctx context.Context, client aruba.Client, args Data
 		return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 30},
-			{Header: "REGION", Width: 20},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, backup := range list.Items() {
-			raw := backup.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No backups found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.DBaaSBackup]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(b *aruba.DBaaSBackup) string {
+			if r := b.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 30}, Value: func(b *aruba.DBaaSBackup) string {
+			if r := b.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 20}, Value: func(b *aruba.DBaaSBackup) string {
+			if r := b.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(b *aruba.DBaaSBackup) string {
+			if r := b.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(b *aruba.DBaaSBackup) bool { return b.Raw() != nil })
 	return nil
 }
 

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -81,6 +81,10 @@ func completeDBaaSDatabaseID(cmd *cobra.Command, args []string, toComplete strin
 	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
+type databaseGetView struct {
+	Name, CreatedAt, CreatedBy string
+}
+
 var dbaasDatabaseCmd = &cobra.Command{
 	Use:   "database [dbaas-id]",
 	Short: "Manage databases in DBaaS",
@@ -446,29 +450,24 @@ func DatabaseDBaaSDatabaseGet(ctx context.Context, client aruba.Client, args Dat
 		return fmt.Errorf("getting database: %w", apiErrFromV2(err))
 	}
 
-	if db != nil && db.Raw() != nil {
-		raw := db.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(db, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nDatabase Details:")
-		fmt.Println("================")
-		fmt.Printf("Name:            %s\n", raw.Name)
-		if raw.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
-		}
-		if raw.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
-		}
-		fmt.Println()
-	} else {
+	if db == nil || db.Raw() == nil {
 		fmt.Println("Database not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(db, nil, nil)
+		return nil
+	}
+	raw := db.Raw()
+	view := databaseGetView{Name: raw.Name}
+	if raw.CreationDate != nil {
+		view.CreatedAt = raw.CreationDate.Format(DateLayout)
+	}
+	if raw.CreatedBy != nil {
+		view.CreatedBy = *raw.CreatedBy
+	}
+	return renderGet(databaseGetTmpl, view)
 }
 
 // DatabaseDBaaSDatabaseUpdate updates a database's name.
@@ -514,33 +513,30 @@ func DatabaseDBaaSDatabaseList(ctx context.Context, client aruba.Client, args Da
 		return fmt.Errorf("listing databases: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 40},
-			{Header: "CREATION DATE", Width: 25},
-			{Header: "CREATED BY", Width: 30},
-		}
-
-		var rows [][]string
-		for _, db := range list.Items() {
-			raw := db.Raw()
-			if raw == nil {
-				continue
-			}
-			creationDate := ""
-			if raw.CreationDate != nil {
-				creationDate = raw.CreationDate.Format(DateLayout)
-			}
-			createdBy := ""
-			if raw.CreatedBy != nil {
-				createdBy = *raw.CreatedBy
-			}
-			rows = append(rows, []string{raw.Name, creationDate, createdBy})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No databases found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.Database]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 40}, Value: func(db *aruba.Database) string {
+			if r := db.Raw(); r != nil {
+				return r.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "CREATION DATE", Width: 25}, Value: func(db *aruba.Database) string {
+			if r := db.Raw(); r != nil && r.CreationDate != nil {
+				return r.CreationDate.Format(DateLayout)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "CREATED BY", Width: 30}, Value: func(db *aruba.Database) string {
+			if r := db.Raw(); r != nil && r.CreatedBy != nil {
+				return *r.CreatedBy
+			}
+			return ""
+		}},
+	}, list.Items(), func(db *aruba.Database) bool { return db.Raw() != nil })
 	return nil
 }
 

--- a/cmd/database.dbaas.go
+++ b/cmd/database.dbaas.go
@@ -64,6 +64,10 @@ func init() {
 }
 
 // dbaasRef builds the URI for a specific DBaaS instance.
+type dbaasGetView struct {
+	ID, URI, Name, Region, EngineType, EngineVersion, EngineName, Flavor, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func dbaasRef(projectID, dbaasID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Database/dbaas/" + dbaasID)
@@ -573,62 +577,56 @@ func DatabaseDBaaSGet(ctx context.Context, client aruba.Client, args DatabaseDBa
 		return fmt.Errorf("getting DBaaS instance: %w", apiErrFromV2(err))
 	}
 
-	if dbaas != nil && dbaas.Raw() != nil {
-		raw := dbaas.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(dbaas, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nDBaaS Instance Details:")
-		fmt.Println("=======================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Properties.Engine != nil {
-			if raw.Properties.Engine.Type != nil {
-				fmt.Printf("Engine Type:     %s\n", *raw.Properties.Engine.Type)
-			}
-			if raw.Properties.Engine.Version != nil {
-				fmt.Printf("Engine Version:  %s\n", *raw.Properties.Engine.Version)
-			}
-			if raw.Properties.Engine.Name != nil {
-				fmt.Printf("Engine Name:     %s\n", *raw.Properties.Engine.Name)
-			}
-		}
-		if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
-			fmt.Printf("Flavor:          %s\n", *raw.Properties.Flavor.Name)
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if dbaas == nil || dbaas.Raw() == nil {
 		fmt.Println("DBaaS instance not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(dbaas, nil, nil)
+		return nil
+	}
+	raw := dbaas.Raw()
+	view := dbaasGetView{Tags: "[]"}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.Engine != nil {
+		if raw.Properties.Engine.Type != nil {
+			view.EngineType = *raw.Properties.Engine.Type
+		}
+		if raw.Properties.Engine.Version != nil {
+			view.EngineVersion = *raw.Properties.Engine.Version
+		}
+		if raw.Properties.Engine.Name != nil {
+			view.EngineName = *raw.Properties.Engine.Name
+		}
+	}
+	if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
+		view.Flavor = *raw.Properties.Flavor.Name
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(dbaasGetTmpl, view)
 }
 
 // DatabaseDBaaSUpdate updates a DBaaS instance's name and/or tags.
@@ -722,57 +720,54 @@ func DatabaseDBaaSList(ctx context.Context, client aruba.Client, args DatabaseDB
 		return fmt.Errorf("listing DBaaS instances: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 30},
-			{Header: "ENGINE", Width: 20},
-			{Header: "VERSION", Width: 15},
-			{Header: "FLAVOR", Width: 20},
-			{Header: "REGION", Width: 20},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, d := range list.Items() {
-			raw := d.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			engine := ""
-			if raw.Properties.Engine != nil && raw.Properties.Engine.Type != nil {
-				engine = *raw.Properties.Engine.Type
-			}
-			version := ""
-			if raw.Properties.Engine != nil && raw.Properties.Engine.Version != nil {
-				version = *raw.Properties.Engine.Version
-			}
-			flavor := ""
-			if raw.Properties.Flavor != nil && raw.Properties.Flavor.Name != nil {
-				flavor = *raw.Properties.Flavor.Name
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, engine, version, flavor, region, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No DBaaS instances found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.DBaaS]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 30}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ENGINE", Width: 20}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Properties.Engine != nil && r.Properties.Engine.Type != nil {
+				return *r.Properties.Engine.Type
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "VERSION", Width: 15}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Properties.Engine != nil && r.Properties.Engine.Version != nil {
+				return *r.Properties.Engine.Version
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "FLAVOR", Width: 20}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Properties.Flavor != nil && r.Properties.Flavor.Name != nil {
+				return *r.Properties.Flavor.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 20}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(d *aruba.DBaaS) string {
+			if r := d.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(d *aruba.DBaaS) bool { return d.Raw() != nil })
 	return nil
 }
 

--- a/cmd/database.dbaas.grant.go
+++ b/cmd/database.dbaas.grant.go
@@ -402,27 +402,16 @@ func DatabaseDBaaSGrantList(ctx context.Context, client aruba.Client, args Datab
 		return fmt.Errorf("listing grants: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "GRANT ID", Width: 30},
-			{Header: "USERNAME", Width: 30},
-			{Header: "ROLE", Width: 20},
-			{Header: "DATABASE", Width: 25},
-		}
-		var rows [][]string
-		for _, g := range list.Items() {
-			row := []string{
-				g.ID(),
-				g.Username(),
-				g.RoleName(),
-				g.DatabaseName(),
-			}
-			rows = append(rows, row)
-		}
-		PrintOutput(nil, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No grants found")
+		return nil
 	}
+	renderList(nil, []ListColumn[*aruba.Grant]{
+		{TableColumn: TableColumn{Header: "GRANT ID", Width: 30}, Value: func(g *aruba.Grant) string { return g.ID() }},
+		{TableColumn: TableColumn{Header: "USERNAME", Width: 30}, Value: func(g *aruba.Grant) string { return g.Username() }},
+		{TableColumn: TableColumn{Header: "ROLE", Width: 20}, Value: func(g *aruba.Grant) string { return g.RoleName() }},
+		{TableColumn: TableColumn{Header: "DATABASE", Width: 25}, Value: func(g *aruba.Grant) string { return g.DatabaseName() }},
+	}, list.Items())
 	return nil
 }
 

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -10,6 +10,10 @@ import (
 )
 
 // userRef returns a Ref for a specific user inside a DBaaS instance.
+type userGetView struct {
+	Username, CreatedAt, CreatedBy string
+}
+
 func userRef(projectID, dbaasID, username string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID +
 		"/providers/Aruba.Database/dbaas/" + dbaasID +
@@ -460,29 +464,24 @@ func DatabaseDBaaSUserGet(ctx context.Context, client aruba.Client, args Databas
 		return fmt.Errorf("getting user: %w", apiErrFromV2(err))
 	}
 
-	if u != nil && u.Raw() != nil {
-		raw := u.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(u, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nUser Details:")
-		fmt.Println("=============")
-		fmt.Printf("Username:        %s\n", raw.Username)
-		if raw.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.CreationDate.Format(DateLayout))
-		}
-		if raw.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.CreatedBy)
-		}
-		fmt.Println()
-	} else {
+	if u == nil || u.Raw() == nil {
 		fmt.Println("User not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(u, nil, nil)
+		return nil
+	}
+	raw := u.Raw()
+	view := userGetView{Username: raw.Username}
+	if raw.CreationDate != nil {
+		view.CreatedAt = raw.CreationDate.Format(DateLayout)
+	}
+	if raw.CreatedBy != nil {
+		view.CreatedBy = *raw.CreatedBy
+	}
+	return renderGet(userGetTmpl, view)
 }
 
 // DatabaseDBaaSUserUpdate updates a user's password.
@@ -528,33 +527,30 @@ func DatabaseDBaaSUserList(ctx context.Context, client aruba.Client, args Databa
 		return fmt.Errorf("listing users: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "USERNAME", Width: 40},
-			{Header: "CREATION DATE", Width: 25},
-			{Header: "CREATED BY", Width: 30},
-		}
-
-		var rows [][]string
-		for _, user := range list.Items() {
-			raw := user.Raw()
-			if raw == nil {
-				continue
-			}
-			creationDate := ""
-			if raw.CreationDate != nil {
-				creationDate = raw.CreationDate.Format(DateLayout)
-			}
-			createdBy := ""
-			if raw.CreatedBy != nil {
-				createdBy = *raw.CreatedBy
-			}
-			rows = append(rows, []string{raw.Username, creationDate, createdBy})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No users found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.User]{
+		{TableColumn: TableColumn{Header: "USERNAME", Width: 40}, Value: func(u *aruba.User) string {
+			if r := u.Raw(); r != nil {
+				return r.Username
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "CREATION DATE", Width: 25}, Value: func(u *aruba.User) string {
+			if r := u.Raw(); r != nil && r.CreationDate != nil {
+				return r.CreationDate.Format(DateLayout)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "CREATED BY", Width: 30}, Value: func(u *aruba.User) string {
+			if r := u.Raw(); r != nil && r.CreatedBy != nil {
+				return *r.CreatedBy
+			}
+			return ""
+		}},
+	}, list.Items(), func(u *aruba.User) bool { return u.Raw() != nil })
 	return nil
 }
 

--- a/cmd/management.project.go
+++ b/cmd/management.project.go
@@ -81,6 +81,10 @@ func completeProjectID(cmd *cobra.Command, args []string, toComplete string) ([]
 	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
+type projectGetView struct {
+	ID, Name, Description, Default, CreatedAt, UpdatedAt, CreatedBy, UpdatedBy, Tags string
+}
+
 var projectCmd = &cobra.Command{
 	Use:   "project",
 	Short: "Manage projects",
@@ -416,51 +420,34 @@ func ManagementProjectGet(ctx context.Context, client aruba.Client, args Managem
 		return fmt.Errorf("getting project: %w", apiErrFromV2(err))
 	}
 
-	if p != nil && p.ID() != "" {
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(p, nil, nil)
-			return nil
-		}
-
-		// Display project details
-		fmt.Println("\nProject Details:")
-		fmt.Println("================")
-
-		fmt.Printf("ID:              %s\n", p.ID())
-		fmt.Printf("Name:            %s\n", p.Name())
-
-		if p.Description() != "" {
-			fmt.Printf("Description:     %s\n", p.Description())
-		}
-
-		fmt.Printf("Default:         %t\n", p.IsDefault())
-
-		if !p.CreatedAt().IsZero() {
-			fmt.Printf("Creation Date:   %s\n", p.CreatedAt().Format(DateLayout))
-		}
-		if !p.UpdatedAt().IsZero() {
-			fmt.Printf("Update Date:     %s\n", p.UpdatedAt().Format(DateLayout))
-		}
-		if v := p.CreatedBy(); v != "" {
-			fmt.Printf("Created By:      %s\n", v)
-		}
-		if v := p.UpdatedBy(); v != "" {
-			fmt.Printf("Updated By:      %s\n", v)
-		}
-
-		tags := p.Tags()
-		if len(tags) > 0 {
-			fmt.Printf("Tags:            %v\n", tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-
-		fmt.Println()
-	} else {
+	if p == nil || p.ID() == "" {
 		fmt.Println("Project not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(p, nil, nil)
+		return nil
+	}
+	view := projectGetView{
+		ID:          p.ID(),
+		Name:        p.Name(),
+		Description: p.Description(),
+		Default:     fmt.Sprintf("%t", p.IsDefault()),
+		CreatedBy:   p.CreatedBy(),
+		UpdatedBy:   p.UpdatedBy(),
+		Tags:        "[]",
+	}
+	if !p.CreatedAt().IsZero() {
+		view.CreatedAt = p.CreatedAt().Format(DateLayout)
+	}
+	if !p.UpdatedAt().IsZero() {
+		view.UpdatedAt = p.UpdatedAt().Format(DateLayout)
+	}
+	if tags := p.Tags(); len(tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", tags)
+	}
+	return renderGet(projectGetTmpl, view)
 }
 
 // ManagementProjectUpdate updates a project's description and/or tags.
@@ -542,34 +529,20 @@ func ManagementProjectList(ctx context.Context, client aruba.Client, args Manage
 		return fmt.Errorf("listing projects: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		// Define table columns
-		headers := []TableColumn{
-			{Header: "NAME", Width: 40},
-			{Header: "ID", Width: 30},
-			{Header: "CREATION DATE", Width: 15},
-		}
-
-		// Build rows
-		var rows [][]string
-		for _, p := range list.Items() {
-			name := p.Name()
-			id := p.ID()
-
-			// Format creation date as dd-mm-yyyy
-			creationDate := "N/A"
-			if !p.CreatedAt().IsZero() {
-				creationDate = p.CreatedAt().Format("02-01-2006")
-			}
-
-			rows = append(rows, []string{name, id, creationDate})
-		}
-
-		// Print the table
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No projects found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.Project]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 40}, Value: func(p *aruba.Project) string { return p.Name() }},
+		{TableColumn: TableColumn{Header: "ID", Width: 30}, Value: func(p *aruba.Project) string { return p.ID() }},
+		{TableColumn: TableColumn{Header: "CREATION DATE", Width: 15}, Value: func(p *aruba.Project) string {
+			if p.CreatedAt().IsZero() {
+				return "N/A"
+			}
+			return p.CreatedAt().Format("02-01-2006")
+		}},
+	}, list.Items())
 	return nil
 }
 

--- a/cmd/network.elasticip.go
+++ b/cmd/network.elasticip.go
@@ -84,6 +84,10 @@ func completeElasticIPID(cmd *cobra.Command, args []string, toComplete string) (
 }
 
 // ElasticIP subcommands
+type elasticIPGetView struct {
+	ID, URI, Name, Region, Address, BillingPeriod, LinkedResources, CreatedAt, CreatedBy, Tags, Status string
+}
+
 var elasticipCmd = &cobra.Command{
 	Use:   "elasticip",
 	Short: "Manage Elastic IPs",
@@ -472,47 +476,50 @@ func NetworkElasticIPGet(ctx context.Context, client aruba.Client, args NetworkE
 		return fmt.Errorf("getting Elastic IP details: %w", apiErrFromV2(err))
 	}
 
-	if eip != nil && eip.Raw() != nil {
-		raw := eip.Raw()
-
-		fmt.Println("\nElastic IP Details:")
-		fmt.Println("===================")
-
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-		}
-		if raw.Properties.Address != nil {
-			fmt.Printf("Address:         %s\n", *raw.Properties.Address)
-		}
-		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-			fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
-		}
-		fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
+	if eip == nil || eip.Raw() == nil {
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(eip, nil, nil)
+		return nil
+	}
+	raw := eip.Raw()
+	view := elasticIPGetView{
+		LinkedResources: fmt.Sprintf("%d", len(raw.Properties.LinkedResources)),
+		Tags:            "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.Address != nil {
+		view.Address = *raw.Properties.Address
+	}
+	if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+		view.BillingPeriod = string(*raw.Properties.BillingPlanCommon.BillingPeriod)
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(elasticIPGetTmpl, view)
 }
 
 // NetworkElasticIPUpdate updates an Elastic IP's name and/or tags.
@@ -592,48 +599,42 @@ func NetworkElasticIPList(ctx context.Context, client aruba.Client, args Network
 		return fmt.Errorf("listing Elastic IPs: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "REGION", Width: 18},
-			{Header: "ADDRESS", Width: 16},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, eip := range list.Items() {
-			raw := eip.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			address := ""
-			if raw.Properties.Address != nil {
-				address = *raw.Properties.Address
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, address, status})
-		}
-
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No Elastic IPs found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.ElasticIP]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(e *aruba.ElasticIP) string {
+			if r := e.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(e *aruba.ElasticIP) string {
+			if r := e.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 18}, Value: func(e *aruba.ElasticIP) string {
+			if r := e.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ADDRESS", Width: 16}, Value: func(e *aruba.ElasticIP) string {
+			if r := e.Raw(); r != nil && r.Properties.Address != nil {
+				return *r.Properties.Address
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(e *aruba.ElasticIP) string {
+			if r := e.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(e *aruba.ElasticIP) bool { return e.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.loadbalancer.go
+++ b/cmd/network.loadbalancer.go
@@ -27,6 +27,10 @@ func init() {
 
 }
 
+type loadBalancerGetView struct {
+	ID, URI, Name, Address, VPC, LinkedResources, CreatedAt, CreatedBy, Tags, Status string
+}
+
 func loadBalancerRef(projectID, lbID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/loadBalancers/" + lbID)
 }
@@ -196,48 +200,42 @@ func NetworkLoadBalancerList(ctx context.Context, client aruba.Client, args Netw
 		return fmt.Errorf("listing Load Balancers: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "REGION", Width: 18},
-			{Header: "ADDRESS", Width: 16},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, lb := range list.Items() {
-			raw := lb.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			address := ""
-			if raw.Properties.Address != nil {
-				address = *raw.Properties.Address
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, address, status})
-		}
-
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No Load Balancers found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.LoadBalancer]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(lb *aruba.LoadBalancer) string {
+			if r := lb.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(lb *aruba.LoadBalancer) string {
+			if r := lb.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 18}, Value: func(lb *aruba.LoadBalancer) string {
+			if r := lb.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ADDRESS", Width: 16}, Value: func(lb *aruba.LoadBalancer) string {
+			if r := lb.Raw(); r != nil && r.Properties.Address != nil {
+				return *r.Properties.Address
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(lb *aruba.LoadBalancer) string {
+			if r := lb.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(lb *aruba.LoadBalancer) bool { return lb.Raw() != nil })
 	return nil
 }
 
@@ -248,48 +246,47 @@ func NetworkLoadBalancerGet(ctx context.Context, client aruba.Client, args Netwo
 		return fmt.Errorf("getting Load Balancer details: %w", apiErrFromV2(err))
 	}
 
-	if lb != nil && lb.Raw() != nil {
-		raw := lb.Raw()
-
-		fmt.Println("\nLoad Balancer Details:")
-		fmt.Println("======================")
-
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Properties.Address != nil {
-			fmt.Printf("Address:         %s\n", *raw.Properties.Address)
-		}
-		if raw.Properties.VPC != nil && raw.Properties.VPC.URI != "" {
-			fmt.Printf("VPC:             %s\n", raw.Properties.VPC.URI)
-		}
-
-		fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
-
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
+	if lb == nil || lb.Raw() == nil {
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(lb, nil, nil)
+		return nil
+	}
+	raw := lb.Raw()
+	view := loadBalancerGetView{
+		LinkedResources: fmt.Sprintf("%d", len(raw.Properties.LinkedResources)),
+		Tags:            "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Properties.Address != nil {
+		view.Address = *raw.Properties.Address
+	}
+	if raw.Properties.VPC != nil {
+		view.VPC = raw.Properties.VPC.URI
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(loadBalancerGetTmpl, view)
 }
 
 // =============================================================================

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -10,6 +10,10 @@ import (
 )
 
 // securityGroupRef is shared with securityrule.go; uses hyphenated path segment (/security-groups/) to match SDK ID parser.
+type securityGroupGetView struct {
+	ID, URI, Name, Region, CreatedAt, CreatedBy, Tags, Status string
+}
+
 func securityGroupRef(projectID, vpcID, sgID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Network/vpcs/" + vpcID + "/security-groups/" + sgID)
 }
@@ -450,40 +454,42 @@ func NetworkSecurityGroupGet(ctx context.Context, client aruba.Client, args Netw
 		return fmt.Errorf("getting security group: %w", apiErrFromV2(err))
 	}
 
-	if sg != nil && sg.Raw() != nil {
-		raw := sg.Raw()
-		fmt.Println("\nSecurity Group Details:")
-		fmt.Println("======================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if sg == nil || sg.Raw() == nil {
 		fmt.Println("Security group not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(sg, nil, nil)
+		return nil
+	}
+	raw := sg.Raw()
+	view := securityGroupGetView{Tags: "[]"}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(securityGroupGetTmpl, view)
 }
 
 // NetworkSecurityGroupUpdate updates an existing security group.
@@ -582,41 +588,36 @@ func NetworkSecurityGroupList(ctx context.Context, client aruba.Client, args Net
 		return fmt.Errorf("listing security groups: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "REGION", Width: 18},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, sg := range list.Items() {
-			raw := sg.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No security groups found.")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.SecurityGroup]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(sg *aruba.SecurityGroup) string {
+			if r := sg.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(sg *aruba.SecurityGroup) string {
+			if r := sg.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 18}, Value: func(sg *aruba.SecurityGroup) string {
+			if r := sg.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(sg *aruba.SecurityGroup) string {
+			if r := sg.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(sg *aruba.SecurityGroup) bool { return sg.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -104,6 +104,11 @@ func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string
 }
 
 // SecurityRule subcommands
+type securityRuleGetView struct {
+	ID, URI, Name, Region, Direction, Protocol, Port, TargetKind, TargetValue string
+	CreatedAt, CreatedBy, Tags, Status                                        string
+}
+
 var securityruleCmd = &cobra.Command{
 	Use:   "securityrule",
 	Short: "Manage security rules",
@@ -570,47 +575,51 @@ func NetworkSecurityRuleGet(ctx context.Context, client aruba.Client, args Netwo
 		return fmt.Errorf("getting security rule: %w", apiErrFromV2(err))
 	}
 
-	if rule != nil && rule.Raw() != nil {
-		raw := rule.Raw()
-		fmt.Println("\nSecurity Rule Details:")
-		fmt.Println("=====================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-		}
-		fmt.Printf("Direction:       %s\n", raw.Properties.Direction)
-		fmt.Printf("Protocol:        %s\n", raw.Properties.Protocol)
-		fmt.Printf("Port:            %s\n", raw.Properties.Port)
-		if raw.Properties.Target != nil {
-			fmt.Printf("Target Kind:     %s\n", raw.Properties.Target.Kind)
-			fmt.Printf("Target Value:    %s\n", raw.Properties.Target.Value)
-		}
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if rule == nil || rule.Raw() == nil {
 		fmt.Println("Security rule not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(rule, nil, nil)
+		return nil
+	}
+	raw := rule.Raw()
+	view := securityRuleGetView{
+		Direction: string(raw.Properties.Direction),
+		Protocol:  string(raw.Properties.Protocol),
+		Port:      raw.Properties.Port,
+		Tags:      "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.Target != nil {
+		view.TargetKind = string(raw.Properties.Target.Kind)
+		view.TargetValue = raw.Properties.Target.Value
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(securityRuleGetTmpl, view)
 }
 
 // NetworkSecurityRuleUpdate updates an existing security rule.
@@ -708,47 +717,55 @@ func NetworkSecurityRuleList(ctx context.Context, client aruba.Client, args Netw
 		return fmt.Errorf("listing security rules: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "DIRECTION", Width: 12},
-			{Header: "PROTOCOL", Width: 12},
-			{Header: "PORT", Width: 12},
-			{Header: "TARGET", Width: 30},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, rule := range list.Items() {
-			raw := rule.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			direction := string(raw.Properties.Direction)
-			protocol := string(raw.Properties.Protocol)
-			port := raw.Properties.Port
-			target := ""
-			if raw.Properties.Target != nil {
-				target = fmt.Sprintf("%s:%s", raw.Properties.Target.Kind, raw.Properties.Target.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, direction, protocol, port, target, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No security rules found.")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.SecurityRule]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(r *aruba.SecurityRule) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.Name != nil {
+				return *raw.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(r *aruba.SecurityRule) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.ID != nil {
+				return *raw.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "DIRECTION", Width: 12}, Value: func(r *aruba.SecurityRule) string {
+			if raw := r.Raw(); raw != nil {
+				return string(raw.Properties.Direction)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "PROTOCOL", Width: 12}, Value: func(r *aruba.SecurityRule) string {
+			if raw := r.Raw(); raw != nil {
+				return string(raw.Properties.Protocol)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "PORT", Width: 12}, Value: func(r *aruba.SecurityRule) string {
+			if raw := r.Raw(); raw != nil {
+				return raw.Properties.Port
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "TARGET", Width: 30}, Value: func(r *aruba.SecurityRule) string {
+			raw := r.Raw()
+			if raw == nil || raw.Properties.Target == nil {
+				return ""
+			}
+			return fmt.Sprintf("%s:%s", raw.Properties.Target.Kind, raw.Properties.Target.Value)
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(r *aruba.SecurityRule) string {
+			if raw := r.Raw(); raw != nil && raw.Status.State != nil {
+				return string(*raw.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(r *aruba.SecurityRule) bool { return r.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -56,6 +56,10 @@ func init() {
 }
 
 // Subnet subcommands
+type subnetGetView struct {
+	ID, URI, Name, Region, Type, CIDR string
+}
+
 var subnetCmd = &cobra.Command{
 	Use:   "subnet",
 	Short: "Manage subnets",
@@ -552,56 +556,61 @@ func NetworkSubnetGet(ctx context.Context, client aruba.Client, args NetworkSubn
 	if err != nil {
 		return fmt.Errorf("getting subnet: %w", apiErrFromV2(err))
 	}
-	if subnet != nil && subnet.Raw() != nil {
-		raw := subnet.Raw()
-		fmt.Println("\nSubnet Details:")
-		fmt.Println("===============")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil && string(raw.Metadata.LocationResponse.Value) != "" {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Properties.Type != "" {
-			fmt.Printf("Type:            %s\n", raw.Properties.Type)
-		}
-		if raw.Properties.Network != nil {
-			fmt.Printf("CIDR:            %s\n", raw.Properties.Network.Address)
-		}
-		if raw.Properties.DHCP != nil {
-			fmt.Printf("DHCP Enabled:    %v\n", raw.Properties.DHCP.Enabled)
-			if len(raw.Properties.DHCP.Routes) > 0 {
-				fmt.Printf("DHCP Routes:\n")
-				for _, route := range raw.Properties.DHCP.Routes {
-					fmt.Printf("  - %s -> %s\n", route.Address, route.Gateway)
-				}
-			}
-			if len(raw.Properties.DHCP.DNS) > 0 {
-				fmt.Printf("DHCP DNS:        %v\n", raw.Properties.DHCP.DNS)
-			}
-		}
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if subnet == nil || subnet.Raw() == nil {
 		fmt.Println("Subnet not found or no data returned.")
+		return nil
+	}
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(subnet, nil, nil)
+		return nil
+	}
+	raw := subnet.Raw()
+	view := subnetGetView{Type: string(raw.Properties.Type)}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.Network != nil {
+		view.CIDR = raw.Properties.Network.Address
+	}
+	if err := renderGet(subnetGetTmpl, view); err != nil {
+		return err
+	}
+	// DHCP details rendered after the template (dynamic nested content)
+	if raw.Properties.DHCP != nil {
+		fmt.Printf("DHCP Enabled:    %v\n", raw.Properties.DHCP.Enabled)
+		if len(raw.Properties.DHCP.Routes) > 0 {
+			fmt.Printf("DHCP Routes:\n")
+			for _, route := range raw.Properties.DHCP.Routes {
+				fmt.Printf("  - %s -> %s\n", route.Address, route.Gateway)
+			}
+		}
+		if len(raw.Properties.DHCP.DNS) > 0 {
+			fmt.Printf("DHCP DNS:        %v\n", raw.Properties.DHCP.DNS)
+		}
+	}
+	if raw.Metadata.CreationDate != nil {
+		fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+	}
+	if raw.Metadata.CreatedBy != nil {
+		fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+	} else {
+		fmt.Printf("Tags:            []\n")
+	}
+	if raw.Status.State != nil {
+		fmt.Printf("Status:          %s\n", *raw.Status.State)
 	}
 	return nil
 }
@@ -612,46 +621,42 @@ func NetworkSubnetList(ctx context.Context, client aruba.Client, args NetworkSub
 	if err != nil {
 		return fmt.Errorf("listing subnets: %w", apiErrFromV2(err))
 	}
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "REGION", Width: 18},
-			{Header: "CIDR", Width: 18},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, subnet := range list.Items() {
-			raw := subnet.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			cidr := ""
-			if raw.Properties.Network != nil {
-				cidr = raw.Properties.Network.Address
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, cidr, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No subnets found.")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.Subnet]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(s *aruba.Subnet) string {
+			if r := s.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(s *aruba.Subnet) string {
+			if r := s.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 18}, Value: func(s *aruba.Subnet) string {
+			if r := s.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "CIDR", Width: 18}, Value: func(s *aruba.Subnet) string {
+			if r := s.Raw(); r != nil && r.Properties.Network != nil {
+				return r.Properties.Network.Address
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(s *aruba.Subnet) string {
+			if r := s.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(s *aruba.Subnet) bool { return s.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.vpc.go
+++ b/cmd/network.vpc.go
@@ -85,6 +85,10 @@ func completeVPCID(cmd *cobra.Command, args []string, toComplete string) ([]stri
 }
 
 // VPC subcommands
+type vpcGetView struct {
+	ID, URI, Name, Region, Default, LinkedResources, CreatedAt, CreatedBy, Tags, Status string
+}
+
 var vpcCmd = &cobra.Command{
 	Use:   "vpc",
 	Short: "Manage VPCs",
@@ -460,47 +464,46 @@ func NetworkVPCGet(ctx context.Context, client aruba.Client, args NetworkVPCGetA
 		return fmt.Errorf("getting VPC details: %w", apiErrFromV2(err))
 	}
 
-	if vpc != nil && vpc.Raw() != nil {
-		raw := vpc.Raw()
-
-		fmt.Println("\nVPC Details:")
-		fmt.Println("============")
-
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-		}
-		fmt.Printf("Default:         %t\n", raw.Properties.Default)
-		fmt.Printf("Linked Resources: %d\n", len(raw.Properties.LinkedResources))
-
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if vpc == nil || vpc.Raw() == nil {
 		fmt.Println("VPC not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(vpc, nil, nil)
+		return nil
+	}
+	raw := vpc.Raw()
+	view := vpcGetView{
+		Default:         fmt.Sprintf("%t", raw.Properties.Default),
+		LinkedResources: fmt.Sprintf("%d", len(raw.Properties.LinkedResources)),
+		Tags:            "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(vpcGetTmpl, view)
 }
 
 // NetworkVPCUpdate updates a VPC's name and/or tags.

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -46,6 +46,10 @@ func init() {
 }
 
 // Peering subcommands
+type vpcPeeringGetView struct {
+	ID, Name, PeerVPC, Region, CreatedAt, CreatedBy, Tags, Status string
+}
+
 var vpcpeeringCmd = &cobra.Command{
 	Use:   "vpcpeering",
 	Short: "Manage VPC peering",
@@ -454,40 +458,42 @@ func NetworkVPCPeeringGet(ctx context.Context, client aruba.Client, args Network
 	if err != nil {
 		return fmt.Errorf("getting VPC peering: %w", apiErrFromV2(err))
 	}
-	if peering != nil && peering.Raw() != nil {
-		raw := peering.Raw()
-		fmt.Println("\nVPC Peering Details:")
-		fmt.Println("====================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Properties.RemoteVPC != nil {
-			fmt.Printf("Peer VPC:        %s\n", raw.Properties.RemoteVPC.URI)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if peering == nil || peering.Raw() == nil {
 		fmt.Println("VPC peering not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(peering, nil, nil)
+		return nil
+	}
+	raw := peering.Raw()
+	view := vpcPeeringGetView{Tags: "[]"}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Properties.RemoteVPC != nil {
+		view.PeerVPC = raw.Properties.RemoteVPC.URI
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(vpcPeeringGetTmpl, view)
 }
 
 // NetworkVPCPeeringList lists VPC peerings in the given VPC.
@@ -496,46 +502,42 @@ func NetworkVPCPeeringList(ctx context.Context, client aruba.Client, args Networ
 	if err != nil {
 		return fmt.Errorf("listing VPC peerings: %w", apiErrFromV2(err))
 	}
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "PEER VPC", Width: 26},
-			{Header: "REGION", Width: 18},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, peering := range list.Items() {
-			raw := peering.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			peerVPC := ""
-			if raw.Properties.RemoteVPC != nil {
-				peerVPC = raw.Properties.RemoteVPC.URI
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, peerVPC, region, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No VPC peerings found.")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.VPCPeering]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(p *aruba.VPCPeering) string {
+			if r := p.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(p *aruba.VPCPeering) string {
+			if r := p.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "PEER VPC", Width: 26}, Value: func(p *aruba.VPCPeering) string {
+			if r := p.Raw(); r != nil && r.Properties.RemoteVPC != nil {
+				return r.Properties.RemoteVPC.URI
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 18}, Value: func(p *aruba.VPCPeering) string {
+			if r := p.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(p *aruba.VPCPeering) string {
+			if r := p.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(p *aruba.VPCPeering) bool { return p.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -100,6 +100,10 @@ func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete str
 	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
+type vpcPeeringRouteGetView struct {
+	ID, Name, LocalNetwork, RemoteNetwork, BillingPeriod, Tags, Status string
+}
+
 var vpcpeeringrouteCmd = &cobra.Command{
 	Use:   "vpcpeeringroute",
 	Short: "Manage VPC peering routes",
@@ -567,35 +571,39 @@ func NetworkVPCPeeringRouteGet(ctx context.Context, client aruba.Client, args Ne
 		return fmt.Errorf("getting VPC peering route: %w", apiErrFromV2(err))
 	}
 
-	if route != nil && route.Raw() != nil {
-		raw := route.Raw()
-		fmt.Println("\nVPC Peering Route Details:")
-		fmt.Println("==========================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		} else {
-			fmt.Printf("ID:              %s\n", args.RouteID)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		fmt.Printf("Local Network:    %s\n", raw.Properties.LocalNetworkAddress)
-		fmt.Printf("Remote Network:   %s\n", raw.Properties.RemoteNetworkAddress)
-		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-			fmt.Printf("Billing Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if route == nil || route.Raw() == nil {
 		fmt.Println("VPC peering route not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(route, nil, nil)
+		return nil
+	}
+	raw := route.Raw()
+	view := vpcPeeringRouteGetView{
+		LocalNetwork:  raw.Properties.LocalNetworkAddress,
+		RemoteNetwork: raw.Properties.RemoteNetworkAddress,
+		Tags:          "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	} else {
+		view.ID = args.RouteID
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+		view.BillingPeriod = string(*raw.Properties.BillingPlanCommon.BillingPeriod)
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(vpcPeeringRouteGetTmpl, view)
 }
 
 // NetworkVPCPeeringRouteUpdate updates a VPC peering route's fields.
@@ -679,40 +687,42 @@ func NetworkVPCPeeringRouteList(ctx context.Context, client aruba.Client, args N
 		return fmt.Errorf("listing VPC peering routes: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "LOCAL NETWORK", Width: 18},
-			{Header: "REMOTE NETWORK", Width: 18},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, route := range list.Items() {
-			raw := route.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			localNetwork := raw.Properties.LocalNetworkAddress
-			remoteNetwork := raw.Properties.RemoteNetworkAddress
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, localNetwork, remoteNetwork, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No VPC peering routes found.")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.VPCPeeringRoute]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(r *aruba.VPCPeeringRoute) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.Name != nil {
+				return *raw.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(r *aruba.VPCPeeringRoute) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.ID != nil {
+				return *raw.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "LOCAL NETWORK", Width: 18}, Value: func(r *aruba.VPCPeeringRoute) string {
+			if raw := r.Raw(); raw != nil {
+				return raw.Properties.LocalNetworkAddress
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REMOTE NETWORK", Width: 18}, Value: func(r *aruba.VPCPeeringRoute) string {
+			if raw := r.Raw(); raw != nil {
+				return raw.Properties.RemoteNetworkAddress
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(r *aruba.VPCPeeringRoute) string {
+			if raw := r.Raw(); raw != nil && raw.Status.State != nil {
+				return string(*raw.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(r *aruba.VPCPeeringRoute) bool { return r.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -91,6 +91,10 @@ func completeVPNRouteID(cmd *cobra.Command, args []string, toComplete string) ([
 	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
+type vpnRouteGetView struct {
+	ID, URI, Name, Region, CloudSubnet, OnPremSubnet, CreatedAt, CreatedBy, Tags, Status string
+}
+
 var vpnrouteCmd = &cobra.Command{
 	Use:   "vpnroute",
 	Short: "Manage VPN tunnel routes",
@@ -510,42 +514,46 @@ func NetworkVPNRouteGet(ctx context.Context, client aruba.Client, args NetworkVP
 		return fmt.Errorf("getting VPN route: %w", apiErrFromV2(err))
 	}
 
-	if route != nil && route.Raw() != nil {
-		raw := route.Raw()
-		fmt.Println("\nVPN Route Details:")
-		fmt.Println("==================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-		}
-		fmt.Printf("Cloud Subnet:    %s\n", route.CloudSubnet())
-		fmt.Printf("OnPrem Subnet:   %s\n", route.OnPremSubnet())
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
-	} else {
+	if route == nil || route.Raw() == nil {
 		fmt.Println("VPN route not found or no data returned.")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(route, nil, nil)
+		return nil
+	}
+	raw := route.Raw()
+	view := vpnRouteGetView{
+		CloudSubnet:  route.CloudSubnet(),
+		OnPremSubnet: route.OnPremSubnet(),
+		Tags:         "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Metadata.CreationDate != nil {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	return renderGet(vpnRouteGetTmpl, view)
 }
 
 // NetworkVPNRouteUpdate updates a VPN route's name and/or tags.
@@ -627,38 +635,32 @@ func NetworkVPNRouteList(ctx context.Context, client aruba.Client, args NetworkV
 		return fmt.Errorf("listing VPN routes: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "CLOUD SUBNET", Width: 18},
-			{Header: "ONPREM SUBNET", Width: 18},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, route := range list.Items() {
-			raw := route.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, route.CloudSubnet(), route.OnPremSubnet(), status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No VPN routes found.")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.VPNRoute]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(r *aruba.VPNRoute) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.Name != nil {
+				return *raw.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(r *aruba.VPNRoute) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.ID != nil {
+				return *raw.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "CLOUD SUBNET", Width: 18}, Value: func(r *aruba.VPNRoute) string { return r.CloudSubnet() }},
+		{TableColumn: TableColumn{Header: "ONPREM SUBNET", Width: 18}, Value: func(r *aruba.VPNRoute) string { return r.OnPremSubnet() }},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(r *aruba.VPNRoute) string {
+			if raw := r.Raw(); raw != nil && raw.Status.State != nil {
+				return string(*raw.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(r *aruba.VPNRoute) bool { return r.Raw() != nil })
 	return nil
 }
 

--- a/cmd/network.vpntunnel.go
+++ b/cmd/network.vpntunnel.go
@@ -103,6 +103,10 @@ var vpnESPPFSGroups = []string{
 
 // vpnTunnelRef builds the combined-URI Ref for a VPN tunnel.
 // Used by network.vpnroute.go for VPNRoute refs that encode the tunnel ancestry.
+type vpnTunnelGetView struct {
+	ID, URI, Name, Region, VPNType, Protocol, PeerIP string
+}
+
 func vpnTunnelRef(projectID, tunnelID string) aruba.Ref {
 	return aruba.VPNTunnelRef(projectID, tunnelID)
 }
@@ -702,47 +706,43 @@ func NetworkVPNTunnelList(ctx context.Context, client aruba.Client, args Network
 		return fmt.Errorf("listing VPN tunnels: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 40},
-			{Header: "ID", Width: 25},
-			{Header: "REGION", Width: 18},
-			{Header: "TYPE", Width: 15},
-			{Header: "STATUS", Width: 15},
-		}
-		var rows [][]string
-		for _, vpn := range list.Items() {
-			redactVPNTunnelSecrets(vpn)
-			raw := vpn.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			region := ""
-			if raw.Metadata.LocationResponse != nil {
-				region = string(raw.Metadata.LocationResponse.Value)
-			}
-			vpnType := ""
-			if raw.Properties.VPNType != nil {
-				vpnType = string(*raw.Properties.VPNType)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, region, vpnType, status})
-		}
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No VPN tunnels found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.VPNTunnel]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 40}, Value: func(v *aruba.VPNTunnel) string {
+			redactVPNTunnelSecrets(v)
+			if r := v.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 25}, Value: func(v *aruba.VPNTunnel) string {
+			if r := v.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "REGION", Width: 18}, Value: func(v *aruba.VPNTunnel) string {
+			if r := v.Raw(); r != nil && r.Metadata.LocationResponse != nil {
+				return string(r.Metadata.LocationResponse.Value)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "TYPE", Width: 15}, Value: func(v *aruba.VPNTunnel) string {
+			if r := v.Raw(); r != nil && r.Properties.VPNType != nil {
+				return string(*r.Properties.VPNType)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(v *aruba.VPNTunnel) string {
+			if r := v.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(v *aruba.VPNTunnel) bool { return v.Raw() != nil })
 	return nil
 }
 
@@ -753,65 +753,72 @@ func NetworkVPNTunnelGet(ctx context.Context, client aruba.Client, args NetworkV
 		return fmt.Errorf("getting VPN tunnel details: %w", apiErrFromV2(err))
 	}
 
-	if vpn != nil && vpn.Raw() != nil {
-		raw := vpn.Raw()
-
-		fmt.Println("\nVPN Tunnel Details:")
-		fmt.Println("===================")
-
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
+	if vpn == nil || vpn.Raw() == nil {
+		return nil
+	}
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(vpn, nil, nil)
+		return nil
+	}
+	raw := vpn.Raw()
+	view := vpnTunnelGetView{}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.VPNType != nil {
+		view.VPNType = string(*raw.Properties.VPNType)
+	}
+	if raw.Properties.VPNClientProtocol != nil {
+		view.Protocol = string(*raw.Properties.VPNClientProtocol)
+	}
+	if raw.Properties.VPNClientSettingsCommon != nil && raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP != nil {
+		view.PeerIP = *raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP
+	}
+	if err := renderGet(vpnTunnelGetTmpl, view); err != nil {
+		return err
+	}
+	// IP Configuration section — dynamic nested content rendered after template
+	if raw.Properties.IPConfigurationsCommon != nil {
+		fmt.Println("\nIP Configuration:")
+		if raw.Properties.IPConfigurationsCommon.VPC != nil {
+			fmt.Printf("  VPC:           %s\n", raw.Properties.IPConfigurationsCommon.VPC.URI)
 		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-			fmt.Printf("Region:          %s\n", raw.Metadata.LocationResponse.Value)
-		}
-		if raw.Properties.VPNType != nil {
-			fmt.Printf("VPN Type:        %s\n", *raw.Properties.VPNType)
-		}
-		if raw.Properties.VPNClientProtocol != nil {
-			fmt.Printf("Protocol:        %s\n", *raw.Properties.VPNClientProtocol)
-		}
-		if raw.Properties.VPNClientSettingsCommon != nil && raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP != nil {
-			fmt.Printf("Peer IP:         %s\n", *raw.Properties.VPNClientSettingsCommon.PeerClientPublicIP)
-		}
-		if raw.Properties.IPConfigurationsCommon != nil {
-			fmt.Println("\nIP Configuration:")
-			if raw.Properties.IPConfigurationsCommon.VPC != nil {
-				fmt.Printf("  VPC:           %s\n", raw.Properties.IPConfigurationsCommon.VPC.URI)
+		if raw.Properties.IPConfigurationsCommon.Subnet != nil {
+			fmt.Printf("  Subnet CIDR:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.CIDR)
+			if raw.Properties.IPConfigurationsCommon.Subnet.Name != "" {
+				fmt.Printf("  Subnet Name:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.Name)
 			}
-			if raw.Properties.IPConfigurationsCommon.Subnet != nil {
-				fmt.Printf("  Subnet CIDR:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.CIDR)
-				if raw.Properties.IPConfigurationsCommon.Subnet.Name != "" {
-					fmt.Printf("  Subnet Name:   %s\n", raw.Properties.IPConfigurationsCommon.Subnet.Name)
-				}
-			}
-			if raw.Properties.IPConfigurationsCommon.PublicIP != nil {
-				fmt.Printf("  Public IP:     %s\n", raw.Properties.IPConfigurationsCommon.PublicIP.URI)
-			}
 		}
-		if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
-			fmt.Printf("\nBilling Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
+		if raw.Properties.IPConfigurationsCommon.PublicIP != nil {
+			fmt.Printf("  Public IP:     %s\n", raw.Properties.IPConfigurationsCommon.PublicIP.URI)
 		}
-		if raw.Metadata.CreationDate != nil {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", *raw.Status.State)
-		}
+	}
+	if raw.Properties.BillingPlanCommon != nil && raw.Properties.BillingPlanCommon.BillingPeriod != nil {
+		fmt.Printf("\nBilling Period:  %s\n", *raw.Properties.BillingPlanCommon.BillingPeriod)
+	}
+	if raw.Metadata.CreationDate != nil {
+		fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
+	}
+	if raw.Metadata.CreatedBy != nil {
+		fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
+	} else {
+		fmt.Printf("Tags:            []\n")
+	}
+	if raw.Status.State != nil {
+		fmt.Printf("Status:          %s\n", *raw.Status.State)
 	}
 	return nil
 }

--- a/cmd/schedule.job.go
+++ b/cmd/schedule.job.go
@@ -11,6 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type scheduleJobGetView struct {
+	ID, URI, Name, Region, JobType, Enabled, ScheduleAt, Cron, ExecuteUntil, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func jobRef(projectID, jobID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Schedule/jobs/" + jobID)
 }
@@ -573,59 +577,55 @@ func ScheduleJobGet(ctx context.Context, client aruba.Client, args ScheduleJobGe
 		return fmt.Errorf("getting job: %w", apiErrFromV2(err))
 	}
 
-	if job != nil && job.Raw() != nil {
-		raw := job.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(job, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nJob Details:")
-		fmt.Println("============")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		fmt.Printf("Job Type:        %s\n", string(raw.Properties.JobType))
-		fmt.Printf("Enabled:         %t\n", raw.Properties.Enabled)
-		if raw.Properties.ScheduleAt != nil {
-			fmt.Printf("Schedule At:     %s\n", *raw.Properties.ScheduleAt)
-		}
-		if raw.Properties.Cron != nil {
-			fmt.Printf("CRON:            %s\n", *raw.Properties.Cron)
-		}
-		if raw.Properties.ExecuteUntil != nil {
-			fmt.Printf("Execute Until:   %s\n", *raw.Properties.ExecuteUntil)
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if job == nil || job.Raw() == nil {
 		fmt.Println("Job not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(job, nil, nil)
+		return nil
+	}
+	raw := job.Raw()
+	view := scheduleJobGetView{
+		JobType: string(raw.Properties.JobType),
+		Enabled: fmt.Sprintf("%t", raw.Properties.Enabled),
+		Tags:    "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Properties.ScheduleAt != nil {
+		view.ScheduleAt = *raw.Properties.ScheduleAt
+	}
+	if raw.Properties.Cron != nil {
+		view.Cron = *raw.Properties.Cron
+	}
+	if raw.Properties.ExecuteUntil != nil {
+		view.ExecuteUntil = *raw.Properties.ExecuteUntil
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(scheduleJobGetTmpl, view)
 }
 
 // ScheduleJobList lists all scheduled jobs in a project.

--- a/cmd/storage.backup.go
+++ b/cmd/storage.backup.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type storageBackupGetView struct {
+	ID, URI, Name, Type, SourceVolume, RetentionDays, BillingPeriod, Region, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func backupRef(projectID, backupID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/backups/" + backupID)
 }
@@ -478,57 +482,52 @@ func StorageBackupGet(ctx context.Context, client aruba.Client, args StorageBack
 		return fmt.Errorf("getting backup: %w", apiErrFromV2(err))
 	}
 
-	if bkp != nil && bkp.Raw() != nil {
-		raw := bkp.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(bkp, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nStorage Backup Details:")
-		fmt.Println("=======================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		fmt.Printf("Type:            %s\n", string(raw.Properties.Type))
-		if raw.Properties.Origin.URI != "" {
-			fmt.Printf("Source Volume:   %s\n", raw.Properties.Origin.URI)
-		}
-		if raw.Properties.RetentionDays != nil {
-			fmt.Printf("Retention Days:  %d\n", *raw.Properties.RetentionDays)
-		}
-		if raw.Properties.BillingPeriod != nil {
-			fmt.Printf("Billing Period:  %s\n", string(*raw.Properties.BillingPeriod))
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-	} else {
+	if bkp == nil || bkp.Raw() == nil {
 		fmt.Println("Backup not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(bkp, nil, nil)
+		return nil
+	}
+	raw := bkp.Raw()
+	view := storageBackupGetView{
+		Type:         string(raw.Properties.Type),
+		SourceVolume: raw.Properties.Origin.URI,
+		Tags:         "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Properties.RetentionDays != nil {
+		view.RetentionDays = fmt.Sprintf("%d", *raw.Properties.RetentionDays)
+	}
+	if raw.Properties.BillingPeriod != nil {
+		view.BillingPeriod = string(*raw.Properties.BillingPeriod)
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(storageBackupGetTmpl, view)
 }
 
 // StorageBackupUpdate is a stub — the API does not support backup updates.
@@ -553,40 +552,36 @@ func StorageBackupList(ctx context.Context, client aruba.Client, args StorageBac
 		return fmt.Errorf("listing backups: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "TYPE", Width: 12},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, bkp := range list.Items() {
-			raw := bkp.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			backupType := string(raw.Properties.Type)
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, backupType, status})
-		}
-
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No backups found")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.StorageBackup]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(b *aruba.StorageBackup) string {
+			if r := b.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(b *aruba.StorageBackup) string {
+			if r := b.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "TYPE", Width: 12}, Value: func(b *aruba.StorageBackup) string {
+			if r := b.Raw(); r != nil {
+				return string(r.Properties.Type)
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(b *aruba.StorageBackup) string {
+			if r := b.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(b *aruba.StorageBackup) bool { return b.Raw() != nil })
 	return nil
 }
 

--- a/cmd/storage.restore.go
+++ b/cmd/storage.restore.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type storageRestoreGetView struct {
+	ID, URI, Name, TargetVolume, Region, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func restoreRef(projectID, backupID, restoreID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/backups/" + backupID + "/restores/" + restoreID)
 }
@@ -488,51 +492,45 @@ func StorageRestoreGet(ctx context.Context, client aruba.Client, args StorageRes
 		return fmt.Errorf("getting restore: %w", apiErrFromV2(err))
 	}
 
-	if restore != nil && restore.Raw() != nil {
-		raw := restore.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(restore, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nRestore Operation Details:")
-		fmt.Println("==========================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Properties.Destination.URI != "" {
-			fmt.Printf("Target Volume:   %s\n", raw.Properties.Destination.URI)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if restore == nil || restore.Raw() == nil {
 		fmt.Println("Restore operation not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(restore, nil, nil)
+		return nil
+	}
+	raw := restore.Raw()
+	view := storageRestoreGetView{
+		TargetVolume: raw.Properties.Destination.URI,
+		Tags:         "[]",
+	}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(restoreGetTmpl, view)
 }
 
 // StorageRestoreUpdate updates a restore operation's name and/or tags.
@@ -601,38 +599,30 @@ func StorageRestoreList(ctx context.Context, client aruba.Client, args StorageRe
 		return fmt.Errorf("listing restores: %w", apiErrFromV2(err))
 	}
 
-	if list != nil && len(list.Items()) > 0 {
-		headers := []TableColumn{
-			{Header: "NAME", Width: 30},
-			{Header: "ID", Width: 26},
-			{Header: "STATUS", Width: 15},
-		}
-
-		var rows [][]string
-		for _, r := range list.Items() {
-			raw := r.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, status})
-		}
-
-		PrintOutput(list, headers, rows)
-	} else {
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Println("No restores found for this backup")
+		return nil
 	}
+	renderList(list, []ListColumn[*aruba.StorageRestore]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(r *aruba.StorageRestore) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.Name != nil {
+				return *raw.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(r *aruba.StorageRestore) string {
+			if raw := r.Raw(); raw != nil && raw.Metadata.ID != nil {
+				return *raw.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(r *aruba.StorageRestore) string {
+			if raw := r.Raw(); raw != nil && raw.Status.State != nil {
+				return string(*raw.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(r *aruba.StorageRestore) bool { return r.Raw() != nil })
 	return nil
 }
 

--- a/cmd/storage.snapshot.go
+++ b/cmd/storage.snapshot.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type snapshotGetView struct {
+	ID, URI, Name, Size, SourceVolume, Region, Status, CreatedAt, CreatedBy, Tags string
+}
+
 func snapshotRef(projectID, snapshotID string) aruba.Ref {
 	return aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/snapshots/" + snapshotID)
 }
@@ -468,54 +472,48 @@ func StorageSnapshotGet(ctx context.Context, client aruba.Client, args StorageSn
 		return fmt.Errorf("getting snapshot: %w", apiErrFromV2(err))
 	}
 
-	if snap != nil && snap.Raw() != nil {
-		raw := snap.Raw()
-
-		format := resolveOutputFormat()
-		if format == OutputFormatJSON || format == OutputFormatYAML {
-			PrintOutput(snap, nil, nil)
-			return nil
-		}
-
-		fmt.Println("\nSnapshot Details:")
-		fmt.Println("=================")
-		if raw.Metadata.ID != nil {
-			fmt.Printf("ID:              %s\n", *raw.Metadata.ID)
-		}
-		if raw.Metadata.URI != nil {
-			fmt.Printf("URI:             %s\n", *raw.Metadata.URI)
-		}
-		if raw.Metadata.Name != nil {
-			fmt.Printf("Name:            %s\n", *raw.Metadata.Name)
-		}
-		if raw.Properties.SizeGB != nil {
-			fmt.Printf("Size (GB):       %d\n", *raw.Properties.SizeGB)
-		}
-		if raw.Properties.Volume != nil && raw.Properties.Volume.URI != nil {
-			fmt.Printf("Source Volume:   %s\n", *raw.Properties.Volume.URI)
-		}
-		if raw.Metadata.LocationResponse != nil {
-			fmt.Printf("Region:          %s\n", string(raw.Metadata.LocationResponse.Value))
-		}
-		if raw.Status.State != nil {
-			fmt.Printf("Status:          %s\n", string(*raw.Status.State))
-		}
-		if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
-			fmt.Printf("Creation Date:   %s\n", raw.Metadata.CreationDate.Format(DateLayout))
-		}
-		if raw.Metadata.CreatedBy != nil {
-			fmt.Printf("Created By:      %s\n", *raw.Metadata.CreatedBy)
-		}
-		if len(raw.Metadata.Tags) > 0 {
-			fmt.Printf("Tags:            %v\n", raw.Metadata.Tags)
-		} else {
-			fmt.Printf("Tags:            []\n")
-		}
-		fmt.Println()
-	} else {
+	if snap == nil || snap.Raw() == nil {
 		fmt.Println("Snapshot not found")
+		return nil
 	}
-	return nil
+	format := resolveOutputFormat()
+	if format == OutputFormatJSON || format == OutputFormatYAML {
+		PrintOutput(snap, nil, nil)
+		return nil
+	}
+	raw := snap.Raw()
+	view := snapshotGetView{Tags: "[]"}
+	if raw.Metadata.ID != nil {
+		view.ID = *raw.Metadata.ID
+	}
+	if raw.Metadata.URI != nil {
+		view.URI = *raw.Metadata.URI
+	}
+	if raw.Metadata.Name != nil {
+		view.Name = *raw.Metadata.Name
+	}
+	if raw.Properties.SizeGB != nil {
+		view.Size = fmt.Sprintf("%d", *raw.Properties.SizeGB)
+	}
+	if raw.Properties.Volume != nil && raw.Properties.Volume.URI != nil {
+		view.SourceVolume = *raw.Properties.Volume.URI
+	}
+	if raw.Metadata.LocationResponse != nil {
+		view.Region = string(raw.Metadata.LocationResponse.Value)
+	}
+	if raw.Status.State != nil {
+		view.Status = string(*raw.Status.State)
+	}
+	if raw.Metadata.CreationDate != nil && !raw.Metadata.CreationDate.IsZero() {
+		view.CreatedAt = raw.Metadata.CreationDate.Format(DateLayout)
+	}
+	if raw.Metadata.CreatedBy != nil {
+		view.CreatedBy = *raw.Metadata.CreatedBy
+	}
+	if len(raw.Metadata.Tags) > 0 {
+		view.Tags = fmt.Sprintf("%v", raw.Metadata.Tags)
+	}
+	return renderGet(snapshotGetTmpl, view)
 }
 
 // StorageSnapshotUpdate updates a snapshot.
@@ -575,49 +573,39 @@ func StorageSnapshotList(ctx context.Context, client aruba.Client, args StorageS
 		return fmt.Errorf("listing snapshots: %w", apiErrFromV2(err))
 	}
 
-	headers := []TableColumn{
-		{Header: "NAME", Width: 30},
-		{Header: "ID", Width: 26},
-		{Header: "SIZE(GB)", Width: 12},
-		{Header: "STATUS", Width: 15},
-	}
-
-	var rows [][]string
-	if list != nil {
-		for _, snap := range list.Items() {
-			if snap.VolumeURI() != volumeRef(args.ProjectID, args.VolumeID).URI() {
-				continue
-			}
-			raw := snap.Raw()
-			if raw == nil {
-				continue
-			}
-			name := ""
-			if raw.Metadata.Name != nil {
-				name = *raw.Metadata.Name
-			}
-			id := ""
-			if raw.Metadata.ID != nil {
-				id = *raw.Metadata.ID
-			}
-			size := "0"
-			if raw.Properties.SizeGB != nil {
-				size = fmt.Sprintf("%d", *raw.Properties.SizeGB)
-			}
-			status := ""
-			if raw.Status.State != nil {
-				status = string(*raw.Status.State)
-			}
-			rows = append(rows, []string{name, id, size, status})
-		}
-	}
-
-	if len(rows) == 0 {
+	volumeURI := volumeRef(args.ProjectID, args.VolumeID).URI()
+	if list == nil || len(list.Items()) == 0 {
 		fmt.Printf("No snapshots found for volume: %s\n", args.VolumeID)
 		return nil
 	}
-
-	PrintOutput(list, headers, rows)
+	renderList(list, []ListColumn[*aruba.Snapshot]{
+		{TableColumn: TableColumn{Header: "NAME", Width: 30}, Value: func(s *aruba.Snapshot) string {
+			if r := s.Raw(); r != nil && r.Metadata.Name != nil {
+				return *r.Metadata.Name
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "ID", Width: 26}, Value: func(s *aruba.Snapshot) string {
+			if r := s.Raw(); r != nil && r.Metadata.ID != nil {
+				return *r.Metadata.ID
+			}
+			return ""
+		}},
+		{TableColumn: TableColumn{Header: "SIZE(GB)", Width: 12}, Value: func(s *aruba.Snapshot) string {
+			if r := s.Raw(); r != nil && r.Properties.SizeGB != nil {
+				return fmt.Sprintf("%d", *r.Properties.SizeGB)
+			}
+			return "0"
+		}},
+		{TableColumn: TableColumn{Header: "STATUS", Width: 15}, Value: func(s *aruba.Snapshot) string {
+			if r := s.Raw(); r != nil && r.Status.State != nil {
+				return string(*r.Status.State)
+			}
+			return ""
+		}},
+	}, list.Items(), func(s *aruba.Snapshot) bool {
+		return s.VolumeURI() == volumeURI && s.Raw() != nil
+	})
 	return nil
 }
 

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -2,10 +2,324 @@ package cmd
 
 // Get-command template strings. Each const is rendered by renderGet() against
 // the resource-specific view struct defined in the same file as its command.
+// Complex dynamic sections (DHCP routes, VPN IP config) are appended with
+// fmt.Printf calls in the operation function after the template render.
 
 const kmsGetTmpl = `
 KMS Details:
 ============
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const cloudServerGetTmpl = `
+Cloud Server Details:
+====================
+ID:              {{.ID}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Flavor:          {{.Flavor}}
+CPU:             {{.CPU}}
+RAM:             {{.RAM}}
+HD:              {{.HD}}
+Boot Volume URI: {{.BootVolumeURI}}
+Keypair URI:     {{.KeypairURI}}
+Status:          {{.Status}}
+Tags:            {{.Tags}}
+`
+
+const keypairGetTmpl = `
+Keypair Details:
+===============
+Name:            {{.Name}}
+URI:             {{.URI}}
+Public Key:      {{.PublicKey}}
+Status:          Active
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+`
+
+const projectGetTmpl = `
+Project Details:
+================
+ID:              {{.ID}}
+Name:            {{.Name}}
+Description:     {{.Description}}
+Default:         {{.Default}}
+Creation Date:   {{.CreatedAt}}
+Update Date:     {{.UpdatedAt}}
+Created By:      {{.CreatedBy}}
+Updated By:      {{.UpdatedBy}}
+Tags:            {{.Tags}}
+`
+
+const containerRegistryGetTmpl = `
+Container Registry Details:
+==========================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Public IP:       {{.PublicIP}}
+VPC:             {{.VPC}}
+Subnet:          {{.Subnet}}
+Security Group:  {{.SecurityGroup}}
+Block Storage:   {{.BlockStorage}}
+Billing Period:  {{.BillingPeriod}}
+Admin User:      {{.AdminUser}}
+Concurrent Users: {{.ConcurrentUsers}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const elasticIPGetTmpl = `
+Elastic IP Details:
+===================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Address:         {{.Address}}
+Billing Period:  {{.BillingPeriod}}
+Linked Resources: {{.LinkedResources}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const loadBalancerGetTmpl = `
+Load Balancer Details:
+======================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Address:         {{.Address}}
+VPC:             {{.VPC}}
+Linked Resources: {{.LinkedResources}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const securityGroupGetTmpl = `
+Security Group Details:
+======================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const securityRuleGetTmpl = `
+Security Rule Details:
+=====================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Direction:       {{.Direction}}
+Protocol:        {{.Protocol}}
+Port:            {{.Port}}
+Target Kind:     {{.TargetKind}}
+Target Value:    {{.TargetValue}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const subnetGetTmpl = `
+Subnet Details:
+===============
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Type:            {{.Type}}
+CIDR:            {{.CIDR}}
+`
+
+const vpcGetTmpl = `
+VPC Details:
+============
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Default:         {{.Default}}
+Linked Resources: {{.LinkedResources}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const vpcPeeringGetTmpl = `
+VPC Peering Details:
+====================
+ID:              {{.ID}}
+Name:            {{.Name}}
+Peer VPC:        {{.PeerVPC}}
+Region:          {{.Region}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const vpcPeeringRouteGetTmpl = `
+VPC Peering Route Details:
+==========================
+ID:              {{.ID}}
+Name:            {{.Name}}
+Local Network:    {{.LocalNetwork}}
+Remote Network:   {{.RemoteNetwork}}
+Billing Period:  {{.BillingPeriod}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const vpnRouteGetTmpl = `
+VPN Route Details:
+==================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Cloud Subnet:    {{.CloudSubnet}}
+OnPrem Subnet:   {{.OnPremSubnet}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+Status:          {{.Status}}
+`
+
+const vpnTunnelGetTmpl = `
+VPN Tunnel Details:
+===================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+VPN Type:        {{.VPNType}}
+Protocol:        {{.Protocol}}
+Peer IP:         {{.PeerIP}}
+`
+
+const scheduleJobGetTmpl = `
+Job Details:
+============
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Job Type:        {{.JobType}}
+Enabled:         {{.Enabled}}
+Schedule At:     {{.ScheduleAt}}
+CRON:            {{.Cron}}
+Execute Until:   {{.ExecuteUntil}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const storageBackupGetTmpl = `
+Storage Backup Details:
+=======================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Type:            {{.Type}}
+Source Volume:   {{.SourceVolume}}
+Retention Days:  {{.RetentionDays}}
+Billing Period:  {{.BillingPeriod}}
+Region:          {{.Region}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const snapshotGetTmpl = `
+Snapshot Details:
+=================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Size (GB):       {{.Size}}
+Source Volume:   {{.SourceVolume}}
+Region:          {{.Region}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const restoreGetTmpl = `
+Restore Operation Details:
+==========================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Target Volume:   {{.TargetVolume}}
+Region:          {{.Region}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const dbaasGetTmpl = `
+DBaaS Instance Details:
+=======================
+ID:              {{.ID}}
+URI:             {{.URI}}
+Name:            {{.Name}}
+Region:          {{.Region}}
+Engine Type:     {{.EngineType}}
+Engine Version:  {{.EngineVersion}}
+Engine Name:     {{.EngineName}}
+Flavor:          {{.Flavor}}
+Status:          {{.Status}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+Tags:            {{.Tags}}
+`
+
+const databaseGetTmpl = `
+Database Details:
+================
+Name:            {{.Name}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+`
+
+const userGetTmpl = `
+User Details:
+=============
+Username:        {{.Username}}
+Creation Date:   {{.CreatedAt}}
+Created By:      {{.CreatedBy}}
+`
+
+const databaseBackupGetTmpl = `
+Backup Details:
+==============
 ID:              {{.ID}}
 URI:             {{.URI}}
 Name:            {{.Name}}


### PR DESCRIPTION
## Summary

Completes the incremental migration of all remaining `list` and `get` operation functions to the `RenderList[T]` and `RenderGet` helpers introduced in #206 and #207.

## List commands migrated (21)

| Family | Commands |
|---|---|
| compute | `CloudServerList`, `KeyPairList` |
| container | `ContainerRegistryList` |
| database | `DBaaSList`, `DBaaSDatabaseList`, `DBaaSGrantList`, `DBaaSUserList`, `DBaaSBackupList` |
| management | `ProjectList` |
| network | `ElasticIPList`, `LoadBalancerList`, `SecurityGroupList`, `SecurityRuleList`, `SubnetList`, `VPCPeeringList`, `VPCPeeringRouteList`, `VPNRouteList`, `VPNTunnelList` |
| storage | `BackupList`, `RestoreList`, `SnapshotList` |

## Get commands migrated (22)

All 22 get-command template strings are consolidated in `cmd/templates.go`. View structs (flat string bags) stay in the resource file, coupled to the nil-check extraction logic.

| Family | Commands | Notes |
|---|---|---|
| compute | `CloudServerGet`, `KeyPairGet` | CloudServer preserves `--verbose` JSON dump |
| container | `ContainerRegistryGet` | |
| database | `DBaaSGet`, `DBaaSDatabaseGet`, `DBaaSUserGet`, `DBaaSBackupGet` | |
| management | `ProjectGet` | Uses wrapper accessors, no `.Raw()` |
| network | `ElasticIPGet`, `LoadBalancerGet`, `SecurityGroupGet`, `SecurityRuleGet` | Added JSON/YAML early-return where missing |
| network | `SubnetGet` | Hybrid: template for basic fields + `fmt.Printf` for DHCP routes/DNS |
| network | `VPCGet`, `VPCPeeringGet`, `VPCPeeringRouteGet`, `VPNRouteGet` | |
| network | `VPNTunnelGet` | Hybrid: template for header + `fmt.Printf` for IP Configuration section |
| schedule | `JobGet` | |
| storage | `BackupGet`, `SnapshotGet`, `RestoreGet` | |

## Test plan

- [x] `go build ./...` — no compile errors
- [x] `go test ./...` — all packages green
- [x] `gofmt -l .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
