### PR TITLE
docs: fix securitygroup create and securityrule create examples

### DIFF
--- a/docs/website/docs/examples/containerregistry.md
+++ b/docs/website/docs/examples/containerregistry.md
@@ -63,19 +63,20 @@ acloud network securitygroup list 69495ef64d0cdc87949b71ec
 If you need to create a new security group and add the HTTPS rule:
 
 ```bash
-# Create security group
-acloud network securitygroup create \
+# Create security group (vpc-id is the first positional argument)
+acloud network securitygroup create 69495ef64d0cdc87949b71ec \
   --name "registry-sg" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
   --region "ITBG-Bergamo"
 
 # Add inbound rule for HTTPS (port 443)
 acloud network securityrule create 69495ef64d0cdc87949b71ec <securitygroup-id> \
-  --direction Inbound \
+  --name "allow-https" \
+  --region "ITBG-Bergamo" \
+  --direction Ingress \
   --protocol TCP \
-  --port-range-min 443 \
-  --port-range-max 443 \
-  --remote-ip-prefix "0.0.0.0/0"
+  --port 443 \
+  --target-kind Ip \
+  --target-value "0.0.0.0/0"
 ```
 
 Note the security group `ID`.

--- a/docs/website/docs/examples/database.md
+++ b/docs/website/docs/examples/database.md
@@ -63,19 +63,20 @@ acloud network securitygroup list 69495ef64d0cdc87949b71ec
 If you need to create a new security group with a MySQL inbound rule:
 
 ```bash
-# Create security group
-acloud network securitygroup create \
+# Create security group (vpc-id is the first positional argument)
+acloud network securitygroup create 69495ef64d0cdc87949b71ec \
   --name "db-security-group" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
   --region "ITBG-Bergamo"
 
 # Add inbound rule for MySQL (port 3306)
 acloud network securityrule create 69495ef64d0cdc87949b71ec <securitygroup-id> \
-  --direction Inbound \
+  --name "allow-mysql" \
+  --region "ITBG-Bergamo" \
+  --direction Ingress \
   --protocol TCP \
-  --port-range-min 3306 \
-  --port-range-max 3306 \
-  --remote-ip-prefix "0.0.0.0/0"
+  --port 3306 \
+  --target-kind Ip \
+  --target-value "0.0.0.0/0"
 ```
 
 Note the security group `ID`.

--- a/docs/website/docs/it/examples/containerregistry.md
+++ b/docs/website/docs/it/examples/containerregistry.md
@@ -51,17 +51,19 @@ acloud network securitygroup list <vpc-id>
 Se devi creare un nuovo security group:
 
 ```bash
-acloud network securitygroup create \
+# Il vpc-id è il primo argomento posizionale
+acloud network securitygroup create <vpc-id> \
   --name "registry-sg" \
-  --vpc-id "<vpc-id>" \
   --region "ITBG-Bergamo"
 
 acloud network securityrule create <vpc-id> <securitygroup-id> \
-  --direction Inbound \
+  --name "allow-https" \
+  --region "ITBG-Bergamo" \
+  --direction Ingress \
   --protocol TCP \
-  --port-range-min 443 \
-  --port-range-max 443 \
-  --remote-ip-prefix "0.0.0.0/0"
+  --port 443 \
+  --target-kind Ip \
+  --target-value "0.0.0.0/0"
 ```
 
 Annota l'`ID` del security group.

--- a/docs/website/docs/it/examples/database.md
+++ b/docs/website/docs/it/examples/database.md
@@ -57,17 +57,19 @@ acloud network securitygroup list 69495ef64d0cdc87949b71ec
 Se devi creare un nuovo security group con una regola MySQL inbound:
 
 ```bash
-acloud network securitygroup create \
+# Il vpc-id è il primo argomento posizionale
+acloud network securitygroup create 69495ef64d0cdc87949b71ec \
   --name "db-security-group" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
   --region "ITBG-Bergamo"
 
 acloud network securityrule create 69495ef64d0cdc87949b71ec <securitygroup-id> \
-  --direction Inbound \
+  --name "allow-mysql" \
+  --region "ITBG-Bergamo" \
+  --direction Ingress \
   --protocol TCP \
-  --port-range-min 3306 \
-  --port-range-max 3306 \
-  --remote-ip-prefix "0.0.0.0/0"
+  --port 3306 \
+  --target-kind Ip \
+  --target-value "0.0.0.0/0"
 ```
 
 Annota l'`ID` del security group.

--- a/docs/website/docs/resources/network/securityrule.md
+++ b/docs/website/docs/resources/network/securityrule.md
@@ -392,19 +392,21 @@ VPC_ID="689307f4745108d3c6343b5a"
 SG_ID="1234567890abcdef"
 RULE_ID="1234567890abcdef123456"
 
-# Update port range
+# Update security rule name
 acloud network securityrule update $VPC_ID $SG_ID $RULE_ID \
-  --port "8080-8090"
+  --name "allow-http-restricted"
 
-# Update target to restrict access
+# Update tags
 acloud network securityrule update $VPC_ID $SG_ID $RULE_ID \
-  --target-value "192.168.1.0/24"
+  --tags "web,http,restricted"
 
-# Update name and tags
+# Update name and tags together
 acloud network securityrule update $VPC_ID $SG_ID $RULE_ID \
   --name "allow-http-restricted" \
   --tags "web,http,restricted"
 ```
+
+**Note:** Only `--name` and `--tags` can be updated. Properties such as direction, protocol, port, and target cannot be modified after creation. To change these, delete and recreate the rule.
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/containerregistry.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/containerregistry.md
@@ -63,19 +63,20 @@ acloud network securitygroup list 69495ef64d0cdc87949b71ec
 Se devi creare un nuovo security group e aggiungere la regola HTTPS:
 
 ```bash
-# Crea security group
-acloud network securitygroup create \
+# Crea security group (il vpc-id è il primo argomento posizionale)
+acloud network securitygroup create 69495ef64d0cdc87949b71ec \
   --name "registry-sg" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
   --region "ITBG-Bergamo"
 
 # Aggiungi regola inbound per HTTPS (porta 443)
 acloud network securityrule create 69495ef64d0cdc87949b71ec <securitygroup-id> \
-  --direction Inbound \
+  --name "allow-https" \
+  --region "ITBG-Bergamo" \
+  --direction Ingress \
   --protocol TCP \
-  --port-range-min 443 \
-  --port-range-max 443 \
-  --remote-ip-prefix "0.0.0.0/0"
+  --port 443 \
+  --target-kind Ip \
+  --target-value "0.0.0.0/0"
 ```
 
 Annota l'`ID` del security group.

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/database.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/database.md
@@ -63,19 +63,20 @@ acloud network securitygroup list 69495ef64d0cdc87949b71ec
 Se devi creare un nuovo security group con una regola MySQL inbound:
 
 ```bash
-# Crea security group
-acloud network securitygroup create \
+# Crea security group (il vpc-id è il primo argomento posizionale)
+acloud network securitygroup create 69495ef64d0cdc87949b71ec \
   --name "db-security-group" \
-  --vpc-id "69495ef64d0cdc87949b71ec" \
   --region "ITBG-Bergamo"
 
 # Aggiungi regola inbound per MySQL (porta 3306)
 acloud network securityrule create 69495ef64d0cdc87949b71ec <securitygroup-id> \
-  --direction Inbound \
+  --name "allow-mysql" \
+  --region "ITBG-Bergamo" \
+  --direction Ingress \
   --protocol TCP \
-  --port-range-min 3306 \
-  --port-range-max 3306 \
-  --remote-ip-prefix "0.0.0.0/0"
+  --port 3306 \
+  --target-kind Ip \
+  --target-value "0.0.0.0/0"
 ```
 
 Annota l'`ID` del security group.


### PR DESCRIPTION
## Summary

- **securitygroup create**: the vpc-id is a positional argument, not a `--vpc-id` flag. All example pages were updated to use the correct positional syntax.
- **securityrule create**: examples used non-existent flags (`--direction Inbound`, `--port-range-min/max`, `--remote-ip-prefix`). Replaced with the actual flags: `--direction Ingress/Egress`, `--port`, `--target-kind`, `--target-value`, plus the required `--name` and `--region`.
- **securityrule update**: the resource reference page incorrectly showed `--port` and `--target-value` as updatable. Only `--name` and `--tags` can be updated; the invalid examples were removed and a note was added.

## Files changed

- `docs/website/docs/examples/database.md`
- `docs/website/docs/examples/containerregistry.md`
- `docs/website/docs/it/examples/database.md`
- `docs/website/docs/it/examples/containerregistry.md`
- `docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/database.md`
- `docs/website/i18n/it/docusaurus-plugin-content-docs/current/examples/containerregistry.md`
- `docs/website/docs/resources/network/securityrule.md`

## Test plan

- [ ] Verify each changed code block matches the actual CLI command syntax
- [ ] Run `acloud network securitygroup create --help` and confirm vpc-id is a positional argument
- [ ] Run `acloud network securityrule create --help` and confirm the correct flag names

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)