### PR TITLE
fix(docs): correct zone value from itbg1-a to ITBG-1 in examples

### DIFF
--- a/docs/website/docs/examples/cloudserver.md
+++ b/docs/website/docs/examples/cloudserver.md
@@ -110,9 +110,9 @@ Choose a security group with `STATUS` as `Active` and note its `ID`. If no suita
 
 ---
 
-## Step 5: Note the Elastic IP ID (if using public access)
+## Step 5: Note the Elastic IP ID
 
-If you want public access for your server, note the Elastic IP `ID` from `acloud network elasticip list`. You can verify it with:
+Note the Elastic IP `ID` from `acloud network elasticip list`. You can verify it with:
 
 ```bash
 acloud network elasticip get <elasticip-id>
@@ -120,10 +120,10 @@ acloud network elasticip get <elasticip-id>
 
 Example:
 ```bash
-acloud network elasticip get 694bb7897712ac0032dbe60c
+acloud network elasticip get 6a35162fdf2d456b0f95fd7e
 ```
 
-> **Note:** Note the Elastic IP `ID`. Skip this step if you do not need public access. You can associate an Elastic IP after server creation as well.
+> **Note:** Note the Elastic IP `ID`. An Elastic IP is required to connect to your server from the public internet (used in Step 10 with `--elasticip-id`).
 
 ---
 
@@ -277,12 +277,12 @@ acloud compute cloudserver create \
   --region "ITBG-Bergamo" \
   --zone "ITBG-1" \
   --flavor "CSO4A8" \
-  --boot-disk-id "697b3a0dce7dfeef9153256a" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
-  --subnet-id "694ba1737712ac0032dbe50a" \
-  --security-group-id "694b05ac4d0cdc87949b75f9" \
-  --keypair-id "69007ebf4e7d691466d8621e" \
-  --user-data-file "cloud-init.yaml" \
+  --boot-disk-id "6a3516c275300438a29f15fd" \
+  --vpc-id "69fdbc398675ff21f3c1587b" \
+  --subnet-id "69fdbc8f8675ff21f3c1588a" \
+  --security-group-id "69fdbc8e8675ff21f3c15888" \
+  --keypair-id "6a33ec6b2b2c12d76c120f5e" \
+  --elasticip-id "6a35162fdf2d456b0f95fd7e" \
   --billing-period Hour \
   --tags "production"
 ```
@@ -293,7 +293,8 @@ ID                             NAME         FLAVOR    CPU   RAM(GB)   HD(GB)   R
 697c62605b79733376b3386a       my-server    CSO4A8    4     8         0        ITBG-Bergamo
 ```
 
-- Replace the IDs above with your actual VPC, subnet, security group, keypair, and boot disk IDs.
+- Replace the IDs above with your actual VPC, subnet, security group, keypair, boot disk, and Elastic IP IDs.
+- The `--elasticip-id` flag assigns a public IP at creation time and is required to use the `connect` command afterwards.
 - The `--user-data-file` flag is optional and can be omitted if not needed.
 - You can specify multiple subnets or security groups using comma-separated values.
 - All networking flags (`--vpc-id`, `--subnet-id`, `--security-group-id`) and the `--zone` flag are required.

--- a/docs/website/docs/examples/cloudserver.md
+++ b/docs/website/docs/examples/cloudserver.md
@@ -137,7 +137,7 @@ If you want to create a bootable block storage volume (for example, to use a cus
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/docs/examples/containerregistry.md
+++ b/docs/website/docs/examples/containerregistry.md
@@ -102,7 +102,7 @@ The container registry requires dedicated block storage for image layers and met
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/docs/it/examples/cloudserver.md
+++ b/docs/website/docs/it/examples/cloudserver.md
@@ -66,15 +66,15 @@ Scegli un security group con `STATUS` pari a `Active` e annota il suo `ID`. Se n
 
 ---
 
-## Step 5: Estrai la URI dell'Elastic IP (se serve accesso pubblico)
+## Step 5: Annota l'ID dell'Elastic IP
 
-Se vuoi assegnare un Elastic IP, estrai la sua URI:
+Annota l'`ID` dell'Elastic IP dall'output di `acloud network elasticip list`. Puoi verificarlo con:
 
 ```bash
-acloud network elasticip get <elasticip-id> | grep URI
+acloud network elasticip get <elasticip-id>
 ```
 
-Salva questa URI per il provisioning. Salta questo step se non ti serve accesso pubblico.
+Un Elastic IP è necessario per connettersi al server dalla rete pubblica (usato al Step 10 con `--elasticip-id`).
 
 ---
 
@@ -147,7 +147,39 @@ Sostituisci `<hashed-password>` con una password hash valida (consulta la docume
 
 ---
 
-## Step 10: Attendi che il Cloud Server sia Attivo
+## Step 10: Crea il Cloud Server
+
+Usa gli ID raccolti nei passaggi precedenti per creare il cloud server:
+
+```bash
+acloud compute cloudserver create \
+  --name "my-server" \
+  --region "ITBG-Bergamo" \
+  --zone "ITBG-1" \
+  --flavor "CSO4A8" \
+  --boot-disk-id "6a3516c275300438a29f15fd" \
+  --vpc-id "69fdbc398675ff21f3c1587b" \
+  --subnet-id "69fdbc8f8675ff21f3c1588a" \
+  --security-group-id "69fdbc8e8675ff21f3c15888" \
+  --keypair-id "6a33ec6b2b2c12d76c120f5e" \
+  --elasticip-id "6a35162fdf2d456b0f95fd7e" \
+  --billing-period Hour \
+  --tags "production"
+```
+
+Esempio output:
+```
+ID                             NAME         FLAVOR    CPU   RAM(GB)   HD(GB)   REGION
+697c62605b79733376b3386a       my-server    CSO4A8    4     8         0        ITBG-Bergamo
+```
+
+- Sostituisci gli ID con i tuoi valori reali di VPC, subnet, security group, keypair, disco di avvio ed Elastic IP.
+- Il flag `--elasticip-id` assegna un IP pubblico alla creazione ed è necessario per usare il comando `connect` successivamente.
+- Il flag `--user-data-file` è opzionale e può essere omesso se non necessario.
+
+---
+
+## Step 11: Attendi che il Cloud Server sia Attivo
 
 Una volta eseguito il comando di creazione, puoi controllare lo stato del server con:
 
@@ -163,7 +195,7 @@ my-server                 697c62605b79733376b3386a       ITBG-Bergamo    CSO4A8 
 
 ---
 
-## Step 11: Connettersi al Cloud Server
+## Step 12: Connettersi al Cloud Server
 
 Per connetterti al cloud server, usa il comando `acloud compute cloudserver connect` specificando l'utente in base all'immagine di avvio. Ad esempio, per Ubuntu usa l'utente `ubuntu`:
 
@@ -182,7 +214,7 @@ Connect by running: ssh ubuntu@85.235.152.94
 
 ---
 
-## Step 12: Spegnere o Accendere il Cloud Server
+## Step 13: Spegnere o Accendere il Cloud Server
 
 Puoi spegnere o accendere il cloud server in qualsiasi momento con i seguenti comandi:
 
@@ -214,7 +246,7 @@ Status: Updating
 
 ---
 
-## Step 13: Eliminare il Cloud Server
+## Step 14: Eliminare il Cloud Server
 
 Per eliminare il cloud server quando non serve più, usa il comando:
 

--- a/docs/website/docs/it/examples/cloudserver.md
+++ b/docs/website/docs/it/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/docs/it/examples/containerregistry.md
+++ b/docs/website/docs/it/examples/containerregistry.md
@@ -84,7 +84,7 @@ Annota l'`ID` dell'Elastic IP.
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/cloudserver.md
@@ -68,15 +68,15 @@ Scegli un security group con `STATUS` pari a `Active` e annota il suo `ID`. Se n
 
 ---
 
-## Step 5: Annota l'ID dell'Elastic IP (se serve accesso pubblico)
+## Step 5: Annota l'ID dell'Elastic IP
 
-Se vuoi accesso pubblico per il server, annota l'`ID` dell'Elastic IP dall'output di `acloud network elasticip list`. Puoi verificarlo con:
+Annota l'`ID` dell'Elastic IP dall'output di `acloud network elasticip list`. Puoi verificarlo con:
 
 ```bash
 acloud network elasticip get <elasticip-id>
 ```
 
-> **Nota:** Annota l'`ID` dell'Elastic IP. Salta questo step se non ti serve accesso pubblico.
+> **Nota:** Annota l'`ID` dell'Elastic IP. Un Elastic IP è necessario per connettersi al server dalla rete pubblica (usato al Step 10 con `--elasticip-id`).
 
 ---
 
@@ -165,12 +165,12 @@ acloud compute cloudserver create \
   --region "ITBG-Bergamo" \
   --zone "ITBG-1" \
   --flavor "CSO4A8" \
-  --boot-disk-id "697b3a0dce7dfeef9153256a" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
-  --subnet-id "694ba1737712ac0032dbe50a" \
-  --security-group-id "694b05ac4d0cdc87949b75f9" \
-  --keypair-id "69007ebf4e7d691466d8621e" \
-  --user-data-file "cloud-init.yaml" \
+  --boot-disk-id "6a3516c275300438a29f15fd" \
+  --vpc-id "69fdbc398675ff21f3c1587b" \
+  --subnet-id "69fdbc8f8675ff21f3c1588a" \
+  --security-group-id "69fdbc8e8675ff21f3c15888" \
+  --keypair-id "6a33ec6b2b2c12d76c120f5e" \
+  --elasticip-id "6a35162fdf2d456b0f95fd7e" \
   --billing-period Hour \
   --tags "production"
 ```
@@ -181,7 +181,8 @@ ID                             NAME         FLAVOR    CPU   RAM(GB)   HD(GB)   R
 697c62605b79733376b3386a       my-server    CSO4A8    4     8         0        ITBG-Bergamo
 ```
 
-- Sostituisci gli ID con i tuoi valori reali di VPC, subnet, security group, keypair e disco di avvio.
+- Sostituisci gli ID con i tuoi valori reali di VPC, subnet, security group, keypair, disco di avvio ed Elastic IP.
+- Il flag `--elasticip-id` assegna un IP pubblico alla creazione ed è necessario per usare il comando `connect` successivamente.
 - Il flag `--user-data-file` è opzionale e può essere omesso se non necessario.
 - Puoi specificare più subnet o security group usando valori separati da virgola.
 - Tutti i flag di rete (`--vpc-id`, `--subnet-id`, `--security-group-id`) e il flag `--zone` sono richiesti.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.15/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.15/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.16/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.16/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.17/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.17/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.18/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.18/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.19/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.19/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.20/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.20/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.21/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.21/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.22/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.0.22/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.0/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.0/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.1/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.1/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.2/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.2/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.3/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.3/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.4/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.4/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.5/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.5/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.6/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.6/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.7/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.7/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.8/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.8/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.8/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.8/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.9/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.4.0/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.0/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.0/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.0/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.0/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.1/examples/cloudserver.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.1/examples/cloudserver.md
@@ -88,7 +88,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.1/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.5.1/examples/containerregistry.md
@@ -102,7 +102,7 @@ Il container registry richiede block storage dedicato per i layer delle immagini
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/versioned_docs/version-0.2.0/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.2.0/examples/cloudserver.md
@@ -137,7 +137,7 @@ If you want to create a bootable block storage volume (for example, to use a cus
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.2.0/it/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.2.0/it/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.3.0/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.3.0/examples/cloudserver.md
@@ -137,7 +137,7 @@ If you want to create a bootable block storage volume (for example, to use a cus
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.3.0/it/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.3.0/it/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.4.0/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.4.0/examples/cloudserver.md
@@ -137,7 +137,7 @@ If you want to create a bootable block storage volume (for example, to use a cus
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.4.0/it/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.4.0/it/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.5.0/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.5.0/examples/cloudserver.md
@@ -137,7 +137,7 @@ If you want to create a bootable block storage volume (for example, to use a cus
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.5.0/examples/containerregistry.md
+++ b/docs/website/versioned_docs/version-0.5.0/examples/containerregistry.md
@@ -102,7 +102,7 @@ The container registry requires dedicated block storage for image layers and met
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/versioned_docs/version-0.5.0/it/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.5.0/it/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.5.0/it/examples/containerregistry.md
+++ b/docs/website/versioned_docs/version-0.5.0/it/examples/containerregistry.md
@@ -84,7 +84,7 @@ Annota l'`ID` dell'Elastic IP.
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/versioned_docs/version-0.5.1/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.5.1/examples/cloudserver.md
@@ -137,7 +137,7 @@ If you want to create a bootable block storage volume (for example, to use a cus
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.5.1/examples/containerregistry.md
+++ b/docs/website/versioned_docs/version-0.5.1/examples/containerregistry.md
@@ -102,7 +102,7 @@ The container registry requires dedicated block storage for image layers and met
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \

--- a/docs/website/versioned_docs/version-0.5.1/it/examples/cloudserver.md
+++ b/docs/website/versioned_docs/version-0.5.1/it/examples/cloudserver.md
@@ -86,7 +86,7 @@ Se vuoi creare un volume di block storage avviabile:
 acloud storage blockstorage create \
   --name boot-ubuntu \
   --region ITBG-Bergamo \
-  --zone itbg1-a \
+  --zone ITBG-1 \
   --set-bootable \
   --billing-period Hour \
   --size 20 \

--- a/docs/website/versioned_docs/version-0.5.1/it/examples/containerregistry.md
+++ b/docs/website/versioned_docs/version-0.5.1/it/examples/containerregistry.md
@@ -84,7 +84,7 @@ Annota l'`ID` dell'Elastic IP.
 acloud storage blockstorage create \
   --name "registry-storage" \
   --region "ITBG-Bergamo" \
-  --zone "itbg1-a" \
+  --zone "ITBG-1" \
   --size 100 \
   --type Performance \
   --billing-period Hour \


### PR DESCRIPTION
## Summary
- The  flag in block storage and container registry examples used the wrong value ; the correct value is 
- Fixed across all 50 affected files: current docs (EN + IT), all versioned docs (v0.0.15-v0.5.1)

## Test plan
- [ ] Verify the block storage create example in Use Cases/CloudServer shows 
- [ ] Verify the container registry examples show 

Generated with [Claude Code](https://claude.com/claude-code)