### PR TITLE
fix: update broken context-management anchor links

### DIFF
--- a/docs/website/docs/resources/database.md
+++ b/docs/website/docs/resources/database.md
@@ -169,7 +169,7 @@ Database resources are scoped to a project. You can either:
    acloud database dbaas list  # Uses context project ID
    ```
 
-See [Installation - Context Management](../installation.md#context-management) for more information.
+See [Configuration - Context Management](../configuration.md#context-management) for more information.
 
 ## Next Steps
 

--- a/docs/website/docs/resources/network.md
+++ b/docs/website/docs/resources/network.md
@@ -293,4 +293,4 @@ acloud network vpc list --project-id <project-id>
 - [VPC Peering Route Documentation](network/vpcpeeringroute.md)
 - [VPN Tunnel Documentation](network/vpntunnel.md)
 - [VPN Tunnel Route Documentation](network/vpnroute.md)
-- [Context Management](../installation.md#context-management)
+- [Context Management](../configuration.md#context-management)

--- a/docs/website/docs/resources/network/elasticip.md
+++ b/docs/website/docs/resources/network/elasticip.md
@@ -465,4 +465,4 @@ acloud network elasticip delete <eip-id> --yes
 
 - [VPC](vpc.md) - Network isolation for Elastic IPs
 - [Load Balancer](loadbalancer.md) - Use Elastic IPs with load balancers
-- [Context Management](../../installation.md#context-management) - Manage project contexts
+- [Context Management](../../configuration.md#context-management) - Manage project contexts

--- a/docs/website/docs/resources/network/loadbalancer.md
+++ b/docs/website/docs/resources/network/loadbalancer.md
@@ -365,7 +365,7 @@ The get command shows detailed information:
 
 - [VPC](vpc.md) - View VPC associated with Load Balancers
 - [Elastic IP](elasticip.md) - View Elastic IPs used by Load Balancers
-- [Context Management](../../installation.md#context-management) - Manage project contexts
+- [Context Management](../../configuration.md#context-management) - Manage project contexts
 
 ## Future Enhancements
 

--- a/docs/website/docs/resources/network/vpc.md
+++ b/docs/website/docs/resources/network/vpc.md
@@ -392,4 +392,4 @@ acloud network vpc update <vpc-id> --tags tag1,tag2
 
 - [Elastic IP](elasticip.md) - Assign public IPs within VPCs
 - [Load Balancer](loadbalancer.md) - Distribute traffic within VPCs
-- [Context Management](../../installation.md#context-management) - Manage project contexts
+- [Context Management](../../configuration.md#context-management) - Manage project contexts

--- a/docs/website/docs/resources/schedule.md
+++ b/docs/website/docs/resources/schedule.md
@@ -154,7 +154,7 @@ Scheduled jobs are scoped to a project. You can either:
    acloud schedule job list  # Uses context project ID
    ```
 
-See [Installation - Context Management](../installation.md#context-management) for more information.
+See [Configuration - Context Management](../configuration.md#context-management) for more information.
 
 ## Next Steps
 

--- a/docs/website/docs/resources/security.md
+++ b/docs/website/docs/resources/security.md
@@ -128,7 +128,7 @@ Security resources are scoped to a project. You can either:
    acloud security kms list  # Uses context project ID
    ```
 
-See [Installation - Context Management](../installation.md#context-management) for more information.
+See [Configuration - Context Management](../configuration.md#context-management) for more information.
 
 ## Next Steps
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database.md
@@ -169,7 +169,7 @@ Le risorse database sono limitate a un progetto. Puoi:
    acloud database dbaas list  # Usa l'ID progetto del contesto
    ```
 
-Vedi [Installazione - Gestione Contesto](../installation.md#context-management) per maggiori informazioni.
+Vedi [Configurazione - Gestione Contesto](../configuration.md#context-management) per maggiori informazioni.
 
 ## Prossimi Passi
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/elasticip.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/elasticip.md
@@ -465,4 +465,4 @@ acloud network elasticip delete <eip-id> --yes
 
 - [VPC](vpc.md) - Isolamento di rete per Elastic IP
 - [Load Balancer](loadbalancer.md) - Usa Elastic IP con load balancer
-- [Gestione Contesto](../../installation.md#context-management) - Gestisci contesti progetto
+- [Gestione Contesto](../../configuration.md#context-management) - Gestisci contesti progetto

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/loadbalancer.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/loadbalancer.md
@@ -183,4 +183,4 @@ La CLI fornisce accesso in sola lettura per monitoraggio e riferimento.
 
 - [VPC](vpc.md) - Visualizza VPC associato ai Load Balancer
 - [Elastic IP](elasticip.md) - Visualizza Elastic IP usati dai Load Balancer
-- [Gestione Contesto](../../installation.md#context-management) - Gestisci contesti progetto
+- [Gestione Contesto](../../configuration.md#context-management) - Gestisci contesti progetto

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpc.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpc.md
@@ -392,4 +392,4 @@ acloud network vpc update <vpc-id> --tags tag1,tag2
 
 - [Elastic IP](elasticip.md) - Assegna IP pubblici all'interno dei VPC
 - [Load Balancer](loadbalancer.md) - Distribuisci il traffico all'interno dei VPC
-- [Gestione Contesto](../../installation.md#context-management) - Gestisci contesti progetto
+- [Gestione Contesto](../../configuration.md#context-management) - Gestisci contesti progetto

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/schedule.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/schedule.md
@@ -154,7 +154,7 @@ I job pianificati sono limitati a un progetto. Puoi:
    acloud schedule job list  # Usa l'ID progetto del contesto
    ```
 
-Vedi [Installazione - Gestione Contesto](../installation.md#context-management) per maggiori informazioni.
+Vedi [Configurazione - Gestione Contesto](../configuration.md#context-management) per maggiori informazioni.
 
 ## Prossimi Passi
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/security.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/security.md
@@ -128,7 +128,7 @@ Le risorse di sicurezza sono limitate a un progetto. Puoi:
    acloud security kms list  # Usa l'ID progetto del contesto
    ```
 
-Vedi [Installazione - Gestione Contesto](../installation.md#context-management) per maggiori informazioni.
+Vedi [Configurazione - Gestione Contesto](../configuration.md#context-management) per maggiori informazioni.
 
 ## Prossimi Passi
 


### PR DESCRIPTION
Resources pages (network, database, schedule, security, elasticip, loadbalancer, vpc) linked to installation.md#context-management, which no longer exists after the section was moved to configuration.md in #219. This fixes the Docusaurus broken-anchor build error that caused the deploy-docs pipeline to fail.

Fixes 13 files (EN + IT).

Generated with Claude Code