### PR TITLE
docs: add Cryptographic Keys and KMIP Services to resources index

### DIFF
--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -53,7 +53,9 @@ Manage scheduled jobs for automation.
 
 Manage security and encryption resources.
 
-- [KMS Keys](resources/security/kms.md) - Key Management System keys
+- [KMS Instances](resources/security/kms.md) - Key Management System instances
+- [Cryptographic Keys](resources/security/key.md) - AES/RSA keys nested inside a KMS instance
+- [KMIP Services](resources/security/kmip.md) - KMIP endpoints with certificate-based authentication
 
 ### [Compute Resources](resources/compute.md)
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -53,7 +53,9 @@ Gestisci job pianificati per l'automazione.
 
 Gestisci risorse di sicurezza e crittografia.
 
-- [Chiavi KMS](resources/security/kms.md) - Chiavi Key Management System
+- [Istanze KMS](resources/security/kms.md) - Istanze Key Management System
+- [Chiavi Crittografiche](resources/security/key.md) - Chiavi AES/RSA annidate in un'istanza KMS
+- [Servizi KMIP](resources/security/kmip.md) - Endpoint KMIP con autenticazione basata su certificati
 
 ### [Risorse Compute](resources/compute.md)
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.0/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.0/resources.md
@@ -53,7 +53,9 @@ Gestisci job pianificati per l'automazione.
 
 Gestisci risorse di sicurezza e crittografia.
 
-- [Chiavi KMS](resources/security/kms.md) - Chiavi Key Management System
+- [Istanze KMS](resources/security/kms.md) - Istanze Key Management System
+- [Chiavi Crittografiche](resources/security/key.md) - Chiavi AES/RSA annidate in un'istanza KMS
+- [Servizi KMIP](resources/security/kmip.md) - Endpoint KMIP con autenticazione basata su certificati
 
 ### [Risorse Compute](resources/compute.md)
 

--- a/docs/website/versioned_docs/version-0.5.0/resources.md
+++ b/docs/website/versioned_docs/version-0.5.0/resources.md
@@ -53,7 +53,9 @@ Manage scheduled jobs for automation.
 
 Manage security and encryption resources.
 
-- [KMS Keys](resources/security/kms.md) - Key Management System keys
+- [KMS Instances](resources/security/kms.md) - Key Management System instances
+- [Cryptographic Keys](resources/security/key.md) - AES/RSA keys nested inside a KMS instance
+- [KMIP Services](resources/security/kmip.md) - KMIP endpoints with certificate-based authentication
 
 ### [Compute Resources](resources/compute.md)
 


### PR DESCRIPTION
The Security section of resources.md (EN current, IT current, EN versioned 0.5.0, IT versioned 0.5.0) only listed KMS Instances, omitting Cryptographic Keys and KMIP Services which were implemented in #215 but not reflected in the resources index page.