### PR TITLE
fix: error when config set is called with no values to update

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -62,7 +62,7 @@ var configCmd = &cobra.Command{
 var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set configuration values",
-	Long:  `Set configuration values for acloud. Pass clientId as a flag; clientSecret is read from ACLOUD_CLIENT_SECRET or prompted securely.`,
+	Long:  `Set or update acloud configuration values. Provide only the fields you want to change; existing values are preserved. clientSecret is read from ACLOUD_CLIENT_SECRET or prompted when not yet set.`,
 	RunE:  ConfigSetRun,
 }
 
@@ -85,7 +85,7 @@ func init() {
 	configProfileCmd.AddCommand(configProfileUseCmd)
 
 	// Flags for config set command
-	configSetCmd.Flags().String("client-id", "", "Aruba Cloud API client ID (required)")
+	configSetCmd.Flags().String("client-id", "", "Aruba Cloud API client ID")
 	configSetCmd.Flags().String("base-url", "", "Base URL for Aruba Cloud API (optional, default: https://api.arubacloud.com)")
 	configSetCmd.Flags().String("token-issuer-url", "", "Token issuer URL for authentication (optional, default: https://login.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token)")
 
@@ -445,16 +445,24 @@ func ConfigSet(_ context.Context, args ConfigSetArgs) error {
 		config = &Config{}
 	}
 
-	// If no client-id is available from either the existing config or the flag, fail.
-	if config.ClientID == "" && args.ClientID == "" {
-		return fmt.Errorf("--client-id is required")
-	}
-	// ACLOUD_CLIENT_SECRET is accepted for automation and takes precedence over prompt.
+	// Read the secret from env early so we can tell whether any update is incoming.
 	if args.ClientSecret == "" {
 		args.ClientSecret = os.Getenv("ACLOUD_CLIENT_SECRET")
 	}
 
-	// If no client-secret is available, prompt interactively.
+	// If nothing is being provided and the existing config is already complete,
+	// there is nothing to update — fail instead of silently re-saving identical values.
+	nothingProvided := args.ClientID == "" && args.ClientSecret == "" && args.BaseURL == "" && args.TokenIssuerURL == ""
+	if nothingProvided && config.ClientID != "" && config.ClientSecret != "" {
+		return fmt.Errorf("no configuration values provided. Use --client-id, --base-url, --token-issuer-url, or ACLOUD_CLIENT_SECRET to update")
+	}
+
+	// Need a clientId (from the existing config or the flag).
+	if config.ClientID == "" && args.ClientID == "" {
+		return fmt.Errorf("--client-id is required")
+	}
+
+	// If no client-secret is available yet, prompt interactively.
 	if config.ClientSecret == "" && args.ClientSecret == "" {
 		prompted, err := readSecret("Enter client secret: ")
 		if err != nil {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -624,6 +624,55 @@ func TestConfigSet_Operation_UsesEnvClientSecret(t *testing.T) {
 	}
 }
 
+func TestConfigSet_NoArgs_CompleteConfig_Errors(t *testing.T) {
+	defer withTempHome(t)()
+	os.Unsetenv("ACLOUD_CLIENT_ID")
+	os.Unsetenv("ACLOUD_CLIENT_SECRET")
+
+	// Pre-populate a complete config.
+	if err := SaveConfig(&Config{ClientID: "existing-id", ClientSecret: "existing-secret"}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	err := ConfigSet(context.Background(), ConfigSetArgs{})
+	if err == nil {
+		t.Fatal("expected error when no values provided and config is already complete")
+	}
+	if !strings.Contains(err.Error(), "no configuration values provided") {
+		t.Errorf("expected 'no configuration values provided' in error, got: %v", err)
+	}
+}
+
+func TestConfigSet_PartialUpdate_OnlyBaseURL(t *testing.T) {
+	defer withTempHome(t)()
+	os.Unsetenv("ACLOUD_CLIENT_ID")
+	os.Unsetenv("ACLOUD_CLIENT_SECRET")
+
+	if err := SaveConfig(&Config{ClientID: "existing-id", ClientSecret: "existing-secret"}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	// Update just the base URL — no need to re-supply clientId or clientSecret.
+	err := ConfigSet(context.Background(), ConfigSetArgs{BaseURL: "https://custom.api.example.com"})
+	if err != nil {
+		t.Fatalf("ConfigSet() error: %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if loaded.ClientID != "existing-id" {
+		t.Errorf("ClientID = %q, want existing-id (preserved)", loaded.ClientID)
+	}
+	if loaded.ClientSecret != "existing-secret" {
+		t.Errorf("ClientSecret should be preserved, got %q", loaded.ClientSecret)
+	}
+	if loaded.BaseURL != "https://custom.api.example.com" {
+		t.Errorf("BaseURL = %q, want https://custom.api.example.com", loaded.BaseURL)
+	}
+}
+
 func TestConfigSet_Operation_MissingClientSecret_NonInteractive(t *testing.T) {
 	defer withTempHome(t)()
 	os.Unsetenv("ACLOUD_CLIENT_SECRET")


### PR DESCRIPTION
## Summary

- `acloud config set` with no arguments and a complete existing config now fails with `"no configuration values provided"` instead of silently re-saving identical values
- Fixed `--client-id` flag description: removed misleading "(required)" label — the flag is only required when no client ID exists in the current config
- Updated `Long` command description to clarify partial-update semantics

Closes #225

## Behaviour change

Before:
```
$ acloud config set        # active profile already has clientId + clientSecret
Configuration updated successfully   ← wrong: nothing changed
```

After:
```
$ acloud config set
Error: no configuration values provided. Use --client-id, --base-url, --token-issuer-url, or ACLOUD_CLIENT_SECRET to update
```

Partial updates still work as expected:
```
$ acloud config set --base-url https://custom.api.example.com
Configuration updated successfully
  Base URL: https://custom.api.example.com
```

## Test plan

- [ ] `TestConfigSet_NoArgs_CompleteConfig_Errors` — new: errors when nothing provided and config is complete
- [ ] `TestConfigSet_PartialUpdate_OnlyBaseURL` — new: partial update (base-url only) preserves existing credentials
- [ ] `TestConfigSet_Operation_UpdatesExistingConfig` — existing: still passes (updates existing config with new base-url)
- [ ] Full suite: `make test-skip-client` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
