### PR TITLE
feat: replace log package with structured logging via log/slog

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Arubacloud/acloud-cli/internal/client"
+	"github.com/Arubacloud/acloud-cli/internal/logging"
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/spf13/cobra"
 )
@@ -57,6 +58,10 @@ func GetArubaClient() (aruba.Client, error) {
 	}
 
 	debug, _ := rootCmd.PersistentFlags().GetBool("debug")
+	logLevel := resolveLogLevel(debug)
+	logFormat, _ := rootCmd.PersistentFlags().GetString("log-format")
+
+	logging.Setup(logLevel, logFormat)
 
 	return client.Get(client.Params{
 		ClientID:       cfg.ClientID,
@@ -65,6 +70,8 @@ func GetArubaClient() (aruba.Client, error) {
 		TokenIssuerURL: tokenIssuer,
 		Debug:          debug,
 		UserAgent:      "acloud-cli@" + rootCmd.Version,
+		LogLevel:       logLevel,
+		LogFormat:      logFormat,
 	})
 }
 
@@ -75,4 +82,18 @@ func resetClientState() {
 
 func setClientForTesting(c aruba.Client) {
 	client.SetForTesting(c)
+}
+
+// resolveLogLevel returns the effective log level string. --debug takes
+// precedence over --log-level (back-compat: --debug was the only verbosity
+// control before --log-level was introduced).
+func resolveLogLevel(debug bool) string {
+	if debug {
+		return "debug"
+	}
+	level, _ := rootCmd.PersistentFlags().GetString("log-level")
+	if level == "" {
+		return "info"
+	}
+	return level
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,10 +38,12 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging (WARNING: may expose credentials and tokens in HTTP headers)")
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging — equivalent to --log-level debug (WARNING: exposes credentials in HTTP headers)")
 	rootCmd.PersistentFlags().StringP("output", "o", OutputFormatTable, "Output format: table|std|standard, table-json|std-json, table-yaml|std-yaml, json, yaml")
 	rootCmd.PersistentFlags().String("timeout", "30s", "Timeout for API calls (e.g. 30s, 2m, 5m)")
 	rootCmd.PersistentFlags().String("profile", "", "Credential profile to use (overrides ACLOUD_PROFILE env var)")
+	rootCmd.PersistentFlags().String("log-level", "info", "Log verbosity: debug, info, warn, error")
+	rootCmd.PersistentFlags().String("log-format", "text", "Log output format: text, json")
 }
 
 // GetProjectID returns the project ID from the flag or current context.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"fmt"
-	"log"
-	"os"
+	"net/http"
 	"sync"
 
+	"github.com/Arubacloud/acloud-cli/internal/logging"
+	"github.com/Arubacloud/acloud-cli/internal/middleware"
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 )
 
@@ -17,6 +18,8 @@ type Params struct {
 	TokenIssuerURL string
 	UserAgent      string
 	Debug          bool
+	LogLevel       string
+	LogFormat      string
 }
 
 type cachedState struct {
@@ -27,6 +30,8 @@ type cachedState struct {
 	debug       bool
 	baseURL     string
 	tokenIssuer string
+	logLevel    string
+	logFormat   string
 	override    aruba.Client // set by SetForTesting only
 }
 
@@ -43,27 +48,34 @@ func Get(p Params) (aruba.Client, error) {
 		s.secret == p.ClientSecret &&
 		s.debug == p.Debug &&
 		s.baseURL == p.BaseURL &&
-		s.tokenIssuer == p.TokenIssuerURL {
+		s.tokenIssuer == p.TokenIssuerURL &&
+		s.logLevel == p.LogLevel &&
+		s.logFormat == p.LogFormat {
 		return s.client, nil
 	}
 
-	options := aruba.DefaultOptions(p.ClientID, p.ClientSecret)
+	options := aruba.DefaultOptions(p.ClientID, p.ClientSecret).WithDefaultLogger()
 	if p.BaseURL != "" {
 		options = options.WithBaseURL(p.BaseURL)
 	}
 	if p.TokenIssuerURL != "" {
 		options = options.WithTokenIssuerURL(p.TokenIssuerURL)
 	}
-	if p.Debug {
-		options = options.WithNativeLogger()
-		log.SetOutput(os.Stderr)
-		log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-		log.SetPrefix("[ArubaSDK] ")
-	} else {
-		options = options.WithDefaultLogger()
-	}
 	if p.UserAgent != "" {
 		options = options.WithUserAgent(p.UserAgent)
+	}
+
+	// Inject a logging transport when debug-level logging is active so that
+	// HTTP requests and responses are visible with Authorization headers
+	// redacted. This replaces the former WithNativeLogger + global log.*
+	// side-effects approach.
+	if p.LogLevel == "debug" {
+		options = options.WithCustomHTTPClient(&http.Client{
+			Transport: &middleware.LoggingTransport{
+				Base:   http.DefaultTransport,
+				Logger: logging.L(),
+			},
+		})
 	}
 
 	c, err := aruba.NewClient(options)
@@ -77,6 +89,8 @@ func Get(p Params) (aruba.Client, error) {
 	s.debug = p.Debug
 	s.baseURL = p.BaseURL
 	s.tokenIssuer = p.TokenIssuerURL
+	s.logLevel = p.LogLevel
+	s.logFormat = p.LogFormat
 
 	return c, nil
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,59 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+)
+
+var (
+	mu     sync.RWMutex
+	global *slog.Logger
+)
+
+// Setup initialises the package-level slog logger from the resolved level and
+// format strings. All output goes to stderr so it never corrupts -o json/yaml
+// stdout output.
+//
+// level:  "debug" | "info" | "warn" | "error" (default: "info")
+// format: "text" | "json"                      (default: "text")
+func Setup(level, format string) {
+	lvl := parseLevel(level)
+	opts := &slog.HandlerOptions{Level: lvl}
+
+	var h slog.Handler
+	if format == "json" {
+		h = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		h = slog.NewTextHandler(os.Stderr, opts)
+	}
+
+	mu.Lock()
+	global = slog.New(h)
+	mu.Unlock()
+}
+
+// L returns the package-level slog.Logger. If Setup has not yet been called,
+// it falls back to the default slog logger.
+func L() *slog.Logger {
+	mu.RLock()
+	l := global
+	mu.RUnlock()
+	if l == nil {
+		return slog.Default()
+	}
+	return l
+}
+
+func parseLevel(s string) slog.Level {
+	switch s {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,95 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestSetup_DefaultIsInfo(t *testing.T) {
+	Setup("info", "text")
+	l := L()
+	if !l.Enabled(nil, slog.LevelInfo) {
+		t.Error("expected INFO to be enabled")
+	}
+	if l.Enabled(nil, slog.LevelDebug) {
+		t.Error("expected DEBUG to be disabled at INFO level")
+	}
+}
+
+func TestSetup_Debug(t *testing.T) {
+	Setup("debug", "text")
+	l := L()
+	if !l.Enabled(nil, slog.LevelDebug) {
+		t.Error("expected DEBUG to be enabled")
+	}
+}
+
+func TestSetup_Warn(t *testing.T) {
+	Setup("warn", "text")
+	l := L()
+	if !l.Enabled(nil, slog.LevelWarn) {
+		t.Error("expected WARN to be enabled")
+	}
+	if l.Enabled(nil, slog.LevelInfo) {
+		t.Error("expected INFO to be disabled at WARN level")
+	}
+}
+
+func TestSetup_Error(t *testing.T) {
+	Setup("error", "text")
+	l := L()
+	if !l.Enabled(nil, slog.LevelError) {
+		t.Error("expected ERROR to be enabled")
+	}
+	if l.Enabled(nil, slog.LevelWarn) {
+		t.Error("expected WARN to be disabled at ERROR level")
+	}
+}
+
+func TestSetup_UnknownLevelDefaultsToInfo(t *testing.T) {
+	Setup("verbose", "text")
+	l := L()
+	if !l.Enabled(nil, slog.LevelInfo) {
+		t.Error("expected INFO for unknown level")
+	}
+	if l.Enabled(nil, slog.LevelDebug) {
+		t.Error("expected DEBUG disabled for unknown level")
+	}
+}
+
+func TestSetup_JSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	// Override global with a JSON handler writing to buf for output verification.
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	mu.Lock()
+	global = slog.New(slog.NewJSONHandler(&buf, opts))
+	mu.Unlock()
+
+	L().Debug("test message", "key", "value")
+
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		t.Fatal("expected log output, got none")
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(line), &record); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\noutput: %s", err, line)
+	}
+	if record["msg"] != "test message" {
+		t.Errorf("expected msg='test message', got: %v", record["msg"])
+	}
+}
+
+func TestL_FallsBackToDefault(t *testing.T) {
+	mu.Lock()
+	global = nil
+	mu.Unlock()
+
+	l := L()
+	if l == nil {
+		t.Error("expected non-nil logger even before Setup")
+	}
+}

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// LoggingTransport is an http.RoundTripper that logs each request and response
+// at DEBUG level via the provided slog.Logger. The Authorization header value
+// is always replaced with "Bearer [REDACTED]" before logging to prevent
+// credential exposure.
+type LoggingTransport struct {
+	Base   http.RoundTripper
+	Logger *slog.Logger
+}
+
+func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	t.Logger.Debug("→ request",
+		"method", req.Method,
+		"url", req.URL.String(),
+		"authorization", redactAuth(req.Header.Get("Authorization")),
+	)
+
+	resp, err := base.RoundTrip(req)
+	if err != nil {
+		t.Logger.Debug("← error", "err", err)
+		return nil, err
+	}
+
+	t.Logger.Debug("← response",
+		"method", req.Method,
+		"url", req.URL.String(),
+		"status", resp.StatusCode,
+	)
+	return resp, nil
+}
+
+// redactAuth replaces the token value in an Authorization header with
+// "[REDACTED]", preserving the scheme prefix (e.g. "Bearer").
+func redactAuth(v string) string {
+	if v == "" {
+		return ""
+	}
+	parts := strings.SplitN(v, " ", 2)
+	if len(parts) == 2 {
+		return parts[0] + " [REDACTED]"
+	}
+	return "[REDACTED]"
+}

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -1,0 +1,145 @@
+package middleware
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// logginMockTransport is a simple RoundTripper for logging tests.
+type loggingMockTransport struct {
+	resp *http.Response
+	err  error
+}
+
+func (m *loggingMockTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.resp, nil
+}
+
+func newLogLogger() (*slog.Logger, *strings.Builder) {
+	buf := &strings.Builder{}
+	h := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), buf
+}
+
+func logResp(status int) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(""))}
+}
+
+func TestLoggingTransport_LogsRequestAndResponse(t *testing.T) {
+	logger, buf := newLogLogger()
+	lt := &LoggingTransport{
+		Base:   &loggingMockTransport{resp: logResp(200)},
+		Logger: logger,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/path", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+
+	resp, err := lt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "request") {
+		t.Errorf("expected 'request' in log, got: %s", out)
+	}
+	if !strings.Contains(out, "response") {
+		t.Errorf("expected 'response' in log, got: %s", out)
+	}
+	if !strings.Contains(out, "200") {
+		t.Errorf("expected status code in log, got: %s", out)
+	}
+}
+
+func TestLoggingTransport_RedactsAuthorizationHeader(t *testing.T) {
+	logger, buf := newLogLogger()
+	lt := &LoggingTransport{
+		Base:   &loggingMockTransport{resp: logResp(200)},
+		Logger: logger,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set("Authorization", "Bearer super-secret-token-12345")
+
+	lt.RoundTrip(req) //nolint:errcheck
+
+	out := buf.String()
+	if strings.Contains(out, "super-secret-token-12345") {
+		t.Errorf("secret token must not appear in logs, got: %s", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in logs, got: %s", out)
+	}
+	if !strings.Contains(out, "Bearer") {
+		t.Errorf("expected scheme prefix 'Bearer' preserved, got: %s", out)
+	}
+}
+
+func TestLoggingTransport_LogsTransportError(t *testing.T) {
+	logger, buf := newLogLogger()
+	lt := &LoggingTransport{
+		Base:   &loggingMockTransport{err: io.ErrUnexpectedEOF},
+		Logger: logger,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	_, err := lt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "error") {
+		t.Errorf("expected 'error' in log, got: %s", out)
+	}
+}
+
+func TestLoggingTransport_NoAuthHeader(t *testing.T) {
+	logger, buf := newLogLogger()
+	lt := &LoggingTransport{
+		Base:   &loggingMockTransport{resp: logResp(201)},
+		Logger: logger,
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com", nil)
+	resp, err := lt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 201 {
+		t.Errorf("expected 201, got %d", resp.StatusCode)
+	}
+	out := buf.String()
+	if strings.Contains(out, "[REDACTED]") {
+		t.Errorf("expected no [REDACTED] when no auth header, got: %s", out)
+	}
+}
+
+func TestRedactAuth(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Bearer abc123", "Bearer [REDACTED]"},
+		{"Token xyz", "Token [REDACTED]"},
+		{"Basic dXNlcjpwYXNz", "Basic [REDACTED]"},
+		{"plain-token", "[REDACTED]"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := redactAuth(tc.input)
+		if got != tc.want {
+			t.Errorf("redactAuth(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces the global `log` package with Go's `log/slog` (available since Go 1.21)
- Adds `--log-level` (debug|info|warn|error, default: info) and `--log-format` (text|json, default: text)
- Adds Authorization header redaction in debug HTTP logs — tokens never appear unredacted
- Closes #181

## Details

**New flags:**
- `--log-level debug|info|warn|error` — independent verbosity control
- `--log-format text|json` — `json` produces newline-delimited JSON records to stderr
- `--debug` remains fully working as an alias for `--log-level debug` (back-compat)

**Logging architecture:**
- `internal/logging/` — initialises a package-level `*slog.Logger` via `logging.Setup(level, format)`, always writes to stderr
- `internal/middleware/LoggingTransport` — `http.RoundTripper` injected when log level is `debug`, logs method + URL + redacted Authorization + response status via slog
- `WithCustomHTTPClient` injection replaces the former `WithNativeLogger()` + `log.SetOutput/SetFlags/SetPrefix` global side-effects

**Redaction:** `Authorization: Bearer <token>` → `Authorization: Bearer [REDACTED]` before any log output.

Files changed:
- `internal/logging/logger.go` + `logger_test.go`
- `internal/middleware/logging.go` + `logging_test.go`
- `internal/client/client.go` — `LogLevel`/`LogFormat` in `Params` + cache key, logging transport injection
- `cmd/root.go` — `--log-level` and `--log-format` persistent flags
- `cmd/client.go` — `resolveLogLevel()`, `logging.Setup()` call, passes new params

## Test plan

- [ ] `go test ./...` passes
- [ ] `acloud --log-level debug network vpc list` logs HTTP requests with `[REDACTED]` Authorization
- [ ] `acloud --debug network vpc list` behaves identically to `--log-level debug`
- [ ] `acloud --log-format json --log-level debug network vpc list` logs to stderr as JSON
- [ ] `acloud --log-level debug network vpc list --output json` — stdout is clean JSON, debug goes to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
