### PR TITLE
feat: auto-select context when only one is configured

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -250,7 +250,8 @@ Completion functions that run interactively may keep `context.Background()`.
 
 `GetProjectID(cmd)` in `cmd/root.go` resolves in order:
 1. `--project-id` flag value (if non-empty)
-2. `GetCurrentProjectID()` → reads `CurrentContext` from `~/.acloud-context.yaml`, returns its `ProjectID`
+2. `GetCurrentProjectID()` → reads `CurrentContext` from `~/.acloud-context.yaml`, returns its `ProjectID`;
+   if `CurrentContext` is unset but exactly one context exists, that context is auto-selected
 3. Returns error: `"project ID not specified. Use --project-id flag or set a context with 'acloud context use <name>'"`
 
 ---
@@ -293,6 +294,8 @@ type CtxInfo struct {
 
 **Command behaviours:**
 - `context set <name> --project-id <id>` — creates/updates a named context but does **not** switch to it automatically.
+  When only one context exists and `CurrentContext` is empty, `GetCurrentProjectID()` auto-selects it,
+  so `acloud context use` is not required in the single-context case.
 - `context use <name>` — validates the name exists, then sets `CurrentContext`.
 - `context delete <name>` — removes the context; clears `CurrentContext` if it was the active one.
 - `context list` — prints all contexts with `*` marking the current one.

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -105,7 +105,10 @@ func SaveContext(ctx *Context) error {
 	return os.WriteFile(contextFile, data, FilePermConfig)
 }
 
-// GetCurrentProjectID returns the project ID from the current context
+// GetCurrentProjectID returns the project ID from the current context.
+// When no current context is set but exactly one context exists, that context
+// is used automatically — so `acloud context set` is enough without a follow-up
+// `acloud context use`.
 func GetCurrentProjectID() (string, error) {
 	ctx, err := LoadContext()
 	if err != nil {
@@ -113,6 +116,11 @@ func GetCurrentProjectID() (string, error) {
 	}
 
 	if ctx.CurrentContext == "" {
+		if len(ctx.Contexts) == 1 {
+			for _, info := range ctx.Contexts {
+				return info.ProjectID, nil
+			}
+		}
 		return "", fmt.Errorf("no current context set")
 	}
 

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -175,7 +175,7 @@ func TestSaveContext_EmptyContext(t *testing.T) {
 	}
 }
 
-func TestGetCurrentProjectID_NoCurrentContext(t *testing.T) {
+func TestGetCurrentProjectID_NoCurrentContext_SingleContext(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	if originalHome == "" {
 		originalHome = os.Getenv("USERPROFILE")
@@ -199,9 +199,43 @@ func TestGetCurrentProjectID_NoCurrentContext(t *testing.T) {
 		t.Fatalf("SaveContext() error = %v", err)
 	}
 
+	// Single context with no CurrentContext set: auto-selected.
+	projectID, err := GetCurrentProjectID()
+	if err != nil {
+		t.Errorf("GetCurrentProjectID() should auto-select the only context, got error: %v", err)
+	}
+	if projectID != "test-project-id" {
+		t.Errorf("GetCurrentProjectID() = %v, want test-project-id", projectID)
+	}
+}
+
+func TestGetCurrentProjectID_NoCurrentContext_MultipleContexts(t *testing.T) {
+	originalHome := os.Getenv("HOME")
+	if originalHome == "" {
+		originalHome = os.Getenv("USERPROFILE")
+	}
+
+	tmpDir := t.TempDir()
+
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+
+	testContext := &Context{
+		Contexts: map[string]CtxInfo{
+			"ctx-a": {ProjectID: "pid-a"},
+			"ctx-b": {ProjectID: "pid-b"},
+		},
+	}
+
+	err := SaveContext(testContext)
+	if err != nil {
+		t.Fatalf("SaveContext() error = %v", err)
+	}
+
+	// Multiple contexts with no CurrentContext set: must still error.
 	projectID, err := GetCurrentProjectID()
 	if err == nil {
-		t.Error("GetCurrentProjectID() should return error when no current context is set")
+		t.Error("GetCurrentProjectID() should return error when no current context is set and multiple contexts exist")
 	}
 	if projectID != "" {
 		t.Errorf("GetCurrentProjectID() = %v, want empty string", projectID)

--- a/docs/website/docs/configuration.md
+++ b/docs/website/docs/configuration.md
@@ -21,9 +21,11 @@ Create a context with a project ID:
 acloud context set my-prod --project-id "66a10244f62b99c686572a9f"
 ```
 
+> **Single-context shortcut**: When only one context is configured, the CLI uses it automatically — you do not need to run `acloud context use` first. If you add a second context later, you will need to explicitly switch with `acloud context use <name>`.
+
 ### Using a Context
 
-Switch to a saved context:
+Switch to a saved context when you have more than one:
 
 ```bash
 acloud context use my-prod


### PR DESCRIPTION
## Summary

- `GetCurrentProjectID()` now auto-selects the only configured context when `CurrentContext` is unset, so `acloud context set` alone is enough — no follow-up `acloud context use` required
- When two or more contexts exist the existing behaviour is preserved: an explicit `acloud context use <name>` is required
- Tests updated: the single-context / no-current-context scenario now expects success; a new test covers the multi-context / no-current case
- Docs (`docs/website/docs/configuration.md`) and `ai/ARCHITECTURE.md` updated to document the behaviour

## Test plan

- [ ] `acloud context set my-ctx --project-id <id>` then `acloud network vpc list` works without `acloud context use`
- [ ] Adding a second context and running without `acloud context use` still returns an error
- [ ] Unit tests: `go test ./cmd/ -run TestGetCurrentProjectID` — all pass
- [ ] Full suite: `ACLOUD_TEST_SKIP_CLIENT=true go test ./cmd/` — no regressions

Closes #235 

Generated with [Claude Code](https://claude.com/claude-code)