### PR TITLE
fix: show default base URL in profile list when field is unset

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -677,7 +677,11 @@ func ConfigProfileListRun(_ *cobra.Command, _ []string) error {
 		if name == active {
 			marker = "* "
 		}
-		rows = append(rows, []string{marker + name, p.ClientID, p.BaseURL})
+		baseURL := p.BaseURL
+		if baseURL == "" {
+			baseURL = DefaultBaseURL
+		}
+		rows = append(rows, []string{marker + name, p.ClientID, baseURL})
 	}
 	PrintOutput(nil, headers, rows)
 	return nil

--- a/cmd/config_profile_test.go
+++ b/cmd/config_profile_test.go
@@ -266,6 +266,28 @@ func TestConfigProfileList_ShowsProfiles(t *testing.T) {
 	}
 }
 
+func TestConfigProfileList_ShowsDefaultBaseURL(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("ACLOUD_PROFILE", "default")
+	resetCmdFlags(rootCmd)
+	t.Cleanup(func() { resetCmdFlags(rootCmd) })
+
+	// Profile with no explicit BaseURL — the list should show the default.
+	if err := saveAllProfiles(map[string]configFile{
+		"default": {ClientID: "id-default", ClientSecret: "secret"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(func() {
+		_ = ConfigProfileListRun(nil, nil)
+	})
+	if !strings.Contains(out, DefaultBaseURL) {
+		t.Errorf("expected DefaultBaseURL %q in list output, got: %s", DefaultBaseURL, out)
+	}
+}
+
 func TestConfigProfileDelete(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
Profiles that rely on the implicit default show an empty BASE_URL column in Configure acloud with your Aruba Cloud API credentials (clientId and clientSecret).

Usage:
  acloud config [command]

Available Commands:
  set         Set configuration values
  show        Show current configuration

Flags:
  -h, --help   help for config

Global Flags:
  -d, --debug           Enable debug logging (WARNING: may expose credentials and tokens in HTTP headers)
  -o, --output string   Output format: table|std|standard, table-json|std-json, table-yaml|std-yaml, json, yaml (default "table")

Use "acloud config [command] --help" for more information about a command.. The fix falls back to DefaultBaseURL when the stored field is empty, matching the behaviour of Current configuration:
  Client ID: cmp-50b86017-38d3-42b6-b5fb-c4717064c17e
  Client Secret: ********
  Base URL: https://api.arubacloud.com (default)
  Token Issuer URL: https://mylogin.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token (default). A regression test is included.