### PR TITLE
fix(completion): complete parent-ID slots for nested network resources

### DIFF
--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -772,3 +772,278 @@ func TestCompleteKaaSID_APIError(t *testing.T) {
 		t.Errorf("expected nil completions on API error, got %v", comps)
 	}
 }
+
+// ─── completeSubnetID ────────────────────────────────────────────────────────
+
+func TestCompleteSubnetID_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSubnetID(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs from delegation, got none")
+	}
+}
+
+func TestCompleteSubnetID_NoArgs_NoProjectID(t *testing.T) {
+	cleanup := withTempHomeDir(t)
+	defer cleanup()
+
+	comps, _ := completeSubnetID(&cobra.Command{}, []string{}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions without project-id, got %v", comps)
+	}
+}
+
+func TestCompleteSubnetID(t *testing.T) {
+	id, name := "sub-001", "my-subnet"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/subnets", jsonResponse(200, types.SubnetListResponse{
+		Values: []types.SubnetResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSubnetID(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected completions, got none")
+	}
+}
+
+func TestCompleteSubnetID_NoProjectID(t *testing.T) {
+	cleanup := withTempHomeDir(t)
+	defer cleanup()
+
+	comps, _ := completeSubnetID(&cobra.Command{}, []string{"vpc-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions without project-id, got %v", comps)
+	}
+}
+
+func TestCompleteSubnetID_TooManyArgs(t *testing.T) {
+	comps, _ := completeSubnetID(&cobra.Command{}, []string{"vpc-001", "sub-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions with too many args, got %v", comps)
+	}
+}
+
+// ─── completeSecurityGroupID ─────────────────────────────────────────────────
+
+func TestCompleteSecurityGroupID_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityGroupID(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs from delegation, got none")
+	}
+}
+
+func TestCompleteSecurityGroupID_NoArgs_NoProjectID(t *testing.T) {
+	cleanup := withTempHomeDir(t)
+	defer cleanup()
+
+	comps, _ := completeSecurityGroupID(&cobra.Command{}, []string{}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions without project-id, got %v", comps)
+	}
+}
+
+func TestCompleteSecurityGroupID(t *testing.T) {
+	id, name := "sg-001", "my-sg"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
+		Values: []types.SecurityGroupResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityGroupID(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected completions, got none")
+	}
+}
+
+func TestCompleteSecurityGroupID_NoProjectID(t *testing.T) {
+	cleanup := withTempHomeDir(t)
+	defer cleanup()
+
+	comps, _ := completeSecurityGroupID(&cobra.Command{}, []string{"vpc-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions without project-id, got %v", comps)
+	}
+}
+
+func TestCompleteSecurityGroupID_TooManyArgs(t *testing.T) {
+	comps, _ := completeSecurityGroupID(&cobra.Command{}, []string{"vpc-001", "sg-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions with too many args, got %v", comps)
+	}
+}
+
+// ─── completeVPCPeeringID ────────────────────────────────────────────────────
+
+func TestCompleteVPCPeeringID_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringID(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs from delegation, got none")
+	}
+}
+
+func TestCompleteVPCPeeringID_NoArgs_NoProjectID(t *testing.T) {
+	cleanup := withTempHomeDir(t)
+	defer cleanup()
+
+	comps, _ := completeVPCPeeringID(&cobra.Command{}, []string{}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions without project-id, got %v", comps)
+	}
+}
+
+func TestCompleteVPCPeeringID(t *testing.T) {
+	id, name := "peer-001", "my-peering"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings", jsonResponse(200, types.VPCPeeringListResponse{
+		Values: []types.VPCPeeringResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringID(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected completions, got none")
+	}
+}
+
+func TestCompleteVPCPeeringID_NoProjectID(t *testing.T) {
+	cleanup := withTempHomeDir(t)
+	defer cleanup()
+
+	comps, _ := completeVPCPeeringID(&cobra.Command{}, []string{"vpc-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions without project-id, got %v", comps)
+	}
+}
+
+func TestCompleteVPCPeeringID_TooManyArgs(t *testing.T) {
+	comps, _ := completeVPCPeeringID(&cobra.Command{}, []string{"vpc-001", "peer-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions with too many args, got %v", comps)
+	}
+}
+
+// ─── completeSecurityRuleID parent-slot fixes ────────────────────────────────
+
+func TestCompleteSecurityRuleID_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityRuleID(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs from delegation, got none")
+	}
+}
+
+func TestCompleteSecurityRuleID_OneArg_DelegatesToSGID(t *testing.T) {
+	id, name := "sg-001", "my-sg"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
+		Values: []types.SecurityGroupResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityRuleID(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected SG IDs from delegation, got none")
+	}
+}
+
+func TestCompleteSecurityRuleID_TooManyArgs(t *testing.T) {
+	comps, _ := completeSecurityRuleID(&cobra.Command{}, []string{"vpc-001", "sg-001", "rule-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions with too many args, got %v", comps)
+	}
+}
+
+// ─── completeVPCPeeringRouteID parent-slot fixes ─────────────────────────────
+
+func TestCompleteVPCPeeringRouteID_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringRouteID(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs from delegation, got none")
+	}
+}
+
+func TestCompleteVPCPeeringRouteID_OneArg_DelegatesToPeeringID(t *testing.T) {
+	id, name := "peer-001", "my-peering"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings", jsonResponse(200, types.VPCPeeringListResponse{
+		Values: []types.VPCPeeringResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringRouteID(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected peering IDs from delegation, got none")
+	}
+}
+
+func TestCompleteVPCPeeringRouteID_TooManyArgs(t *testing.T) {
+	comps, _ := completeVPCPeeringRouteID(&cobra.Command{}, []string{"vpc-001", "peer-001", "route-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions with too many args, got %v", comps)
+	}
+}

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -46,6 +46,56 @@ func init() {
 	securitygroupListCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	securitygroupListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	securitygroupListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+
+	securitygroupCreateCmd.ValidArgsFunction = completeSecurityGroupID
+	securitygroupListCmd.ValidArgsFunction = completeSecurityGroupID
+	securitygroupGetCmd.ValidArgsFunction = completeSecurityGroupID
+	securitygroupUpdateCmd.ValidArgsFunction = completeSecurityGroupID
+	securitygroupDeleteCmd.ValidArgsFunction = completeSecurityGroupID
+}
+
+func completeSecurityGroupID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) > 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	vpcID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	key := cacheKey("security-group", projectID, vpcID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ctx := context.Background()
+	list, err := client.FromNetwork().SecurityGroups().List(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	if list != nil {
+		for _, sg := range list.Items() {
+			id := sg.ID()
+			if id != "" {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, sg.Name()))
+			}
+		}
+	}
+
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // SecurityGroup subcommands

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -55,13 +55,21 @@ func init() {
 	securityruleListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
+	securityruleCreateCmd.ValidArgsFunction = completeSecurityRuleID
+	securityruleListCmd.ValidArgsFunction = completeSecurityRuleID
 	securityruleGetCmd.ValidArgsFunction = completeSecurityRuleID
 	securityruleUpdateCmd.ValidArgsFunction = completeSecurityRuleID
 	securityruleDeleteCmd.ValidArgsFunction = completeSecurityRuleID
 }
 
 func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) < 2 {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) == 1 {
+		return completeSecurityGroupID(cmd, args, toComplete)
+	}
+	if len(args) > 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -53,6 +53,56 @@ func init() {
 	subnetListCmd.Flags().String("vpc-id", "", "Parent VPC ID (required)")
 	subnetListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	subnetListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+
+	subnetCreateCmd.ValidArgsFunction = completeSubnetID
+	subnetListCmd.ValidArgsFunction = completeSubnetID
+	subnetGetCmd.ValidArgsFunction = completeSubnetID
+	subnetUpdateCmd.ValidArgsFunction = completeSubnetID
+	subnetDeleteCmd.ValidArgsFunction = completeSubnetID
+}
+
+func completeSubnetID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) > 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	vpcID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	key := cacheKey("subnet", projectID, vpcID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ctx := context.Background()
+	list, err := client.FromNetwork().Subnets().List(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	if list != nil {
+		for _, s := range list.Items() {
+			id := s.ID()
+			if id != "" {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, s.Name()))
+			}
+		}
+	}
+
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // Subnet subcommands

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -43,6 +43,56 @@ func init() {
 	vpcpeeringListCmd.Flags().String("project-id", "", "Project ID (uses context if not specified)")
 	vpcpeeringListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	vpcpeeringListCmd.Flags().Int32("offset", 0, "Number of results to skip")
+
+	vpcpeeringCreateCmd.ValidArgsFunction = completeVPCPeeringID
+	vpcpeeringListCmd.ValidArgsFunction = completeVPCPeeringID
+	vpcpeeringGetCmd.ValidArgsFunction = completeVPCPeeringID
+	vpcpeeringUpdateCmd.ValidArgsFunction = completeVPCPeeringID
+	vpcpeeringDeleteCmd.ValidArgsFunction = completeVPCPeeringID
+}
+
+func completeVPCPeeringID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) > 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	vpcID := args[0]
+	projectID, err := GetProjectID(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	key := cacheKey("vpc-peering", projectID, vpcID)
+	if cached, _ := completionCacheGet(key); cached != nil {
+		return filterCompletions(cached, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := GetArubaClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ctx := context.Background()
+	list, err := client.FromNetwork().VPCPeerings().List(ctx, aruba.VPCRef(projectID, vpcID))
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	if list != nil {
+		for _, p := range list.Items() {
+			id := p.ID()
+			if id != "" {
+				completions = append(completions, fmt.Sprintf("%s\t%s", id, p.Name()))
+			}
+		}
+	}
+
+	completionCachePut(key, completions)
+	return filterCompletions(completions, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // Peering subcommands

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -52,13 +52,21 @@ func init() {
 	vpcpeeringrouteListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
+	vpcpeeringrouteCreateCmd.ValidArgsFunction = completeVPCPeeringRouteID
+	vpcpeeringrouteListCmd.ValidArgsFunction = completeVPCPeeringRouteID
 	vpcpeeringrouteGetCmd.ValidArgsFunction = completeVPCPeeringRouteID
 	vpcpeeringrouteUpdateCmd.ValidArgsFunction = completeVPCPeeringRouteID
 	vpcpeeringrouteDeleteCmd.ValidArgsFunction = completeVPCPeeringRouteID
 }
 
 func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) < 2 {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) == 1 {
+		return completeVPCPeeringID(cmd, args, toComplete)
+	}
+	if len(args) > 2 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 


### PR DESCRIPTION
﻿## Summary

Fixes shell autocomplete falling back to filesystem suggestions for nested network resource commands. Reported case: `acloud network subnet list <TAB>` showing `.`, `..`, `.bashrc` instead of VPC IDs.

- **3 new completion functions** (`completeSubnetID`, `completeSecurityGroupID`, `completeVPCPeeringID`) following the `completeRestoreID` pattern from `storage.restore.go` ? delegate to the parent completer at `args[0]`, query the child resource scoped to the parent at `args[1]`.
- **2 existing functions fixed** (`completeSecurityRuleID`, `completeVPCPeeringRouteID`) ? both had `if len(args) < 2 { return nil }` which suppressed the VPC-ID and intermediate-parent slots; replaced with per-slot delegation.
- **Missing registrations added** ? `subnet`, `securitygroup`, `vpcpeering` had zero `ValidArgsFunction` registrations; `securityrule list/create` and `vpcpeeringroute list/create` were also unregistered.

Closes #239

## Slot completion after this fix

| TAB position | Command example | Completes |
|---|---|---|
| `args[0]` | `subnet list <TAB>` | VPC IDs |
| `args[0]` | `securityrule get <TAB>` | VPC IDs |
| `args[1]` | `subnet get <vpc-id> <TAB>` | Subnet IDs (scoped to VPC) |
| `args[1]` | `securityrule get <vpc-id> <TAB>` | Security group IDs (scoped to VPC) |
| `args[2]` | `securityrule get <vpc-id> <sg-id> <TAB>` | Rule IDs (scoped to VPC+SG) |
| `args[1]` | `vpcpeeringroute list <vpc-id> <TAB>` | VPC peering IDs (scoped to VPC) |
| `args[2]` | `vpcpeeringroute get <vpc-id> <peering-id> <TAB>` | Route IDs (scoped to VPC+peering) |

## Test plan

- [ ] `acloud network vpc get <TAB>` ? VPC IDs (regression check)
- [ ] `acloud network subnet list <TAB>` ? VPC IDs (was: filesystem)
- [ ] `acloud network subnet get <vpc-id> <TAB>` ? subnet IDs for that VPC
- [ ] `acloud network securitygroup list <TAB>` ? VPC IDs
- [ ] `acloud network securitygroup get <vpc-id> <TAB>` ? SG IDs for that VPC
- [ ] `acloud network securityrule get <TAB>` ? VPC IDs (was: nothing)
- [ ] `acloud network securityrule get <vpc-id> <TAB>` ? SG IDs (was: nothing)
- [ ] `acloud network securityrule get <vpc-id> <sg-id> <TAB>` ? rule IDs (was already working)
- [ ] `acloud network vpcpeering list <TAB>` ? VPC IDs
- [ ] `acloud network vpcpeeringroute get <TAB>` ? VPC IDs (was: nothing)
- [ ] `acloud network vpcpeeringroute get <vpc-id> <TAB>` ? peering IDs (was: nothing)
- [ ] `make test-skip-client` passes

?? Generated with [Claude Code](https://claude.com/claude-code)

