### PR TITLE
docs: Italian completion docs + v0.5.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-19
+
+### Added
+
+- **Context auto-selection** — when exactly one context is configured and no
+  `CurrentContext` is set, `GetCurrentProjectID()` now automatically selects it.
+  Running `acloud context set` no longer requires a follow-up `acloud context use`
+  in the single-context case (closes #234).
+- **Clear-contexts prompt on profile switch** — switching to a different credential
+  profile with `--profile` (or `ACLOUD_PROFILE`) now detects that existing contexts
+  belong to the previous profile's projects and offers to clear them interactively.
+  Prevents stale contexts from causing "project not found" errors after a profile
+  change (closes #236).
+
+### Fixed
+
+- **Shell completion — network sub-resources** — pressing TAB at any positional
+  argument slot in nested network commands now suggests the correct parent resource
+  IDs instead of falling back to filesystem completion. Previously, only the final
+  slot (the resource's own ID) was completed; all earlier slots returned nothing.
+  Fixed resources and their full TAB sequences:
+  - `subnet list/get/create <TAB>` → VPC IDs; `subnet get <vpc-id> <TAB>` → subnet IDs
+  - `securitygroup list/get/create <TAB>` → VPC IDs; `securitygroup get <vpc-id> <TAB>` → SG IDs
+  - `vpcpeering list/get/create <TAB>` → VPC IDs; `vpcpeering get <vpc-id> <TAB>` → peering IDs
+  - `securityrule get/list <TAB>` → VPC IDs; `… <vpc-id> <TAB>` → SG IDs; `… <sg-id> <TAB>` → rule IDs
+  - `vpcpeeringroute get/list <TAB>` → VPC IDs; slot 2 → peering IDs; slot 3 → route IDs
+
+  Completion is now also registered on `list` and `create` commands that
+  previously had no `ValidArgsFunction` at all (closes #239, PR #240).
+
+- **Shell completion — database and storage sub-resources** — same class of fix
+  extended to the database and storage families (PR #241):
+  - `dbaas database list/create <TAB>` → DBaaS IDs; slot 2 → database names
+  - `dbaas user list/create <TAB>` → DBaaS IDs; slot 2 → usernames
+  - `dbaas grant list/create <TAB>` → DBaaS IDs; slot 2 → database names; slot 3 → grant IDs
+    (`create`, `list`, `get`, `delete` had no `ValidArgsFunction` at all)
+  - `storage backup <TAB>` (create command) → volume IDs
+  - `storage restore <TAB>` (create command) → backup IDs; slot 2 → volume IDs
+
+- **Docs**: corrected zone value from `itbg1-a` to `ITBG-1` in cloud server
+  create examples (closes #238).
+
+### Documentation
+
+- Shell auto-completion sections updated in English and Italian across all
+  resource pages affected by the completion fixes: `subnet`, `securitygroup`,
+  `vpcpeering`, `securityrule`, `vpcpeeringroute`, `dbaas.database`, `dbaas.user`,
+  `dbaas.grant`, `storage/backup`, `storage/restore`. Each section now shows the
+  full hierarchical TAB sequence for every positional argument slot rather than
+  only the final one.
+- `getting-started.md` auto-completion examples extended to cover `storage backup`
+  create (volume ID), `storage restore` create (backup ID then volume ID), and
+  database sub-resource hierarchical completion (DBaaS → database → user/grant).
+
 ## [0.5.1] - 2026-06-19
 
 ### Fixed
@@ -262,7 +316,8 @@ is unchanged.
 - **E2e**: project `DELETE` failure now propagates correctly in the management
   suite (closes #128).
 
-[Unreleased]: https://github.com/Arubacloud/acloud-cli/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/Arubacloud/acloud-cli/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/Arubacloud/acloud-cli/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Arubacloud/acloud-cli/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Arubacloud/acloud-cli/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Arubacloud/acloud-cli/compare/v0.3.0...v0.4.0

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.database.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.database.md
@@ -146,6 +146,23 @@ acloud database dbaas database delete <dbaas-id> <database-name> [--yes] [flags]
 acloud database dbaas database delete 69455aa70d0972656501d45d "my-database" --yes
 ```
 
+## Auto-completamento Shell
+
+I comandi database supportano auto-completamento gerarchico: il primo TAB
+completa gli ID istanza DBaaS, il secondo completa i nomi dei database limitati
+a quell'istanza.
+
+```bash
+# Primo argomento — mostra gli ID istanza DBaaS disponibili
+acloud database dbaas database list <TAB>
+acloud database dbaas database get <TAB>
+
+# Secondo argomento — mostra i nomi dei database per l'istanza DBaaS indicata
+acloud database dbaas database get <dbaas-id> <TAB>
+acloud database dbaas database update <dbaas-id> <TAB>
+acloud database dbaas database delete <dbaas-id> <TAB>
+```
+
 ## Risorse Correlate
 
 - [DBaaS](dbaas.md) - Gestisci istanze DBaaS

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.grant.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.grant.md
@@ -145,6 +145,25 @@ acloud database dbaas grant create <dbaas-id> "appdb" --username "restapi" --rol
 acloud database dbaas grant list <dbaas-id> "appdb"
 ```
 
+## Auto-completamento Shell
+
+I comandi grant supportano auto-completamento gerarchico su tutti e tre gli
+argomenti posizionali:
+
+```bash
+# Primo argomento — mostra gli ID istanza DBaaS disponibili
+acloud database dbaas grant list <TAB>
+acloud database dbaas grant get <TAB>
+
+# Secondo argomento — mostra i nomi database per l'istanza DBaaS indicata
+acloud database dbaas grant list <dbaas-id> <TAB>
+acloud database dbaas grant get <dbaas-id> <TAB>
+
+# Terzo argomento — mostra gli ID grant per l'istanza e il database indicati
+acloud database dbaas grant get <dbaas-id> <database-name> <TAB>
+acloud database dbaas grant delete <dbaas-id> <database-name> <TAB>
+```
+
 ## Risorse Correlate
 
 - [DBaaS](dbaas.md) - Gestisci istanze DBaaS

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.user.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.user.md
@@ -156,6 +156,22 @@ acloud database dbaas user delete 69455aa70d0972656501d45d "app-user" --yes
 - Non condividere mai password o committarle nel controllo versione
 - Considera l'uso di un password manager
 
+## Auto-completamento Shell
+
+I comandi utente supportano auto-completamento gerarchico: il primo TAB completa
+gli ID istanza DBaaS, il secondo completa i nomi utente limitati a quell'istanza.
+
+```bash
+# Primo argomento — mostra gli ID istanza DBaaS disponibili
+acloud database dbaas user list <TAB>
+acloud database dbaas user get <TAB>
+
+# Secondo argomento — mostra i nomi utente per l'istanza DBaaS indicata
+acloud database dbaas user get <dbaas-id> <TAB>
+acloud database dbaas user update <dbaas-id> <TAB>
+acloud database dbaas user delete <dbaas-id> <TAB>
+```
+
 ## Risorse Correlate
 
 - [DBaaS](dbaas.md) - Gestisci istanze DBaaS

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securitygroup.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securitygroup.md
@@ -131,7 +131,20 @@ Security Group 1234567890abcdef deleted successfully!
 
 ## Auto-completamento Shell
 
-I comandi security group supportano auto-completamento per ID VPC e ID security group.
+I comandi security group supportano auto-completamento gerarchico: il primo TAB
+completa gli ID VPC, il secondo completa gli ID security group limitati al VPC
+selezionato.
+
+```bash
+# Primo argomento — mostra gli ID VPC disponibili
+acloud network securitygroup list <TAB>
+acloud network securitygroup get <TAB>
+
+# Secondo argomento — mostra gli ID security group per il VPC indicato
+acloud network securitygroup get <vpc-id> <TAB>
+acloud network securitygroup update <vpc-id> <TAB>
+acloud network securitygroup delete <vpc-id> <TAB>
+```
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securityrule.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securityrule.md
@@ -250,13 +250,19 @@ ID                              STATUS
 
 ## Auto-completamento Shell
 
-I comandi security rule supportano auto-completamento intelligente per gli ID security rule:
+I comandi security rule supportano auto-completamento gerarchico su tutti e tre
+gli argomenti posizionali:
 
 ```bash
-# Abilita completamento (bash)
-source <(acloud completion bash)
+# Primo argomento — mostra gli ID VPC disponibili
+acloud network securityrule get <TAB>
+acloud network securityrule list <TAB>
 
-# Digita il comando e premi TAB per vedere gli ID security rule disponibili
+# Secondo argomento — mostra gli ID security group per il VPC indicato
+acloud network securityrule get <vpc-id> <TAB>
+acloud network securityrule list <vpc-id> <TAB>
+
+# Terzo argomento — mostra gli ID rule per il VPC e security group indicati
 acloud network securityrule get <vpc-id> <securitygroup-id> <TAB>
 acloud network securityrule update <vpc-id> <securitygroup-id> <TAB>
 acloud network securityrule delete <vpc-id> <securitygroup-id> <TAB>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/subnet.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/subnet.md
@@ -176,7 +176,19 @@ Subnet 1234567890abcdef deleted successfully!
 
 ## Auto-completamento Shell
 
-I comandi subnet supportano auto-completamento per ID VPC e ID subnet.
+I comandi subnet supportano auto-completamento gerarchico: il primo TAB completa
+gli ID VPC, il secondo completa gli ID subnet limitati al VPC selezionato.
+
+```bash
+# Primo argomento — mostra gli ID VPC disponibili
+acloud network subnet list <TAB>
+acloud network subnet get <TAB>
+
+# Secondo argomento — mostra gli ID subnet per il VPC indicato
+acloud network subnet get <vpc-id> <TAB>
+acloud network subnet update <vpc-id> <TAB>
+acloud network subnet delete <vpc-id> <TAB>
+```
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeering.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeering.md
@@ -139,7 +139,20 @@ VPC Peering 6949666e4d0cdc87949b7204 deleted successfully!
 
 ## Auto-completamento Shell
 
-I comandi VPC Peering supportano auto-completamento per ID VPC e ID peering.
+I comandi VPC Peering supportano auto-completamento gerarchico: il primo TAB
+completa gli ID VPC, il secondo completa gli ID peering limitati al VPC
+selezionato.
+
+```bash
+# Primo argomento — mostra gli ID VPC disponibili
+acloud network vpcpeering list <TAB>
+acloud network vpcpeering get <TAB>
+
+# Secondo argomento — mostra gli ID peering per il VPC indicato
+acloud network vpcpeering get <vpc-id> <TAB>
+acloud network vpcpeering update <vpc-id> <TAB>
+acloud network vpcpeering delete <vpc-id> <TAB>
+```
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeeringroute.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeeringroute.md
@@ -217,13 +217,19 @@ ID                              STATUS
 
 ## Auto-completamento Shell
 
-I comandi VPC Peering Route supportano auto-completamento intelligente per gli ID route:
+I comandi VPC Peering Route supportano auto-completamento gerarchico su tutti e
+tre gli argomenti posizionali:
 
 ```bash
-# Abilita completamento (bash)
-source <(acloud completion bash)
+# Primo argomento — mostra gli ID VPC disponibili
+acloud network vpcpeeringroute get <TAB>
+acloud network vpcpeeringroute list <TAB>
 
-# Digita il comando e premi TAB per vedere gli ID route disponibili
+# Secondo argomento — mostra gli ID peering per il VPC indicato
+acloud network vpcpeeringroute get <vpc-id> <TAB>
+acloud network vpcpeeringroute list <vpc-id> <TAB>
+
+# Terzo argomento — mostra gli ID route per il VPC e peering indicati
 acloud network vpcpeeringroute get <vpc-id> <peering-id> <TAB>
 acloud network vpcpeeringroute update <vpc-id> <peering-id> <TAB>
 acloud network vpcpeeringroute delete <vpc-id> <peering-id> <TAB>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/storage/backup.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/storage/backup.md
@@ -32,7 +32,7 @@ acloud storage backup <volume-id> --name <name> [flags]
 
 ### Argomenti
 
-- `volume-id` - L'ID del volume di block storage da cui fare il backup
+- `volume-id` - L'ID del volume di block storage da cui fare il backup (supporta auto-completamento)
 
 ### Flag Richiesti
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/storage/restore.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/storage/restore.md
@@ -33,8 +33,20 @@ acloud storage restore <backup-id> <volume-id> --name <name> [flags]
 
 ### Argomenti
 
-- `backup-id` - L'ID del backup da cui ripristinare
-- `volume-id` - L'ID del volume target (sarà sovrascritto)
+- `backup-id` - L'ID del backup da cui ripristinare (supporta auto-completamento)
+- `volume-id` - L'ID del volume target (supporta auto-completamento; sarà sovrascritto)
+
+### Auto-completamento
+
+Il comando create supporta auto-completamento gerarchico:
+
+```bash
+# Primo argomento — mostra gli ID backup disponibili
+acloud storage restore <TAB>
+
+# Secondo argomento — mostra gli ID volume una volta selezionato un backup
+acloud storage restore <backup-id> <TAB>
+```
 
 ### Flag Richiesti
 


### PR DESCRIPTION
﻿## Summary

Release prep for v0.5.2 (2026-06-19).

- **Italian docs**: mirror the completion doc updates from #241 in `docs/website/i18n/it/` ? all 10 Italian resource pages now show the full hierarchical TAB sequences for subnet, securitygroup, vpcpeering, securityrule, vpcpeeringroute, dbaas.database, dbaas.user, dbaas.grant, storage/backup, and storage/restore.
- **CHANGELOG.md**: add [0.5.2] entry covering all changes since v0.5.1 ? context auto-selection (#234), profile-switch clear-contexts prompt (#236), shell completion parent-slot fixes (#239/#240, #241), and zone docs fix (#238).

Note: the English doc updates and code fixes were already merged via #240 and #241.

## Test plan

- [ ] Verify Italian doc pages render correctly on the docs site
- [ ] Verify CHANGELOG.md [0.5.2] links resolve once the tag is created

?? Generated with [Claude Code](https://claude.com/claude-code)

