### PR TITLE
docs: add key and kmip to Security sidebar navigation

### DIFF
--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -103,6 +103,8 @@ const sidebars = {
       items: [
         'resources/security',
         'resources/security/kms',
+        'resources/security/key',
+        'resources/security/kmip',
       ],
     },
     {

--- a/docs/website/versioned_sidebars/version-0.5.0-sidebars.json
+++ b/docs/website/versioned_sidebars/version-0.5.0-sidebars.json
@@ -87,7 +87,9 @@
       "label": "Security",
       "items": [
         "resources/security",
-        "resources/security/kms"
+        "resources/security/kms",
+        "resources/security/key",
+        "resources/security/kmip"
       ]
     },
     {


### PR DESCRIPTION
Cryptographic Keys and KMIP Services pages existed and were complete (added in #215) but were absent from the sidebar, making them unreachable through site navigation. Adds both entries to the current sidebar and the versioned 0.5.0 snapshot sidebar.