### PR TITLE
fix: add profile use command to persist active profile selection

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -34,7 +34,8 @@ type configFile struct {
 // profiles. Detection: if the YAML has a top-level "profiles" mapping the file
 // is in multi-profile format; otherwise it is treated as single-profile (#180).
 type multiProfileConfigFile struct {
-	Profiles map[string]configFile `yaml:"profiles"`
+	ActiveProfile string                `yaml:"activeProfile,omitempty"`
+	Profiles      map[string]configFile `yaml:"profiles"`
 }
 
 type configShowDisplay struct {
@@ -81,6 +82,7 @@ func init() {
 	configProfileCmd.AddCommand(configProfileListCmd)
 	configProfileCmd.AddCommand(configProfileSetCmd)
 	configProfileCmd.AddCommand(configProfileDeleteCmd)
+	configProfileCmd.AddCommand(configProfileUseCmd)
 
 	// Flags for config set command
 	configSetCmd.Flags().String("client-id", "", "Aruba Cloud API client ID (required)")
@@ -156,7 +158,7 @@ func migrateLegacyConfig() {
 // ─── Multi-profile support (#180) ────────────────────────────────────────────
 
 // getActiveProfile returns the profile name for the current invocation.
-// Priority: --profile persistent flag > ACLOUD_PROFILE env var > "default".
+// Priority: --profile flag > ACLOUD_PROFILE env var > activeProfile in config file > "default".
 func getActiveProfile() string {
 	if rootCmd != nil {
 		if p, _ := rootCmd.PersistentFlags().GetString("profile"); p != "" {
@@ -166,7 +168,54 @@ func getActiveProfile() string {
 	if p := os.Getenv("ACLOUD_PROFILE"); p != "" {
 		return p
 	}
+	if p := loadActiveProfileFromFile(); p != "" {
+		return p
+	}
 	return "default"
+}
+
+// loadActiveProfileFromFile reads the activeProfile field from the config file.
+// Returns empty string if the file is missing or has no activeProfile set.
+func loadActiveProfileFromFile() string {
+	configPath, err := GetConfigPath()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return ""
+	}
+	var mpf multiProfileConfigFile
+	if yaml.Unmarshal(data, &mpf) == nil {
+		return mpf.ActiveProfile
+	}
+	return ""
+}
+
+// setActiveProfile persists the given profile name as the active profile in the
+// config file. Flag (--profile) and env var (ACLOUD_PROFILE) still take precedence
+// at runtime.
+func setActiveProfile(name string) error {
+	configPath, err := GetConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), FilePermDirAll); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	var mpf multiProfileConfigFile
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = yaml.Unmarshal(data, &mpf)
+	}
+	if mpf.Profiles == nil {
+		mpf.Profiles = make(map[string]configFile)
+	}
+	mpf.ActiveProfile = name
+	data, err := yaml.Marshal(mpf)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, data, FilePermConfig)
 }
 
 // loadAllProfiles reads the config file and returns a map of all profiles.
@@ -195,7 +244,8 @@ func loadAllProfiles() (map[string]configFile, error) {
 	return map[string]configFile{"default": fileCfg}, nil
 }
 
-// saveAllProfiles writes all profiles to the config file in multi-profile format.
+// saveAllProfiles writes all profiles to the config file in multi-profile format,
+// preserving the activeProfile field if one was already stored.
 func saveAllProfiles(profiles map[string]configFile) error {
 	configPath, err := GetConfigPath()
 	if err != nil {
@@ -204,7 +254,14 @@ func saveAllProfiles(profiles map[string]configFile) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), FilePermDirAll); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
-	data, err := yaml.Marshal(multiProfileConfigFile{Profiles: profiles})
+	mpf := multiProfileConfigFile{Profiles: profiles}
+	if existing, err := os.ReadFile(configPath); err == nil {
+		var existingMpf multiProfileConfigFile
+		if yaml.Unmarshal(existing, &existingMpf) == nil {
+			mpf.ActiveProfile = existingMpf.ActiveProfile
+		}
+	}
+	data, err := yaml.Marshal(mpf)
 	if err != nil {
 		return err
 	}
@@ -583,6 +640,14 @@ var configProfileDeleteCmd = &cobra.Command{
 	RunE:  ConfigProfileDeleteRun,
 }
 
+var configProfileUseCmd = &cobra.Command{
+	Use:   "use <profile-name>",
+	Short: "Switch the active profile",
+	Long:  `Switch the active credential profile. The selection is persisted in the config file and overridden by --profile flag or ACLOUD_PROFILE env var.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  ConfigProfileUseRun,
+}
+
 // ConfigProfileListRun lists all profiles, marking the active one with *.
 func ConfigProfileListRun(_ *cobra.Command, _ []string) error {
 	profiles, err := loadAllProfiles()
@@ -679,5 +744,24 @@ func ConfigProfileDeleteRun(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("saving profiles: %w", err)
 	}
 	fmt.Printf("Profile %q deleted.\n", profileName)
+	return nil
+}
+
+// ConfigProfileUseRun switches the active profile persisted in the config file.
+func ConfigProfileUseRun(_ *cobra.Command, args []string) error {
+	profileName := args[0]
+
+	profiles, err := loadAllProfiles()
+	if err != nil {
+		return fmt.Errorf("loading profiles: %w", err)
+	}
+	if _, ok := profiles[profileName]; !ok {
+		return fmt.Errorf("profile %q not found. Run 'acloud config profile list' to see available profiles", profileName)
+	}
+
+	if err := setActiveProfile(profileName); err != nil {
+		return fmt.Errorf("switching profile: %w", err)
+	}
+	fmt.Printf("Switched to profile %q.\n", profileName)
 	return nil
 }

--- a/cmd/config_profile_test.go
+++ b/cmd/config_profile_test.go
@@ -10,6 +10,8 @@ import (
 // ─── getActiveProfile ─────────────────────────────────────────────────────────
 
 func TestGetActiveProfile_Default(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("ACLOUD_PROFILE", "")
 	resetCmdFlags(rootCmd)
 
@@ -37,6 +39,49 @@ func TestGetActiveProfile_FlagOverridesEnvVar(t *testing.T) {
 
 	if got := getActiveProfile(); got != "prod" {
 		t.Errorf("getActiveProfile() = %q, want %q (flag should override env)", got, "prod")
+	}
+}
+
+func TestGetActiveProfile_FromFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("ACLOUD_PROFILE", "")
+	resetCmdFlags(rootCmd)
+	t.Cleanup(func() { resetCmdFlags(rootCmd) })
+
+	if err := saveAllProfiles(map[string]configFile{
+		"default": {ClientID: "id-default", ClientSecret: "sec"},
+		"prod":    {ClientID: "id-prod", ClientSecret: "sec"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := setActiveProfile("prod"); err != nil {
+		t.Fatalf("setActiveProfile() error: %v", err)
+	}
+
+	if got := getActiveProfile(); got != "prod" {
+		t.Errorf("getActiveProfile() = %q, want %q (from file)", got, "prod")
+	}
+}
+
+func TestGetActiveProfile_EnvVarOverridesFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("ACLOUD_PROFILE", "staging")
+	resetCmdFlags(rootCmd)
+	t.Cleanup(func() { resetCmdFlags(rootCmd) })
+
+	if err := saveAllProfiles(map[string]configFile{
+		"prod": {ClientID: "id-prod", ClientSecret: "sec"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := setActiveProfile("prod"); err != nil {
+		t.Fatalf("setActiveProfile() error: %v", err)
+	}
+
+	if got := getActiveProfile(); got != "staging" {
+		t.Errorf("getActiveProfile() = %q, want %q (env var should override file)", got, "staging")
 	}
 }
 
@@ -403,6 +448,92 @@ func TestConfigProfileSet_WithBaseURL(t *testing.T) {
 		t.Errorf("TokenIssuerURL = %q", profiles["custom"].TokenIssuerURL)
 	}
 	resetCmdFlags(cmd)
+}
+
+func TestSaveAllProfiles_PreservesActiveProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := saveAllProfiles(map[string]configFile{
+		"default": {ClientID: "id-default", ClientSecret: "sec"},
+		"prod":    {ClientID: "id-prod", ClientSecret: "sec"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := setActiveProfile("prod"); err != nil {
+		t.Fatalf("setActiveProfile() error: %v", err)
+	}
+
+	// Save profiles again (simulates updating a profile's credentials).
+	if err := saveAllProfiles(map[string]configFile{
+		"default": {ClientID: "id-default", ClientSecret: "sec"},
+		"prod":    {ClientID: "id-prod-updated", ClientSecret: "sec"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// activeProfile must survive the second save.
+	if got := loadActiveProfileFromFile(); got != "prod" {
+		t.Errorf("activeProfile = %q after saveAllProfiles, want %q", got, "prod")
+	}
+}
+
+// ─── ConfigProfileUseRun ──────────────────────────────────────────────────────
+
+func TestConfigProfileUse_SwitchesProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("ACLOUD_PROFILE", "")
+	resetCmdFlags(rootCmd)
+	t.Cleanup(func() { resetCmdFlags(rootCmd) })
+
+	if err := saveAllProfiles(map[string]configFile{
+		"default": {ClientID: "id-default", ClientSecret: "sec"},
+		"prod":    {ClientID: "id-prod", ClientSecret: "sec"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(func() {
+		if err := ConfigProfileUseRun(nil, []string{"prod"}); err != nil {
+			t.Errorf("ConfigProfileUseRun() error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "prod") {
+		t.Errorf("expected profile name in output, got: %s", out)
+	}
+
+	if got := getActiveProfile(); got != "prod" {
+		t.Errorf("getActiveProfile() = %q after use, want %q", got, "prod")
+	}
+
+	// Verify LoadConfig returns the prod profile's credentials.
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+	if cfg.ClientID != "id-prod" {
+		t.Errorf("ClientID = %q, want id-prod after switching to prod", cfg.ClientID)
+	}
+}
+
+func TestConfigProfileUse_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := saveAllProfiles(map[string]configFile{
+		"default": {ClientID: "id", ClientSecret: "sec"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ConfigProfileUseRun(nil, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error when switching to nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should mention the profile name, got: %v", err)
+	}
 }
 
 // ─── loadAllProfiles edge cases ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds  to persist the active profile in 
- Adds  field to the config file format (preserved across credential updates)
-  priority chain:  flag >  env var > config file > 
- Fixes  to not clobber a previously stored 
- Improves test isolation for  (now uses a temp )

Closes #223

## Before / After

Before:


After:


## Test plan

- [ ]  — new  and  cases pass
- [ ]  — switches profile, rejects unknown profile
- [ ]  — active profile survives credential updates
- [ ] Full suite: [0;32mRunning tests (skipping client tests)...[0m  — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
