### PR TITLE
fix: prompt for client-secret when --client-id is updated

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -462,8 +462,9 @@ func ConfigSet(_ context.Context, args ConfigSetArgs) error {
 		return fmt.Errorf("--client-id is required")
 	}
 
-	// If no client-secret is available yet, prompt interactively.
-	if config.ClientSecret == "" && args.ClientSecret == "" {
+	// If no client-secret is available yet, or if the client-id is being
+	// replaced (the two are a credential pair), prompt for a new secret.
+	if args.ClientSecret == "" && (config.ClientSecret == "" || args.ClientID != "") {
 		prompted, err := readSecret("Enter client secret: ")
 		if err != nil {
 			return fmt.Errorf("client secret is required (set ACLOUD_CLIENT_SECRET or provide interactive input): %w", err)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -604,6 +604,54 @@ func TestConfigSet_Operation_UpdatesExistingConfig(t *testing.T) {
 	}
 }
 
+func TestConfigSet_Operation_UpdateClientID_RequiresNewSecret(t *testing.T) {
+	defer withTempHome(t)()
+	os.Unsetenv("ACLOUD_CLIENT_SECRET")
+
+	// Existing config has both credentials set.
+	if err := SaveConfig(&Config{ClientID: "old-id", ClientSecret: "old-secret"}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	// Updating only --client-id without providing a new secret must fail in
+	// non-interactive mode, because the old secret belongs to the old credential pair.
+	err := ConfigSet(context.Background(), ConfigSetArgs{ClientID: "new-id"})
+	if err == nil {
+		t.Fatal("expected error when updating client-id without a new secret in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "set ACLOUD_CLIENT_SECRET") {
+		t.Errorf("expected ACLOUD_CLIENT_SECRET guidance, got: %v", err)
+	}
+}
+
+func TestConfigSet_Operation_UpdateClientID_AcceptsNewSecretViaEnv(t *testing.T) {
+	defer withTempHome(t)()
+	origSecret := os.Getenv("ACLOUD_CLIENT_SECRET")
+	os.Setenv("ACLOUD_CLIENT_SECRET", "new-secret")
+	defer os.Setenv("ACLOUD_CLIENT_SECRET", origSecret)
+
+	// Existing config has both credentials set.
+	if err := SaveConfig(&Config{ClientID: "old-id", ClientSecret: "old-secret"}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	err := ConfigSet(context.Background(), ConfigSetArgs{ClientID: "new-id"})
+	if err != nil {
+		t.Fatalf("ConfigSet() error: %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if loaded.ClientID != "new-id" {
+		t.Errorf("ClientID = %q, want new-id", loaded.ClientID)
+	}
+	if loaded.ClientSecret != "new-secret" {
+		t.Errorf("ClientSecret = %q, want new-secret", loaded.ClientSecret)
+	}
+}
+
 func TestConfigSet_Operation_UsesEnvClientSecret(t *testing.T) {
 	defer withTempHome(t)()
 	origSecret := os.Getenv("ACLOUD_CLIENT_SECRET")


### PR DESCRIPTION
## Summary

-  now prompts for (or reads via ) a new client secret even when one is already stored in the config file
- The client-id and client-secret are a credential pair — rotating one requires the other to be supplied fresh
- Two new unit tests cover the regression case (non-interactive → must error) and the happy path (secret accepted via env var)

## Test plan

- [ ]  prompts  interactively
- [ ]  succeeds without a prompt
- [ ]  (no client-id change) still does **not** prompt for the secret when one already exists
- [ ] Unit tests:  — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)