### PR TITLE
docs: update auth/config docs and changelog for v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-19
+
+### Fixed
+
+- **Config**: `acloud config set --client-id <new>` now always collects a new
+  client-secret — via `ACLOUD_CLIENT_SECRET` or the interactive prompt — even
+  when a secret is already stored in the config file. The client-id and
+  client-secret are a matched credential pair; previously only the ID was
+  updated, leaving the config in an inconsistent state (closes #227).
+- **Config**: `acloud config profile list` now shows the effective base URL for
+  every profile. Profiles that rely on the implicit default (`https://api.arubacloud.com`)
+  were previously shown with a blank `BASE_URL` column (closes #228).
+
 ## [0.5.0] - 2026-06-18
 
 ### Added
@@ -249,7 +262,9 @@ is unchanged.
 - **E2e**: project `DELETE` failure now propagates correctly in the management
   suite (closes #128).
 
-[Unreleased]: https://github.com/Arubacloud/acloud-cli/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/Arubacloud/acloud-cli/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/Arubacloud/acloud-cli/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/Arubacloud/acloud-cli/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Arubacloud/acloud-cli/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Arubacloud/acloud-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Arubacloud/acloud-cli/compare/v0.1.9...v0.2.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,12 +109,12 @@ The Aruba Cloud CLI requires API credentials to authenticate with Aruba Cloud se
    # Enter client secret: (hidden input, does not appear in shell history)
    ```
 
-   Alternatively, pass both flags at once (suitable for CI/automation where shell history is not a concern):
+   For CI/automation, provide the secret via environment variable instead of the prompt:
    ```bash
-   acloud config set --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+   ACLOUD_CLIENT_SECRET=YOUR_CLIENT_SECRET acloud config set --client-id YOUR_CLIENT_ID
    ```
 
-   > **Security note**: Avoid passing `--client-secret` interactively — it will appear in your shell history. Omitting the flag causes the CLI to prompt for it with echo disabled, keeping the value out of history.
+   > **Security note**: `--client-secret` is intentionally not a supported flag — passing secrets on the command line exposes them in process lists and shell history. Use the interactive prompt or `ACLOUD_CLIENT_SECRET`.
 
 3. **Verify configuration**:
    ```bash
@@ -123,11 +123,13 @@ The Aruba Cloud CLI requires API credentials to authenticate with Aruba Cloud se
 
 ### Configuration File
 
-Credentials are stored in `~/.acloud.yaml` (file permissions `0600`):
+Credentials are stored in `~/.config/acloud/config.yaml` (XDG Base Directory, file permissions `0600`):
 
 ```yaml
-clientId: your-client-id
-clientSecret: your-client-secret
+profiles:
+  default:
+    clientId: your-client-id
+    clientSecret: your-client-secret
 ```
 
 **Security Note**: Keep your credentials secure. The configuration file contains sensitive information.

--- a/docs/website/docs/authentication.md
+++ b/docs/website/docs/authentication.md
@@ -125,19 +125,23 @@ If `baseUrl` and `tokenIssuerUrl` are not specified, the CLI uses these defaults
 
 ### Updating Configuration
 
-```bash
-# Update only the client secret
-ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config set --client-id YOUR_CLIENT_ID
+`acloud config set` merges changes onto the existing configuration; fields not provided are preserved.
 
-# Update only the base URL
+```bash
+# Rotate credentials — client-id and client-secret are a matched pair.
+# Changing --client-id always asks for a new secret (hidden prompt or ACLOUD_CLIENT_SECRET).
+acloud config set --client-id NEW_CLIENT_ID
+# Enter client secret: (hidden input)
+
+# Same, non-interactively via environment variable
+ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config set --client-id NEW_CLIENT_ID
+
+# Update only optional fields — credentials are untouched
 acloud config set --base-url "https://custom-api.example.com"
+acloud config set --token-issuer-url "https://custom-idp.example.com/token"
 ```
 
-**Note**: Both `clientId` and `clientSecret` must always be present in the configuration. If you're updating one, make sure the other is already set in config/environment. For interactive secret updates, run with `--client-id` and provide the secret when prompted:
-
-```bash
-acloud config set --client-id YOUR_CLIENT_ID   # prompted securely
-```
+**Note**: When `--client-id` is provided, the CLI always collects a new client-secret — either from `ACLOUD_CLIENT_SECRET` or via the interactive prompt. This ensures the stored credentials remain a matched pair. To update only `--base-url` or `--token-issuer-url` without touching credentials, omit `--client-id`.
 
 ## Multi-Profile Credential Management
 
@@ -161,9 +165,11 @@ ACLOUD_CLIENT_SECRET=YOUR_PROD_SECRET \
 You can update a single field of an existing profile without touching the other fields:
 
 ```bash
-# Rotate the client ID in the prod profile while keeping the existing secret
-acloud config profile set prod --client-id NEW_PROD_CLIENT_ID
+# Update only the base URL of the prod profile — credentials are preserved
+acloud config profile set prod --base-url "https://custom-api.example.com"
 ```
+
+> **Credential rotation**: to rotate the credentials of the default profile use `acloud config set --client-id NEW_ID` (always prompts for a new secret). For named profiles use `acloud config profile set <name> --client-id NEW_ID --client-secret NEW_SECRET` (or `ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config profile set <name> --client-id NEW_ID`).
 
 ### Selecting the Active Profile
 
@@ -198,10 +204,12 @@ Example output (active profile marked with `*`):
 
 ```
 PROFILE              CLIENT_ID                        BASE_URL
-* default            default-client-id
+* default            default-client-id                https://api.arubacloud.com
   prod               prod-client-id                   https://api.arubacloud.com
-  staging            staging-client-id
+  staging            staging-client-id                https://api.arubacloud.com
 ```
+
+Profiles that do not have an explicit `baseUrl` in the config file display the default (`https://api.arubacloud.com`).
 
 ### Deleting a Profile
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/authentication.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/authentication.md
@@ -125,19 +125,23 @@ Se `baseUrl` e `tokenIssuerUrl` non sono specificati, la CLI usa questi valori p
 
 ### Aggiornamento della Configurazione
 
-```bash
-# Aggiorna solo il client secret
-ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config set --client-id YOUR_CLIENT_ID
+`acloud config set` unisce le modifiche alla configurazione esistente; i campi non forniti vengono preservati.
 
-# Aggiorna solo il base URL
+```bash
+# Rinnova le credenziali — client-id e client-secret sono una coppia.
+# Cambiare --client-id richiede sempre un nuovo secret (prompt nascosto o ACLOUD_CLIENT_SECRET).
+acloud config set --client-id NEW_CLIENT_ID
+# Enter client secret: (input nascosto)
+
+# Lo stesso, in modo non interattivo tramite variabile d'ambiente
+ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config set --client-id NEW_CLIENT_ID
+
+# Aggiorna solo i campi opzionali — le credenziali non vengono toccate
 acloud config set --base-url "https://custom-api.example.com"
+acloud config set --token-issuer-url "https://custom-idp.example.com/token"
 ```
 
-**Nota**: Sia `clientId` che `clientSecret` devono sempre essere presenti nella configurazione. Se stai aggiornando uno, assicurati che l'altro sia già impostato in config/ambiente. Per aggiornamenti interattivi del secret, esegui con `--client-id` e fornisci il secret quando richiesto:
-
-```bash
-acloud config set --client-id YOUR_CLIENT_ID   # richiesto in modo sicuro
-```
+**Nota**: Quando viene fornito `--client-id`, la CLI raccoglie sempre un nuovo client-secret — da `ACLOUD_CLIENT_SECRET` o tramite il prompt interattivo. Questo garantisce che le credenziali memorizzate rimangano una coppia corrispondente. Per aggiornare solo `--base-url` o `--token-issuer-url` senza toccare le credenziali, ometti `--client-id`.
 
 ## Gestione dei Profili di Credenziali
 
@@ -161,9 +165,11 @@ ACLOUD_CLIENT_SECRET=YOUR_PROD_SECRET \
 Puoi aggiornare un singolo campo di un profilo esistente senza toccare gli altri:
 
 ```bash
-# Rinnova il client ID nel profilo prod mantenendo il secret esistente
-acloud config profile set prod --client-id NEW_PROD_CLIENT_ID
+# Aggiorna solo il base URL del profilo prod — le credenziali vengono preservate
+acloud config profile set prod --base-url "https://custom-api.example.com"
 ```
+
+> **Rinnovo delle credenziali**: per rinnovare le credenziali del profilo predefinito usa `acloud config set --client-id NEW_ID` (richiede sempre un nuovo secret). Per i profili con nome usa `acloud config profile set <nome> --client-id NEW_ID --client-secret NEW_SECRET` (o `ACLOUD_CLIENT_SECRET=NEW_SECRET acloud config profile set <nome> --client-id NEW_ID`).
 
 ### Selezionare il Profilo Attivo
 
@@ -198,10 +204,12 @@ Esempio di output (il profilo attivo è contrassegnato con `*`):
 
 ```
 PROFILE              CLIENT_ID                        BASE_URL
-* default            default-client-id
+* default            default-client-id                https://api.arubacloud.com
   prod               prod-client-id                   https://api.arubacloud.com
-  staging            staging-client-id
+  staging            staging-client-id                https://api.arubacloud.com
 ```
+
+I profili che non hanno un `baseUrl` esplicito nel file di configurazione mostrano il valore predefinito (`https://api.arubacloud.com`).
 
 ### Eliminare un Profilo
 


### PR DESCRIPTION
Updates documentation and changelog ahead of the 0.5.1 release (2026-06-19).

## Changes

**authentication.md (EN + IT)**
- Updating Configuration section: clarifies that  always requires a new client-secret (prompt or ) — they are a matched credential pair
- Profile list example output: shows  for profiles without an explicit , matching the fixed CLI behaviour
- Credential rotation callout: distinguishes  (default profile, always prompts for new secret) from  (named profiles, field-level updates)

**getting-started.md**
- Removes obsolete  flag reference (flag was removed in 0.3.0)
- Updates config file path from  to  (XDG path since 0.4.0)

**CHANGELOG.md**
- Adds  section documenting fixes #227 and #228
- Adds missing comparison links for 0.5.0 and 0.5.1