### PR TITLE
fix: repair broken links in old versioned Italian docs and harden sync script

### DIFF
--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/examples.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/examples.md
@@ -11,7 +11,5 @@ Questa sezione fornisce scenari pratici e guide passo-passo per l'utilizzo della
 - [Uso Base](examples/basic-usage)
 - [CloudServer](examples/cloudserver)
 - [Kubernetes](examples/kubernetes)
-- [Database (DBaaS)](examples/database)
-- [Container Registry](examples/containerregistry)
 
 Scegli uno scenario per iniziare.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/installation.md
@@ -222,8 +222,6 @@ rm -rf ~/.config/acloud
 
 ## Prossimi Passi
 
-- [Configura l'autenticazione](authentication.md) — Imposta le credenziali API e gestisci i profili
-- [Esplora le opzioni di configurazione](configuration.md) — Gestione del contesto, formati di output e altro
 - [Risorse](resources.md) — Esplora i tipi di risorse disponibili
 
 ## Risoluzione dei Problemi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/resources/security.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/resources/security.md
@@ -26,47 +26,6 @@ acloud security kms update <kms-id> --name "updated-name" --tags "production"
 acloud security kms delete <kms-id>
 ```
 
-### [Chiavi Crittografiche](security/key.md)
-
-Le chiavi crittografiche sono annidate in un'istanza KMS e forniscono materiale di cifratura AES o RSA.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutte le chiavi in un'istanza KMS
-acloud security key list --kms-id <kms-id>
-
-# Ottieni i dettagli di una chiave
-acloud security key get <key-id> --kms-id <kms-id>
-
-# Crea una chiave
-acloud security key create --kms-id <kms-id> --name "my-key" --algorithm "Aes"
-
-# Elimina una chiave
-acloud security key delete <key-id> --kms-id <kms-id>
-```
-
-### [Servizi KMIP](security/kmip.md)
-
-I servizi KMIP sono annidati in un'istanza KMS ed espongono un endpoint KMIP per l'autenticazione client basata su certificati.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutti i servizi KMIP in un'istanza KMS
-acloud security kmip list --kms-id <kms-id>
-
-# Ottieni i dettagli di un servizio KMIP
-acloud security kmip get <kmip-id> --kms-id <kms-id>
-
-# Crea un servizio KMIP (e attendi il certificato)
-acloud security kmip create --kms-id <kms-id> --name "my-kmip" --wait
-
-# Scarica certificato e chiave privata (PEM)
-acloud security kmip download <kmip-id> --kms-id <kms-id>
-
-# Elimina un servizio KMIP
-acloud security kmip delete <kmip-id> --kms-id <kms-id>
-```
-
 ## Struttura dei Comandi
 
 Tutti i comandi di sicurezza seguono questa struttura:

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/examples.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/examples.md
@@ -11,7 +11,5 @@ Questa sezione fornisce scenari pratici e guide passo-passo per l'utilizzo della
 - [Uso Base](examples/basic-usage)
 - [CloudServer](examples/cloudserver)
 - [Kubernetes](examples/kubernetes)
-- [Database (DBaaS)](examples/database)
-- [Container Registry](examples/containerregistry)
 
 Scegli uno scenario per iniziare.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/installation.md
@@ -222,8 +222,6 @@ rm -rf ~/.config/acloud
 
 ## Prossimi Passi
 
-- [Configura l'autenticazione](authentication.md) — Imposta le credenziali API e gestisci i profili
-- [Esplora le opzioni di configurazione](configuration.md) — Gestione del contesto, formati di output e altro
 - [Risorse](resources.md) — Esplora i tipi di risorse disponibili
 
 ## Risoluzione dei Problemi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/resources/security.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/resources/security.md
@@ -26,47 +26,6 @@ acloud security kms update <kms-id> --name "updated-name" --tags "production"
 acloud security kms delete <kms-id>
 ```
 
-### [Chiavi Crittografiche](security/key.md)
-
-Le chiavi crittografiche sono annidate in un'istanza KMS e forniscono materiale di cifratura AES o RSA.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutte le chiavi in un'istanza KMS
-acloud security key list --kms-id <kms-id>
-
-# Ottieni i dettagli di una chiave
-acloud security key get <key-id> --kms-id <kms-id>
-
-# Crea una chiave
-acloud security key create --kms-id <kms-id> --name "my-key" --algorithm "Aes"
-
-# Elimina una chiave
-acloud security key delete <key-id> --kms-id <kms-id>
-```
-
-### [Servizi KMIP](security/kmip.md)
-
-I servizi KMIP sono annidati in un'istanza KMS ed espongono un endpoint KMIP per l'autenticazione client basata su certificati.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutti i servizi KMIP in un'istanza KMS
-acloud security kmip list --kms-id <kms-id>
-
-# Ottieni i dettagli di un servizio KMIP
-acloud security kmip get <kmip-id> --kms-id <kms-id>
-
-# Crea un servizio KMIP (e attendi il certificato)
-acloud security kmip create --kms-id <kms-id> --name "my-kmip" --wait
-
-# Scarica certificato e chiave privata (PEM)
-acloud security kmip download <kmip-id> --kms-id <kms-id>
-
-# Elimina un servizio KMIP
-acloud security kmip delete <kmip-id> --kms-id <kms-id>
-```
-
 ## Struttura dei Comandi
 
 Tutti i comandi di sicurezza seguono questa struttura:

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/examples.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/examples.md
@@ -11,7 +11,5 @@ Questa sezione fornisce scenari pratici e guide passo-passo per l'utilizzo della
 - [Uso Base](examples/basic-usage)
 - [CloudServer](examples/cloudserver)
 - [Kubernetes](examples/kubernetes)
-- [Database (DBaaS)](examples/database)
-- [Container Registry](examples/containerregistry)
 
 Scegli uno scenario per iniziare.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/installation.md
@@ -222,8 +222,6 @@ rm -rf ~/.config/acloud
 
 ## Prossimi Passi
 
-- [Configura l'autenticazione](authentication.md) — Imposta le credenziali API e gestisci i profili
-- [Esplora le opzioni di configurazione](configuration.md) — Gestione del contesto, formati di output e altro
 - [Risorse](resources.md) — Esplora i tipi di risorse disponibili
 
 ## Risoluzione dei Problemi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/resources/security.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/resources/security.md
@@ -26,47 +26,6 @@ acloud security kms update <kms-id> --name "updated-name" --tags "production"
 acloud security kms delete <kms-id>
 ```
 
-### [Chiavi Crittografiche](security/key.md)
-
-Le chiavi crittografiche sono annidate in un'istanza KMS e forniscono materiale di cifratura AES o RSA.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutte le chiavi in un'istanza KMS
-acloud security key list --kms-id <kms-id>
-
-# Ottieni i dettagli di una chiave
-acloud security key get <key-id> --kms-id <kms-id>
-
-# Crea una chiave
-acloud security key create --kms-id <kms-id> --name "my-key" --algorithm "Aes"
-
-# Elimina una chiave
-acloud security key delete <key-id> --kms-id <kms-id>
-```
-
-### [Servizi KMIP](security/kmip.md)
-
-I servizi KMIP sono annidati in un'istanza KMS ed espongono un endpoint KMIP per l'autenticazione client basata su certificati.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutti i servizi KMIP in un'istanza KMS
-acloud security kmip list --kms-id <kms-id>
-
-# Ottieni i dettagli di un servizio KMIP
-acloud security kmip get <kmip-id> --kms-id <kms-id>
-
-# Crea un servizio KMIP (e attendi il certificato)
-acloud security kmip create --kms-id <kms-id> --name "my-kmip" --wait
-
-# Scarica certificato e chiave privata (PEM)
-acloud security kmip download <kmip-id> --kms-id <kms-id>
-
-# Elimina un servizio KMIP
-acloud security kmip delete <kmip-id> --kms-id <kms-id>
-```
-
 ## Struttura dei Comandi
 
 Tutti i comandi di sicurezza seguono questa struttura:

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/examples.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/examples.md
@@ -11,7 +11,5 @@ Questa sezione fornisce scenari pratici e guide passo-passo per l'utilizzo della
 - [Uso Base](examples/basic-usage)
 - [CloudServer](examples/cloudserver)
 - [Kubernetes](examples/kubernetes)
-- [Database (DBaaS)](examples/database)
-- [Container Registry](examples/containerregistry)
 
 Scegli uno scenario per iniziare.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/installation.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/installation.md
@@ -222,8 +222,6 @@ rm -rf ~/.config/acloud
 
 ## Prossimi Passi
 
-- [Configura l'autenticazione](authentication.md) — Imposta le credenziali API e gestisci i profili
-- [Esplora le opzioni di configurazione](configuration.md) — Gestione del contesto, formati di output e altro
 - [Risorse](resources.md) — Esplora i tipi di risorse disponibili
 
 ## Risoluzione dei Problemi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/resources/security.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/resources/security.md
@@ -26,47 +26,6 @@ acloud security kms update <kms-id> --name "updated-name" --tags "production"
 acloud security kms delete <kms-id>
 ```
 
-### [Chiavi Crittografiche](security/key.md)
-
-Le chiavi crittografiche sono annidate in un'istanza KMS e forniscono materiale di cifratura AES o RSA.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutte le chiavi in un'istanza KMS
-acloud security key list --kms-id <kms-id>
-
-# Ottieni i dettagli di una chiave
-acloud security key get <key-id> --kms-id <kms-id>
-
-# Crea una chiave
-acloud security key create --kms-id <kms-id> --name "my-key" --algorithm "Aes"
-
-# Elimina una chiave
-acloud security key delete <key-id> --kms-id <kms-id>
-```
-
-### [Servizi KMIP](security/kmip.md)
-
-I servizi KMIP sono annidati in un'istanza KMS ed espongono un endpoint KMIP per l'autenticazione client basata su certificati.
-
-**Comandi Rapidi:**
-```bash
-# Elenca tutti i servizi KMIP in un'istanza KMS
-acloud security kmip list --kms-id <kms-id>
-
-# Ottieni i dettagli di un servizio KMIP
-acloud security kmip get <kmip-id> --kms-id <kms-id>
-
-# Crea un servizio KMIP (e attendi il certificato)
-acloud security kmip create --kms-id <kms-id> --name "my-kmip" --wait
-
-# Scarica certificato e chiave privata (PEM)
-acloud security kmip download <kmip-id> --kms-id <kms-id>
-
-# Elimina un servizio KMIP
-acloud security kmip delete <kmip-id> --kms-id <kms-id>
-```
-
 ## Struttura dei Comandi
 
 Tutti i comandi di sicurezza seguono questa struttura:

--- a/docs/website/scripts/sync-version-translations.js
+++ b/docs/website/scripts/sync-version-translations.js
@@ -86,10 +86,14 @@ versions.forEach(version => {
       fs.mkdirSync(destDir, { recursive: true });
     }
     
-    // For markdown files and other files, copy as-is
-    fs.copyFileSync(sourceFile, destFile);
+    // Only copy if the file does not already exist in this version directory.
+    // This preserves version-specific content and prevents current docs from
+    // overwriting old versions with links to pages that didn't exist yet.
+    if (!fs.existsSync(destFile)) {
+      fs.copyFileSync(sourceFile, destFile);
+    }
   });
-  console.log(`  version-${version}: ${sourceFiles.length} files synced`);
+  console.log(`  version-${version}: synced (new files only, existing files preserved)`);
   
   // Copy and update current.json if it exists (it's in the parent directory, not in current/)
   // Docusaurus expects the JSON file at the same level as the version directory, not inside it


### PR DESCRIPTION
The sync-version-translations.js script was blindly overwriting all existing version directories with the current Italian i18n content. After PR #219 restructured the docs, the sync propagated links to pages that only exist in 0.5.0+ into versions 0.1.9-0.4.0, causing the docs build to fail with broken links.

**Fixes applied to versions 0.1.9 / 0.2.0 / 0.3.0 / 0.4.0:**
- examples.md: remove links to examples/database and examples/containerregistry
- installation.md: remove links to authentication.md and configuration.md
- resources/security.md: remove Chiavi Crittografiche / Servizi KMIP sections, fix context-management link

**Sync script hardened:** now skips copying a file if it already exists in the target version directory, so old versioned content is never overwritten on future release runs.

Generated with Claude Code