### PR TITLE
fix: add create-command auto-completion for sub-resource parent IDs

### DIFF
--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1223,3 +1223,271 @@ func TestCompleteBackupCreateArg_DelegatesToBlockStorageID(t *testing.T) {
 		t.Errorf("expected volume IDs, got none")
 	}
 }
+
+// ─── completeVPNRouteID fix: now delegates to VPN tunnel on first arg ─────────
+
+func TestCompleteVPNRouteID_NoArgs_DelegatesToVPNTunnelID(t *testing.T) {
+	id, name := "vpn-001", "my-tunnel"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelListResponse{
+		Values: []types.VPNTunnelResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPNRouteID(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPN tunnel IDs from delegation, got none")
+	}
+}
+
+func TestCompleteVPNRouteID_TooManyArgs(t *testing.T) {
+	comps, _ := completeVPNRouteID(&cobra.Command{}, []string{"vpn-001", "route-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions with too many args, got %v", comps)
+	}
+}
+
+// ─── completeSubnetCreate ────────────────────────────────────────────────────
+
+func TestCompleteSubnetCreate_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSubnetCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs, got none")
+	}
+}
+
+func TestCompleteSubnetCreate_WithArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeSubnetCreate(&cobra.Command{}, []string{"vpc-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after vpc-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeSecurityGroupCreate ─────────────────────────────────────────────
+
+func TestCompleteSecurityGroupCreate_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityGroupCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs, got none")
+	}
+}
+
+func TestCompleteSecurityGroupCreate_WithArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeSecurityGroupCreate(&cobra.Command{}, []string{"vpc-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after vpc-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeSecurityRuleCreate ──────────────────────────────────────────────
+
+func TestCompleteSecurityRuleCreate_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityRuleCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs, got none")
+	}
+}
+
+func TestCompleteSecurityRuleCreate_OneArg_DelegatesToSGID(t *testing.T) {
+	id, name := "sg-001", "my-sg"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/securityGroups", jsonResponse(200, types.SecurityGroupListResponse{
+		Values: []types.SecurityGroupResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeSecurityRuleCreate(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected SG IDs, got none")
+	}
+}
+
+func TestCompleteSecurityRuleCreate_TwoArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeSecurityRuleCreate(&cobra.Command{}, []string{"vpc-001", "sg-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after sg-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeVPCPeeringCreate ────────────────────────────────────────────────
+
+func TestCompleteVPCPeeringCreate_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs, got none")
+	}
+}
+
+func TestCompleteVPCPeeringCreate_WithArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeVPCPeeringCreate(&cobra.Command{}, []string{"vpc-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after vpc-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeVPCPeeringRouteCreate ───────────────────────────────────────────
+
+func TestCompleteVPCPeeringRouteCreate_NoArgs_DelegatesToVPCID(t *testing.T) {
+	id, name := "vpc-001", "my-vpc"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs", jsonResponse(200, types.VPCListResponse{
+		Values: []types.VPCResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringRouteCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPC IDs, got none")
+	}
+}
+
+func TestCompleteVPCPeeringRouteCreate_OneArg_DelegatesToPeeringID(t *testing.T) {
+	id, name := "peer-001", "my-peering"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpcs/vpc-001/vpcPeerings", jsonResponse(200, types.VPCPeeringListResponse{
+		Values: []types.VPCPeeringResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPCPeeringRouteCreate(makeProjectCmd("proj-123"), []string{"vpc-001"}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected peering IDs, got none")
+	}
+}
+
+func TestCompleteVPCPeeringRouteCreate_TwoArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeVPCPeeringRouteCreate(&cobra.Command{}, []string{"vpc-001", "peer-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after peering-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeVPNRouteCreate ──────────────────────────────────────────────────
+
+func TestCompleteVPNRouteCreate_NoArgs_DelegatesToVPNTunnelID(t *testing.T) {
+	id, name := "vpn-001", "my-tunnel"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Network/vpnTunnels", jsonResponse(200, types.VPNTunnelListResponse{
+		Values: []types.VPNTunnelResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeVPNRouteCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected VPN tunnel IDs, got none")
+	}
+}
+
+func TestCompleteVPNRouteCreate_WithArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeVPNRouteCreate(&cobra.Command{}, []string{"vpn-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after vpn-tunnel-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeDBaasDatabaseCreate ─────────────────────────────────────────────
+
+func TestCompleteDBaasDatabaseCreate_NoArgs_DelegatesToDBaaSID(t *testing.T) {
+	id, name := "dbaas-001", "my-dbaas"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
+		Values: []types.DBaaSResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeDBaasDatabaseCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected DBaaS IDs, got none")
+	}
+}
+
+func TestCompleteDBaasDatabaseCreate_WithArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeDBaasDatabaseCreate(&cobra.Command{}, []string{"dbaas-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after dbaas-id is provided, got %v", comps)
+	}
+}
+
+// ─── completeDBaaSUserCreate ─────────────────────────────────────────────────
+
+func TestCompleteDBaaSUserCreate_NoArgs_DelegatesToDBaaSID(t *testing.T) {
+	id, name := "dbaas-001", "my-dbaas"
+	srv := newArubaTestServer(t)
+	srv.OnGet("/projects/proj-123/providers/Aruba.Database/dbaas", jsonResponse(200, types.DBaaSListResponse{
+		Values: []types.DBaaSResponse{
+			{Metadata: types.ResourceMetadataResponse{ID: &id, Name: &name}},
+		},
+	}))
+	setClientForTesting(srv.Client())
+	defer resetClientState()
+
+	completions, _ := completeDBaaSUserCreate(makeProjectCmd("proj-123"), []string{}, "")
+	if len(completions) == 0 {
+		t.Errorf("expected DBaaS IDs, got none")
+	}
+}
+
+func TestCompleteDBaaSUserCreate_WithArgs_ReturnsNil(t *testing.T) {
+	comps, _ := completeDBaaSUserCreate(&cobra.Command{}, []string{"dbaas-001"}, "")
+	if comps != nil {
+		t.Errorf("expected nil completions after dbaas-id is provided, got %v", comps)
+	}
+}

--- a/cmd/database.dbaas.database.go
+++ b/cmd/database.dbaas.database.go
@@ -34,11 +34,18 @@ func init() {
 	dbaasDatabaseListCmd.Flags().Int("limit", 0, "Maximum number of results to return (0 = no limit)")
 	dbaasDatabaseListCmd.Flags().Int("offset", 0, "Number of results to skip")
 
-	dbaasDatabaseCreateCmd.ValidArgsFunction = completeDBaaSDatabaseID
+	dbaasDatabaseCreateCmd.ValidArgsFunction = completeDBaasDatabaseCreate
 	dbaasDatabaseListCmd.ValidArgsFunction = completeDBaaSDatabaseID
 	dbaasDatabaseGetCmd.ValidArgsFunction = completeDBaaSDatabaseID
 	dbaasDatabaseUpdateCmd.ValidArgsFunction = completeDBaaSDatabaseID
 	dbaasDatabaseDeleteCmd.ValidArgsFunction = completeDBaaSDatabaseID
+}
+
+func completeDBaasDatabaseCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeDBaaSID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeDBaaSDatabaseID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/database.dbaas.user.go
+++ b/cmd/database.dbaas.user.go
@@ -47,11 +47,18 @@ func init() {
 	dbaasUserListCmd.Flags().Int("limit", 0, "Maximum number of results to return (0 = no limit)")
 	dbaasUserListCmd.Flags().Int("offset", 0, "Number of results to skip")
 
-	dbaasUserCreateCmd.ValidArgsFunction = completeDBaaSUserID
+	dbaasUserCreateCmd.ValidArgsFunction = completeDBaaSUserCreate
 	dbaasUserListCmd.ValidArgsFunction = completeDBaaSUserID
 	dbaasUserGetCmd.ValidArgsFunction = completeDBaaSUserID
 	dbaasUserUpdateCmd.ValidArgsFunction = completeDBaaSUserID
 	dbaasUserDeleteCmd.ValidArgsFunction = completeDBaaSUserID
+}
+
+func completeDBaaSUserCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeDBaaSID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeDBaaSUserID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/network.securitygroup.go
+++ b/cmd/network.securitygroup.go
@@ -47,11 +47,18 @@ func init() {
 	securitygroupListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	securitygroupListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
-	securitygroupCreateCmd.ValidArgsFunction = completeSecurityGroupID
+	securitygroupCreateCmd.ValidArgsFunction = completeSecurityGroupCreate
 	securitygroupListCmd.ValidArgsFunction = completeSecurityGroupID
 	securitygroupGetCmd.ValidArgsFunction = completeSecurityGroupID
 	securitygroupUpdateCmd.ValidArgsFunction = completeSecurityGroupID
 	securitygroupDeleteCmd.ValidArgsFunction = completeSecurityGroupID
+}
+
+func completeSecurityGroupCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeSecurityGroupID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/network.securityrule.go
+++ b/cmd/network.securityrule.go
@@ -55,11 +55,21 @@ func init() {
 	securityruleListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
-	securityruleCreateCmd.ValidArgsFunction = completeSecurityRuleID
+	securityruleCreateCmd.ValidArgsFunction = completeSecurityRuleCreate
 	securityruleListCmd.ValidArgsFunction = completeSecurityRuleID
 	securityruleGetCmd.ValidArgsFunction = completeSecurityRuleID
 	securityruleUpdateCmd.ValidArgsFunction = completeSecurityRuleID
 	securityruleDeleteCmd.ValidArgsFunction = completeSecurityRuleID
+}
+
+func completeSecurityRuleCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) == 1 {
+		return completeSecurityGroupID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeSecurityRuleID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/network.subnet.go
+++ b/cmd/network.subnet.go
@@ -54,11 +54,18 @@ func init() {
 	subnetListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	subnetListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
-	subnetCreateCmd.ValidArgsFunction = completeSubnetID
+	subnetCreateCmd.ValidArgsFunction = completeSubnetCreate
 	subnetListCmd.ValidArgsFunction = completeSubnetID
 	subnetGetCmd.ValidArgsFunction = completeSubnetID
 	subnetUpdateCmd.ValidArgsFunction = completeSubnetID
 	subnetDeleteCmd.ValidArgsFunction = completeSubnetID
+}
+
+func completeSubnetCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeSubnetID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -132,6 +139,7 @@ DHCP routes format: "destination:gateway" (e.g., "10.1.0.0/24:10.0.0.1").`,
   acloud network subnet create <vpc-id> --name my-subnet --region IT-BG \
     --cidr 10.0.1.0/24 --dhcp-enabled \
     --dhcp-dns 8.8.8.8,8.8.4.4`,
+	Args: cobra.ExactArgs(1),
 	RunE: NetworkSubnetCreateRun,
 }
 

--- a/cmd/network.vpcpeering.go
+++ b/cmd/network.vpcpeering.go
@@ -44,11 +44,18 @@ func init() {
 	vpcpeeringListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	vpcpeeringListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
-	vpcpeeringCreateCmd.ValidArgsFunction = completeVPCPeeringID
+	vpcpeeringCreateCmd.ValidArgsFunction = completeVPCPeeringCreate
 	vpcpeeringListCmd.ValidArgsFunction = completeVPCPeeringID
 	vpcpeeringGetCmd.ValidArgsFunction = completeVPCPeeringID
 	vpcpeeringUpdateCmd.ValidArgsFunction = completeVPCPeeringID
 	vpcpeeringDeleteCmd.ValidArgsFunction = completeVPCPeeringID
+}
+
+func completeVPCPeeringCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeVPCPeeringID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/network.vpcpeeringroute.go
+++ b/cmd/network.vpcpeeringroute.go
@@ -52,11 +52,21 @@ func init() {
 	vpcpeeringrouteListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
 	// Set up auto-completion for resource IDs
-	vpcpeeringrouteCreateCmd.ValidArgsFunction = completeVPCPeeringRouteID
+	vpcpeeringrouteCreateCmd.ValidArgsFunction = completeVPCPeeringRouteCreate
 	vpcpeeringrouteListCmd.ValidArgsFunction = completeVPCPeeringRouteID
 	vpcpeeringrouteGetCmd.ValidArgsFunction = completeVPCPeeringRouteID
 	vpcpeeringrouteUpdateCmd.ValidArgsFunction = completeVPCPeeringRouteID
 	vpcpeeringrouteDeleteCmd.ValidArgsFunction = completeVPCPeeringRouteID
+}
+
+func completeVPCPeeringRouteCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPCID(cmd, args, toComplete)
+	}
+	if len(args) == 1 {
+		return completeVPCPeeringID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeVPCPeeringRouteID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/network.vpnroute.go
+++ b/cmd/network.vpnroute.go
@@ -48,13 +48,25 @@ func init() {
 	vpnrouteListCmd.Flags().Int32("limit", 0, "Maximum number of results to return (0 = no limit)")
 	vpnrouteListCmd.Flags().Int32("offset", 0, "Number of results to skip")
 
+	vpnrouteCreateCmd.ValidArgsFunction = completeVPNRouteCreate
+	vpnrouteListCmd.ValidArgsFunction = completeVPNTunnelID
 	vpnrouteGetCmd.ValidArgsFunction = completeVPNRouteID
 	vpnrouteUpdateCmd.ValidArgsFunction = completeVPNRouteID
 	vpnrouteDeleteCmd.ValidArgsFunction = completeVPNRouteID
 }
 
+func completeVPNRouteCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeVPNTunnelID(cmd, args, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
 func completeVPNRouteID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) < 1 {
+	if len(args) == 0 {
+		return completeVPNTunnelID(cmd, args, toComplete)
+	}
+	if len(args) > 1 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	projectID, err := GetProjectID(cmd)

--- a/docs/website/docs/resources/database/dbaas.database.md
+++ b/docs/website/docs/resources/database/dbaas.database.md
@@ -153,6 +153,7 @@ DBaaS instance IDs, the second completes database names scoped to that instance.
 
 ```bash
 # First argument — shows available DBaaS instance IDs
+acloud database dbaas database create <TAB>
 acloud database dbaas database list <TAB>
 acloud database dbaas database get <TAB>
 
@@ -161,6 +162,8 @@ acloud database dbaas database get <dbaas-id> <TAB>
 acloud database dbaas database update <dbaas-id> <TAB>
 acloud database dbaas database delete <dbaas-id> <TAB>
 ```
+
+The `create` command only completes the first argument (DBaaS instance ID), since no existing database name is needed.
 
 ## Related Resources
 

--- a/docs/website/docs/resources/database/dbaas.user.md
+++ b/docs/website/docs/resources/database/dbaas.user.md
@@ -163,6 +163,7 @@ DBaaS instance IDs, the second completes usernames scoped to that instance.
 
 ```bash
 # First argument — shows available DBaaS instance IDs
+acloud database dbaas user create <TAB>
 acloud database dbaas user list <TAB>
 acloud database dbaas user get <TAB>
 
@@ -171,6 +172,8 @@ acloud database dbaas user get <dbaas-id> <TAB>
 acloud database dbaas user update <dbaas-id> <TAB>
 acloud database dbaas user delete <dbaas-id> <TAB>
 ```
+
+The `create` command only completes the first argument (DBaaS instance ID), since you are creating a new user.
 
 ## Related Resources
 

--- a/docs/website/docs/resources/network/securitygroup.md
+++ b/docs/website/docs/resources/network/securitygroup.md
@@ -132,6 +132,7 @@ selected VPC.
 
 ```bash
 # First argument — shows available VPC IDs
+acloud network securitygroup create <TAB>
 acloud network securitygroup list <TAB>
 acloud network securitygroup get <TAB>
 
@@ -140,6 +141,8 @@ acloud network securitygroup get <vpc-id> <TAB>
 acloud network securitygroup update <vpc-id> <TAB>
 acloud network securitygroup delete <vpc-id> <TAB>
 ```
+
+The `create` command only completes the first argument (VPC ID), since no existing security group ID is needed.
 
 ## Best Practices
 - Use descriptive names and descriptions for security groups.

--- a/docs/website/docs/resources/network/securityrule.md
+++ b/docs/website/docs/resources/network/securityrule.md
@@ -250,15 +250,17 @@ ID                              STATUS
 
 ## Shell Auto-completion
 
-Security rule commands support hierarchical auto-completion across all three
-positional arguments:
+Security rule commands support hierarchical auto-completion across all positional
+arguments:
 
 ```bash
 # First argument — shows available VPC IDs
+acloud network securityrule create <TAB>
 acloud network securityrule get <TAB>
 acloud network securityrule list <TAB>
 
 # Second argument — shows security group IDs for the given VPC
+acloud network securityrule create <vpc-id> <TAB>
 acloud network securityrule get <vpc-id> <TAB>
 acloud network securityrule list <vpc-id> <TAB>
 
@@ -267,6 +269,8 @@ acloud network securityrule get <vpc-id> <securitygroup-id> <TAB>
 acloud network securityrule update <vpc-id> <securitygroup-id> <TAB>
 acloud network securityrule delete <vpc-id> <securitygroup-id> <TAB>
 ```
+
+The `create` command completes vpc-id and security-group-id (the two required parent IDs), but not the rule ID since you are creating a new rule.
 
 Auto-completion shows security rule IDs with their names:
 ```

--- a/docs/website/docs/resources/network/subnet.md
+++ b/docs/website/docs/resources/network/subnet.md
@@ -176,6 +176,7 @@ VPC IDs, the second completes subnet IDs scoped to the selected VPC.
 
 ```bash
 # First argument — shows available VPC IDs
+acloud network subnet create <TAB>
 acloud network subnet list <TAB>
 acloud network subnet get <TAB>
 
@@ -184,6 +185,8 @@ acloud network subnet get <vpc-id> <TAB>
 acloud network subnet update <vpc-id> <TAB>
 acloud network subnet delete <vpc-id> <TAB>
 ```
+
+The `create` command only completes the first argument (VPC ID), since no existing subnet ID is needed.
 
 ## Best Practices
 - Use descriptive names for subnets based on their purpose.

--- a/docs/website/docs/resources/network/vpcpeering.md
+++ b/docs/website/docs/resources/network/vpcpeering.md
@@ -139,6 +139,7 @@ completes VPC IDs, the second completes peering IDs scoped to the selected VPC.
 
 ```bash
 # First argument — shows available VPC IDs
+acloud network vpcpeering create <TAB>
 acloud network vpcpeering list <TAB>
 acloud network vpcpeering get <TAB>
 
@@ -147,6 +148,8 @@ acloud network vpcpeering get <vpc-id> <TAB>
 acloud network vpcpeering update <vpc-id> <TAB>
 acloud network vpcpeering delete <vpc-id> <TAB>
 ```
+
+The `create` command only completes the first argument (VPC ID), since no existing peering ID is needed.
 
 ## Best Practices
 - Use descriptive names for peering connections.

--- a/docs/website/docs/resources/network/vpcpeeringroute.md
+++ b/docs/website/docs/resources/network/vpcpeeringroute.md
@@ -217,15 +217,17 @@ ID                              STATUS
 
 ## Shell Auto-completion
 
-VPC Peering Route commands support hierarchical auto-completion across all three
-positional arguments:
+VPC Peering Route commands support hierarchical auto-completion across all positional
+arguments:
 
 ```bash
 # First argument — shows available VPC IDs
+acloud network vpcpeeringroute create <TAB>
 acloud network vpcpeeringroute get <TAB>
 acloud network vpcpeeringroute list <TAB>
 
 # Second argument — shows peering IDs for the given VPC
+acloud network vpcpeeringroute create <vpc-id> <TAB>
 acloud network vpcpeeringroute get <vpc-id> <TAB>
 acloud network vpcpeeringroute list <vpc-id> <TAB>
 
@@ -234,6 +236,8 @@ acloud network vpcpeeringroute get <vpc-id> <peering-id> <TAB>
 acloud network vpcpeeringroute update <vpc-id> <peering-id> <TAB>
 acloud network vpcpeeringroute delete <vpc-id> <peering-id> <TAB>
 ```
+
+The `create` command completes vpc-id and peering-id (the two required parent IDs), but not the route ID since you are creating a new route.
 
 Auto-completion shows route IDs with their names:
 ```

--- a/docs/website/docs/resources/network/vpnroute.md
+++ b/docs/website/docs/resources/network/vpnroute.md
@@ -205,13 +205,16 @@ ID                              STATUS
 
 ## Shell Auto-completion
 
-The VPN Tunnel Route commands support intelligent auto-completion for route IDs:
+VPN Route commands support hierarchical auto-completion: the first TAB completes
+VPN tunnel IDs, the second completes route IDs scoped to the selected tunnel.
 
 ```bash
-# Enable completion (bash)
-source <(acloud completion bash)
+# First argument — shows available VPN tunnel IDs
+acloud network vpnroute create <TAB>
+acloud network vpnroute list <TAB>
+acloud network vpnroute get <TAB>
 
-# Type command and press TAB to see available route IDs
+# Second argument — shows route IDs for the given VPN tunnel
 acloud network vpnroute get <vpn-tunnel-id> <TAB>
 acloud network vpnroute update <vpn-tunnel-id> <TAB>
 acloud network vpnroute delete <vpn-tunnel-id> <TAB>
@@ -222,6 +225,8 @@ Auto-completion shows route IDs with their names:
 1234567890abcdef123456    route-1
 1234567890abcdef123457    route-2
 ```
+
+The `create` and `list` commands only complete the first argument (VPN tunnel ID).
 
 ## VPN Route Properties
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.database.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.database.md
@@ -154,6 +154,7 @@ a quell'istanza.
 
 ```bash
 # Primo argomento — mostra gli ID istanza DBaaS disponibili
+acloud database dbaas database create <TAB>
 acloud database dbaas database list <TAB>
 acloud database dbaas database get <TAB>
 
@@ -162,6 +163,8 @@ acloud database dbaas database get <dbaas-id> <TAB>
 acloud database dbaas database update <dbaas-id> <TAB>
 acloud database dbaas database delete <dbaas-id> <TAB>
 ```
+
+Il comando `create` completa solo il primo argomento (ID istanza DBaaS), poiché non è necessario un nome di database esistente.
 
 ## Risorse Correlate
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.user.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/database/dbaas.user.md
@@ -163,6 +163,7 @@ gli ID istanza DBaaS, il secondo completa i nomi utente limitati a quell'istanza
 
 ```bash
 # Primo argomento — mostra gli ID istanza DBaaS disponibili
+acloud database dbaas user create <TAB>
 acloud database dbaas user list <TAB>
 acloud database dbaas user get <TAB>
 
@@ -171,6 +172,8 @@ acloud database dbaas user get <dbaas-id> <TAB>
 acloud database dbaas user update <dbaas-id> <TAB>
 acloud database dbaas user delete <dbaas-id> <TAB>
 ```
+
+Il comando `create` completa solo il primo argomento (ID istanza DBaaS), poiché si sta creando un nuovo utente.
 
 ## Risorse Correlate
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securitygroup.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securitygroup.md
@@ -137,6 +137,7 @@ selezionato.
 
 ```bash
 # Primo argomento — mostra gli ID VPC disponibili
+acloud network securitygroup create <TAB>
 acloud network securitygroup list <TAB>
 acloud network securitygroup get <TAB>
 
@@ -145,6 +146,8 @@ acloud network securitygroup get <vpc-id> <TAB>
 acloud network securitygroup update <vpc-id> <TAB>
 acloud network securitygroup delete <vpc-id> <TAB>
 ```
+
+Il comando `create` completa solo il primo argomento (ID VPC), poiché non è necessario un ID security group esistente.
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securityrule.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/securityrule.md
@@ -250,15 +250,17 @@ ID                              STATUS
 
 ## Auto-completamento Shell
 
-I comandi security rule supportano auto-completamento gerarchico su tutti e tre
-gli argomenti posizionali:
+I comandi security rule supportano auto-completamento gerarchico su tutti gli
+argomenti posizionali:
 
 ```bash
 # Primo argomento — mostra gli ID VPC disponibili
+acloud network securityrule create <TAB>
 acloud network securityrule get <TAB>
 acloud network securityrule list <TAB>
 
 # Secondo argomento — mostra gli ID security group per il VPC indicato
+acloud network securityrule create <vpc-id> <TAB>
 acloud network securityrule get <vpc-id> <TAB>
 acloud network securityrule list <vpc-id> <TAB>
 
@@ -267,6 +269,8 @@ acloud network securityrule get <vpc-id> <securitygroup-id> <TAB>
 acloud network securityrule update <vpc-id> <securitygroup-id> <TAB>
 acloud network securityrule delete <vpc-id> <securitygroup-id> <TAB>
 ```
+
+Il comando `create` completa vpc-id e security-group-id (i due ID padre richiesti), ma non l'ID della rule poiché si sta creando una nuova regola.
 
 L'auto-completamento mostra gli ID security rule con i loro nomi:
 ```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/subnet.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/subnet.md
@@ -181,6 +181,7 @@ gli ID VPC, il secondo completa gli ID subnet limitati al VPC selezionato.
 
 ```bash
 # Primo argomento — mostra gli ID VPC disponibili
+acloud network subnet create <TAB>
 acloud network subnet list <TAB>
 acloud network subnet get <TAB>
 
@@ -189,6 +190,8 @@ acloud network subnet get <vpc-id> <TAB>
 acloud network subnet update <vpc-id> <TAB>
 acloud network subnet delete <vpc-id> <TAB>
 ```
+
+Il comando `create` completa solo il primo argomento (ID VPC), poiché non è necessario un ID subnet esistente.
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeering.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeering.md
@@ -145,6 +145,7 @@ selezionato.
 
 ```bash
 # Primo argomento — mostra gli ID VPC disponibili
+acloud network vpcpeering create <TAB>
 acloud network vpcpeering list <TAB>
 acloud network vpcpeering get <TAB>
 
@@ -153,6 +154,8 @@ acloud network vpcpeering get <vpc-id> <TAB>
 acloud network vpcpeering update <vpc-id> <TAB>
 acloud network vpcpeering delete <vpc-id> <TAB>
 ```
+
+Il comando `create` completa solo il primo argomento (ID VPC), poiché non è necessario un ID peering esistente.
 
 ## Best Practices
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeeringroute.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpcpeeringroute.md
@@ -217,15 +217,17 @@ ID                              STATUS
 
 ## Auto-completamento Shell
 
-I comandi VPC Peering Route supportano auto-completamento gerarchico su tutti e
-tre gli argomenti posizionali:
+I comandi VPC Peering Route supportano auto-completamento gerarchico su tutti
+gli argomenti posizionali:
 
 ```bash
 # Primo argomento — mostra gli ID VPC disponibili
+acloud network vpcpeeringroute create <TAB>
 acloud network vpcpeeringroute get <TAB>
 acloud network vpcpeeringroute list <TAB>
 
 # Secondo argomento — mostra gli ID peering per il VPC indicato
+acloud network vpcpeeringroute create <vpc-id> <TAB>
 acloud network vpcpeeringroute get <vpc-id> <TAB>
 acloud network vpcpeeringroute list <vpc-id> <TAB>
 
@@ -234,6 +236,8 @@ acloud network vpcpeeringroute get <vpc-id> <peering-id> <TAB>
 acloud network vpcpeeringroute update <vpc-id> <peering-id> <TAB>
 acloud network vpcpeeringroute delete <vpc-id> <peering-id> <TAB>
 ```
+
+Il comando `create` completa vpc-id e peering-id (i due ID padre richiesti), ma non l'ID della route poiché si sta creando una nuova route.
 
 L'auto-completamento mostra gli ID route con i loro nomi:
 ```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpnroute.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources/network/vpnroute.md
@@ -205,13 +205,17 @@ ID                              STATUS
 
 ## Auto-completamento Shell
 
-I comandi VPN Tunnel Route supportano auto-completamento intelligente per gli ID route:
+I comandi VPN Route supportano auto-completamento gerarchico: il primo TAB
+completa gli ID VPN tunnel, il secondo completa gli ID route limitati al tunnel
+selezionato.
 
 ```bash
-# Abilita completamento (bash)
-source <(acloud completion bash)
+# Primo argomento — mostra gli ID VPN tunnel disponibili
+acloud network vpnroute create <TAB>
+acloud network vpnroute list <TAB>
+acloud network vpnroute get <TAB>
 
-# Digita il comando e premi TAB per vedere gli ID route disponibili
+# Secondo argomento — mostra gli ID route per il VPN tunnel indicato
 acloud network vpnroute get <vpn-tunnel-id> <TAB>
 acloud network vpnroute update <vpn-tunnel-id> <TAB>
 acloud network vpnroute delete <vpn-tunnel-id> <TAB>
@@ -222,6 +226,8 @@ L'auto-completamento mostra gli ID route con i loro nomi:
 1234567890abcdef123456    route-1
 1234567890abcdef123457    route-2
 ```
+
+I comandi `create` e `list` completano solo il primo argomento (ID VPN tunnel).
 
 ## Proprietà VPN Route
 


### PR DESCRIPTION
## Summary

All `create` commands that take parent resource IDs as positional arguments
now correctly complete only those parent IDs, then stop — they no longer
offer the resource's own IDs on subsequent TAB presses.

Additionally, `vpnroute` get/update/delete now complete the first argument
(VPN tunnel ID) on TAB, which was previously broken (returning nothing).

## Changes

**cmd/ (code)**
- `network.subnet.go`: add `completeSubnetCreate` (vpc-id only); add missing `Args: cobra.ExactArgs(1)` to `subnetCreateCmd`
- `network.securitygroup.go`: add `completeSecurityGroupCreate` (vpc-id only)
- `network.securityrule.go`: add `completeSecurityRuleCreate` (vpc-id → sg-id, then stop)
- `network.vpcpeering.go`: add `completeVPCPeeringCreate` (vpc-id only)
- `network.vpcpeeringroute.go`: add `completeVPCPeeringRouteCreate` (vpc-id → peering-id, then stop)
- `network.vpnroute.go`: fix `completeVPNRouteID` to complete tunnel-id on first TAB; add `completeVPNRouteCreate`; wire create/list commands
- `database.dbaas.database.go`: add `completeDBaasDatabaseCreate` (dbaas-id only)
- `database.dbaas.user.go`: add `completeDBaaSUserCreate` (dbaas-id only)

**docs/**
- Updated Shell Auto-completion sections for all affected resources to
  include the `create` (and `list`) commands, reflecting the new behavior.

## Test plan

- [ ] `acloud network subnet create <TAB>` → shows VPC IDs
- [ ] `acloud network subnet create <vpc-id> <TAB>` → no suggestions (correct)
- [ ] `acloud network securitygroup create <TAB>` → shows VPC IDs
- [ ] `acloud network securitygroup create <vpc-id> <TAB>` → no suggestions
- [ ] `acloud network securityrule create <TAB>` → shows VPC IDs
- [ ] `acloud network securityrule create <vpc-id> <TAB>` → shows SG IDs
- [ ] `acloud network securityrule create <vpc-id> <sg-id> <TAB>` → no suggestions
- [ ] `acloud network vpnroute get <TAB>` → shows VPN tunnel IDs (was broken)
- [ ] `acloud network vpnroute create <TAB>` → shows VPN tunnel IDs (was missing)
- [ ] `acloud network vpnroute list <TAB>` → shows VPN tunnel IDs (was missing)
- [ ] `acloud database dbaas database create <TAB>` → shows DBaaS IDs
- [ ] `acloud database dbaas database create <dbaas-id> <TAB>` → no suggestions
- [ ] `acloud database dbaas user create <TAB>` → shows DBaaS IDs
- [ ] `go test ./cmd/...` passes

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)